### PR TITLE
New UCERF3 epistemic list ERF

### DIFF
--- a/src/scratch/UCERF3/erf/epistemic/HazardOptimizedCFSS.java
+++ b/src/scratch/UCERF3/erf/epistemic/HazardOptimizedCFSS.java
@@ -1,0 +1,94 @@
+package scratch.UCERF3.erf.epistemic;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import com.google.common.base.Preconditions;
+
+import scratch.UCERF3.CompoundFaultSystemSolution;
+import scratch.UCERF3.FaultSystemSolutionFetcher;
+import scratch.UCERF3.enumTreeBranches.DeformationModels;
+import scratch.UCERF3.enumTreeBranches.FaultModels;
+import scratch.UCERF3.enumTreeBranches.ScalingRelationships;
+import scratch.UCERF3.inversion.InversionFaultSystemRupSet;
+import scratch.UCERF3.inversion.InversionFaultSystemSolution;
+import scratch.UCERF3.logicTree.LogicTreeBranch;
+import scratch.UCERF3.logicTree.LogicTreeBranchNode;
+
+public class HazardOptimizedCFSS extends FaultSystemSolutionFetcher {
+	
+	private CompoundFaultSystemSolution cfss;
+	private List<LogicTreeBranch> branches;
+	
+	private InversionFaultSystemRupSet prevRupSet = null;
+
+	public HazardOptimizedCFSS(CompoundFaultSystemSolution cfss) {
+		this.cfss = cfss;
+		this.branches = new ArrayList<>(cfss.getBranches());
+		Collections.sort(branches, new ReadOptimizedBranchComparator());
+		setCacheCopying(false);
+	}
+
+	@Override
+	public Collection<LogicTreeBranch> getBranches() {
+		return branches;
+	}
+
+	@Override
+	protected synchronized InversionFaultSystemSolution fetchSolution(LogicTreeBranch branch) {
+		if (prevRupSet == null) {
+			// do a full load
+			System.out.println("Loading first rupture set");
+			InversionFaultSystemSolution sol = cfss.getSolution(branch);
+			prevRupSet = sol.getRupSet();
+			return sol;
+		}
+		FaultModels fm = branch.getValue(FaultModels.class);
+		DeformationModels dm = branch.getValue(DeformationModels.class);
+		ScalingRelationships scale = branch.getValue(ScalingRelationships.class);
+		LogicTreeBranch prevBranch = prevRupSet.getLogicTreeBranch();
+		if (fm != prevBranch.getValue(FaultModels.class) || dm != prevBranch.getValue(DeformationModels.class)
+				|| scale != prevBranch.getValue(ScalingRelationships.class)) {
+			System.out.println("New FM, DM, or Scaling Relationship, must load full new rupture set");
+			InversionFaultSystemSolution sol = cfss.getSolution(branch);
+			prevRupSet = sol.getRupSet();
+			return sol;
+		}
+		
+		// if we made it this far, we can just load in the rates and reuse the rupture set
+		InversionFaultSystemRupSet invRupSet = new InversionFaultSystemRupSet(
+				prevRupSet, branch, null, null, null, null, null);
+		double[] rates = cfss.getRates(branch);
+		return new InversionFaultSystemSolution(invRupSet, rates);
+	}
+	
+	private class ReadOptimizedBranchComparator implements Comparator<LogicTreeBranch> {
+		
+		List<Class<? extends LogicTreeBranchNode<?>>> sortOrderClasses;
+		
+		public ReadOptimizedBranchComparator() {
+			sortOrderClasses = new ArrayList<>();
+			// default order is ideal
+			sortOrderClasses.addAll(LogicTreeBranch.getLogicTreeNodeClasses());
+		}
+
+		@Override
+		public int compare(LogicTreeBranch b1, LogicTreeBranch b2) {
+			Preconditions.checkState(b1.size() == sortOrderClasses.size());
+			Preconditions.checkState(b2.size() == sortOrderClasses.size());
+			for (Class<? extends LogicTreeBranchNode<?>> clazz : sortOrderClasses) {
+				LogicTreeBranchNode<?> val = b1.getValueUnchecked(clazz);
+				LogicTreeBranchNode<?> oval = b2.getValueUnchecked(clazz);
+				int cmp = val.getShortName().compareTo(oval.getShortName());
+				if (cmp != 0)
+					return cmp;
+			}
+			return 0;
+		}
+		
+	}
+
+}

--- a/src/scratch/UCERF3/erf/epistemic/UCERF3EpistemicListERF.java
+++ b/src/scratch/UCERF3/erf/epistemic/UCERF3EpistemicListERF.java
@@ -1,0 +1,340 @@
+package scratch.UCERF3.erf.epistemic;
+
+import java.awt.geom.Point2D;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.ZipException;
+
+import org.opensha.commons.data.Site;
+import org.opensha.commons.data.TimeSpan;
+import org.opensha.commons.data.function.ArbitrarilyDiscretizedFunc;
+import org.opensha.commons.data.function.DiscretizedFunc;
+import org.opensha.commons.geo.Location;
+import org.opensha.commons.geo.Region;
+import org.opensha.commons.param.Parameter;
+import org.opensha.commons.param.ParameterList;
+import org.opensha.commons.param.event.ParameterChangeEvent;
+import org.opensha.commons.param.event.ParameterChangeListener;
+import org.opensha.commons.param.impl.EnumParameter;
+import org.opensha.sha.calc.HazardCurveCalculator;
+import org.opensha.sha.earthquake.BaseERF;
+import org.opensha.sha.earthquake.ERF;
+import org.opensha.sha.earthquake.EpistemicListERF;
+import org.opensha.sha.earthquake.param.IncludeBackgroundOption;
+import org.opensha.sha.earthquake.param.IncludeBackgroundParam;
+import org.opensha.sha.gui.infoTools.IMT_Info;
+import org.opensha.sha.imr.AttenRelRef;
+import org.opensha.sha.imr.ScalarIMR;
+import org.opensha.sha.util.TectonicRegionType;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
+
+import scratch.UCERF3.CompoundFaultSystemSolution;
+import scratch.UCERF3.FaultSystemSolution;
+import scratch.UCERF3.FaultSystemSolutionFetcher;
+import scratch.UCERF3.enumTreeBranches.DeformationModels;
+import scratch.UCERF3.enumTreeBranches.FaultModels;
+import scratch.UCERF3.enumTreeBranches.ScalingRelationships;
+import scratch.UCERF3.erf.FaultSystemSolutionERF;
+import scratch.UCERF3.erf.mean.MeanUCERF3;
+import scratch.UCERF3.logicTree.LogicTreeBranch;
+import scratch.UCERF3.logicTree.LogicTreeBranchNode;
+
+public class UCERF3EpistemicListERF implements EpistemicListERF, ParameterChangeListener {
+	
+	public static final String NAME = "UCERF3 Epistemic List ERF";
+	
+	private FaultSystemSolutionFetcher fetch;
+	private LogicTreeBranch branch0;
+	
+	private FaultSystemSolutionERF paramERF;
+	private ParameterList paramList;
+	
+	private static final String LOGIC_TREE_BRANCH_ALL_NAME = "(all)";
+	
+	private Map<Class<? extends LogicTreeBranchNode<?>>, EnumParameter<?>> enumParamsMap;
+	
+	private List<LogicTreeBranch> branches;
+	
+	private static final String COMPOUND_FILE_NAME = "full_ucerf3_compound_sol.zip";
+	
+	private static FaultSystemSolutionFetcher loadFetcher() throws ZipException, IOException {
+		File storeDir = MeanUCERF3.getStoreDir();
+		
+		File compoundFile = new File(storeDir, COMPOUND_FILE_NAME);
+		
+		// allow errors so that app doesn't crash if can't download
+		MeanUCERF3.checkDownload(compoundFile, true);
+		
+		if (!compoundFile.exists())
+			return null;
+		
+		return CompoundFaultSystemSolution.fromZipFile(compoundFile);
+	}
+
+	public UCERF3EpistemicListERF() throws ZipException, IOException {
+		this(loadFetcher());
+	}
+
+	public UCERF3EpistemicListERF(FaultSystemSolutionFetcher fetch) {
+		if (fetch instanceof CompoundFaultSystemSolution)
+			fetch = new HazardOptimizedCFSS((CompoundFaultSystemSolution)fetch);
+		this.fetch = fetch;
+		
+		Preconditions.checkState(fetch != null && !fetch.getBranches().isEmpty());
+		branch0 = fetch.getBranches().iterator().next();
+		
+		enumParamsMap = new HashMap<>();
+		
+		// build enum paramters, allow every option in the fetcher
+		Collection<LogicTreeBranch> branches = fetch.getBranches();
+		List<Class<? extends LogicTreeBranchNode<?>>> logicTreeNodeClasses = LogicTreeBranch.getLogicTreeNodeClasses();
+		for (int i=0; i < logicTreeNodeClasses.size(); i++) {
+			Class<? extends LogicTreeBranchNode<?>> clazz = logicTreeNodeClasses.get(i);
+			EnumParameter<?> param = buildParam(clazz, branches);
+			param.addParameterChangeListener(this);
+			enumParamsMap.put(clazz, param);
+		}
+		
+		// just for parameter instantiation
+		paramERF = new FaultSystemSolutionERF();
+		// default to exclude back seis (will be much faster)
+		paramERF.setParameter(IncludeBackgroundParam.NAME, IncludeBackgroundOption.EXCLUDE);
+		createParamList();
+	}
+	
+	private HashSet<Parameter<?>> listeningParams = new HashSet<>();
+	
+	private void createParamList() {
+		paramList = new ParameterList();
+		
+		for (Parameter<?> param : paramERF.getAdjustableParameterList()) {
+			if (!param.getName().equals(FaultSystemSolutionERF.FILE_PARAM_NAME)) {
+				if (!listeningParams.contains(param)) {
+					param.addParameterChangeListener(this);
+					listeningParams.add(param);
+				}
+				paramList.addParameter(param);
+			}
+		}
+		
+		for (Class<? extends LogicTreeBranchNode<?>> clazz : LogicTreeBranch.getLogicTreeNodeClasses()) {
+			EnumParameter<?> param = enumParamsMap.get(clazz);
+			if (param != null)
+				paramList.addParameter(param);
+		}
+	}
+	
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private static EnumParameter buildParam(
+			Class<? extends LogicTreeBranchNode<?>> clazz, Collection<LogicTreeBranch> branches) {
+		HashSet<Enum> set = new HashSet<Enum>();
+		
+		Enum defaultValue = null;
+		
+		String name = null;
+		
+		for (LogicTreeBranch branch : branches) {
+			Preconditions.checkState(branch.isFullySpecified());
+			LogicTreeBranchNode<?> val = branch.getValueUnchecked(clazz);
+			Preconditions.checkNotNull(val);
+			set.add((Enum)val);
+			if (name == null)
+				name = val.getBranchLevelName();
+		}
+		
+		Preconditions.checkState(!set.isEmpty());
+		EnumSet choices = EnumSet.copyOf(set);
+
+		if (set.size() == 1) {
+			defaultValue = set.iterator().next();
+			return new EnumParameter(name, choices, defaultValue, null);
+		}
+		
+		return new EnumParameter(name, choices, defaultValue, LOGIC_TREE_BRANCH_ALL_NAME);
+	}
+	
+	private synchronized void updateBranches() {
+		if (branches != null)
+			return;
+		branches = new ArrayList<>();
+		for (LogicTreeBranch branch : fetch.getBranches()) {
+			boolean keep = true;
+			for (Class<? extends LogicTreeBranchNode<?>> clazz : enumParamsMap.keySet()) {
+				EnumParameter<?> enumParam = enumParamsMap.get(clazz);
+				LogicTreeBranchNode<?> node = (LogicTreeBranchNode<?>) enumParam.getValue();
+				if (node != null) {
+					if (!branch.getValueUnchecked(clazz).equals(node)) {
+						keep = false;
+						break;
+					}
+ 				}
+			}
+			if (keep)
+				branches.add(branch);
+		}
+		System.out.println("Retained "+branches.size()+" branches");
+	}
+
+	@Override
+	public void updateForecast() {
+		updateBranches();
+	}
+
+	@Override
+	public void setTimeSpan(TimeSpan time) {
+		paramERF.setTimeSpan(time);
+	}
+
+	@Override
+	public TimeSpan getTimeSpan() {
+		return paramERF.getTimeSpan();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void setParameter(String name, Object value) {
+		paramList.getParameter(name).setValue(value);
+	}
+
+	@Override
+	public ParameterList getAdjustableParameterList() {
+		return paramList;
+	}
+
+	@Override
+	public Region getApplicableRegion() {
+		return null;
+	}
+
+	@Override
+	public ArrayList<TectonicRegionType> getIncludedTectonicRegionTypes() {
+		ArrayList<TectonicRegionType> list = new ArrayList<TectonicRegionType>();
+		list.add(TectonicRegionType.ACTIVE_SHALLOW);
+		return list;
+	}
+
+	@Override
+	public String getName() {
+		return NAME;
+	}
+
+	@Override
+	public int compareTo(BaseERF o) {
+		return getName().compareToIgnoreCase(o.getName());
+	}
+	
+	@Override
+	public ERF getERF(int index) {
+		updateBranches();
+		LogicTreeBranch branch = branches.get(index);
+		return loadERF(branch);
+	}
+	
+	private FaultSystemSolutionERF loadERF(LogicTreeBranch branch) {
+		System.out.println("LoadERF for "+branch.buildFileName());
+		System.out.println("Loading solution...");
+		FaultSystemSolution sol = fetch.getSolution(branch);
+		System.out.println("DONE loading");
+		
+		System.out.println("Building ERF...");
+		FaultSystemSolutionERF erf = new FaultSystemSolutionERF(sol);
+		erf.setCacheGridSources(false);
+		for (Parameter<?> param : paramERF.getAdjustableParameterList())
+			if (!param.getName().equals(FaultSystemSolutionERF.FILE_PARAM_NAME))
+				erf.setParameter(param.getName(), param.getValue());
+		erf.setTimeSpan(paramERF.getTimeSpan());
+		System.out.println("Updating forecast...");
+		erf.updateForecast();
+		System.out.println("DONE LoadERF");
+		return erf;
+	}
+
+	@Override
+	public double getERF_RelativeWeight(int index) {
+		updateBranches();
+		return branches.get(index).getAprioriBranchWt();
+	}
+
+	@Override
+	public ArrayList<Double> getRelativeWeightsList() {
+		updateBranches();
+		ArrayList<Double> weights = new ArrayList<>();
+		for (LogicTreeBranch branch : branches)
+			weights.add(branch.getAprioriBranchWt());
+		return weights;
+	}
+
+	@Override
+	public int getNumERFs() {
+		updateBranches();
+		return branches.size();
+	}
+
+	@Override
+	public void parameterChange(ParameterChangeEvent event) {
+		if (enumParamsMap.containsValue(event.getParameter())) {
+			branches = null;
+		}
+		createParamList();
+	}
+	
+	public static void main(String[] args) throws ZipException, IOException {
+		UCERF3EpistemicListERF erf = new UCERF3EpistemicListERF();
+		
+		Stopwatch totalWatch = Stopwatch.createStarted();
+		
+		erf.setParameter(IncludeBackgroundParam.NAME, IncludeBackgroundOption.INCLUDE);
+		erf.setParameter("Fault Model", FaultModels.FM3_1);
+		erf.setParameter("Deformation Model", DeformationModels.ZENGBB);
+		erf.setParameter("Scaling Relationship", ScalingRelationships.SHAW_2009_MOD);
+		
+		erf.updateForecast();
+		
+		HazardCurveCalculator calc = new HazardCurveCalculator();
+		
+		ScalarIMR gmpe = AttenRelRef.ASK_2014.instance(null);
+		gmpe.setParamDefaults();
+		Site site = new Site(new Location(34, -118));
+		site.addParameterList(gmpe.getSiteParams());
+		
+		DiscretizedFunc xVals = IMT_Info.getUSGS_SA_Function();
+		DiscretizedFunc logXVals = new ArbitrarilyDiscretizedFunc();
+		for (Point2D pt : xVals)
+			logXVals.set(Math.log(pt.getX()), 0d);
+		
+		double totCalcSecs = 0;
+		double totLoadSecs = 0;
+		
+		for (int i=0; i<erf.getNumERFs(); i++) {
+			Stopwatch buildWatch = Stopwatch.createStarted();
+			ERF subERF = erf.getERF(i);
+			buildWatch.stop();
+			double secs = buildWatch.elapsed(TimeUnit.MILLISECONDS)/1000d;
+			totLoadSecs += secs;
+			System.out.println("Took "+(float)secs+" s to build");
+			System.out.println("Calculating...");
+			Stopwatch calcWatch = Stopwatch.createStarted();
+			calc.getHazardCurve(logXVals, site, gmpe, subERF);
+			calcWatch.stop();
+			secs = calcWatch.elapsed(TimeUnit.MILLISECONDS)/1000d;
+			totCalcSecs += secs;
+			System.out.println("Took "+(float)secs+" s to calc");
+		}
+		
+		totalWatch.stop();
+		System.out.println("TOTAL took "+totalWatch.elapsed(TimeUnit.SECONDS)+" s");
+		System.out.println("\t"+(float)totLoadSecs+" s loading");
+		System.out.println("\t"+(float)totCalcSecs+" s calculating");
+	}
+
+}

--- a/src/scratch/UCERF3/inversion/InversionFaultSystemRupSet.java
+++ b/src/scratch/UCERF3/inversion/InversionFaultSystemRupSet.java
@@ -188,6 +188,7 @@ public class InversionFaultSystemRupSet extends SlipEnabledRupSet {
 			List<List<Integer>> clusterRups,
 			List<List<Integer>> clusterSects) {
 		setParamsFromBranch(branch);
+		this.logicTreeBranch = branch;
 		init(rupSet);
 		
 		int numSects = rupSet.getNumSections();
@@ -201,7 +202,6 @@ public class InversionFaultSystemRupSet extends SlipEnabledRupSet {
 		Preconditions.checkNotNull(branch, "LogicTreeBranch cannot be null");
 		if (!branch.isFullySpecified())
 			System.err.println("WARNING: LogicTreeBranch not fully specified");
-		this.logicTreeBranch = branch;
 		
 		// can be null
 		this.filter = filter;
@@ -458,12 +458,24 @@ public class InversionFaultSystemRupSet extends SlipEnabledRupSet {
 	public void copyCacheFrom(FaultSystemRupSet rupSet) {
 		super.copyCacheFrom(rupSet);
 		if (rupSet instanceof InversionFaultSystemRupSet) {
+			FaultModels myFM = getFaultModel();
+			DeformationModels myDM = getDeformationModel();
+			LogicTreeBranch branch = getLogicTreeBranch();
+			ScalingRelationships myScale = branch.getValue(ScalingRelationships.class);
+			SlipAlongRuptureModels mySlipAlong = branch.getValue(SlipAlongRuptureModels.class);
+			
 			InversionFaultSystemRupSet invRupSet = (InversionFaultSystemRupSet)rupSet;
-			if (invRupSet.getSlipAlongRuptureModel() == getSlipAlongRuptureModel()
-					&& invRupSet.getDeformationModel() == getDeformationModel()
-					&& invRupSet.getLogicTreeBranch().getValue(ScalingRelationships.class)
-						== getLogicTreeBranch().getValue(ScalingRelationships.class))
-				rupSectionSlipsCache = invRupSet.rupSectionSlipsCache;
+			LogicTreeBranch oBranch = invRupSet.getLogicTreeBranch();
+			FaultModels oFM = invRupSet.getFaultModel();
+			DeformationModels oDM = invRupSet.getDeformationModel();
+			ScalingRelationships oScale = oBranch.getValue(ScalingRelationships.class);
+			SlipAlongRuptureModels oSlipAlong = oBranch.getValue(SlipAlongRuptureModels.class);
+			if (myFM == oFM && myDM == oDM && myScale == oScale) {
+				surfCache = invRupSet.surfCache;
+//				System.out.println("Copying surface cache!");
+				if (mySlipAlong == oSlipAlong)
+					rupSectionSlipsCache = invRupSet.rupSectionSlipsCache;
+			}
 		}
 	}
 	


### PR DESCRIPTION
I created a new epistemic list ERF for UCERF3, which works int he Hazard Curve and Spectrum apps. Here are a few notes on use:

The first time you run it, it will download a ~1GB data file (and store it in ~/.opensha/ucerf3_erf/).

It defaults to the full logic tree (all 1440 branches), but you can also fix any/all branches to individual branch choices using the parameter drop down boxes. I would select a small branch subset for initial tests. It also defaults to disabling background seismicity as that calculation will slow things down a bit, and it's already pretty slow to calculate things for the whole logic tree, but you can change that option.

I was able to take advantage of a lot of efficiencies (e.g., not-redoing distance calculations across branches which use the same fault surfaces), but you will have to be patient. In my tests, hazard curve calculations take about 2s per branch on average (the first branch for any unique combination of fault model, deformation model, and scaling relationship will take a bit longer).