### PR TITLE
New inversion constraint framework and tests

### DIFF
--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/InversionInputGenerator.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/InversionInputGenerator.java
@@ -1,0 +1,421 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.opensha.commons.data.CSVFile;
+import org.opensha.commons.util.FileUtils;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
+
+import cern.colt.function.tdouble.IntIntDoubleFunction;
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+import cern.colt.matrix.tdouble.impl.SparseCCDoubleMatrix2D;
+import cern.colt.matrix.tdouble.impl.SparseDoubleMatrix2D;
+import cern.colt.matrix.tdouble.impl.SparseRCDoubleMatrix2D;
+import scratch.UCERF3.FaultSystemRupSet;
+import scratch.UCERF3.simulatedAnnealing.ConstraintRange;
+import scratch.UCERF3.utils.MatrixIO;
+
+/**
+ * This class builds and encodes inversion inputs (A/A_ineq matrices and D/D_ineq vectors) from
+ * a list of constraints
+ * @author kevin
+ *
+ */
+public class InversionInputGenerator {
+	
+	// inputs
+	private int numRuptures;
+	private List<InversionConstraint> constraints;
+	private double[] initialSolution;
+	private double[] waterLevelRates;
+	
+	// outputs
+	private DoubleMatrix2D A;
+	private double[] d;
+	private DoubleMatrix2D A_ineq;
+	private double[] d_ineq;
+	
+	private List<ConstraintRange> constraintRowRanges;
+
+	public InversionInputGenerator(FaultSystemRupSet rupSet, List<InversionConstraint> constraints) {
+		this(rupSet, constraints, null, null);
+	}
+
+	public InversionInputGenerator(FaultSystemRupSet rupSet, List<InversionConstraint> constraints,
+			double[] initialSolution, double[] waterLevelRates) {
+		this.numRuptures = rupSet.getNumRuptures();
+		this.constraints = constraints;
+		this.initialSolution = initialSolution;
+		this.waterLevelRates = waterLevelRates;
+	}
+	
+	public void generateInputs() {
+		generateInputs(null, false);
+	}
+	
+	public void generateInputs(boolean verbose) {
+		generateInputs(null, verbose);
+	}
+	
+	public void generateInputs(Class<? extends DoubleMatrix2D> clazz, final boolean verbose) {
+		if (verbose)
+			System.out.println("Generating inversion inputs with "+numRuptures+" ruptures "
+					+"and "+constraints.size()+" constraints");
+
+		if (initialSolution == null) {
+			if (verbose)
+				System.out.println("Building empty intial solution (all zeroes)");
+			initialSolution = new double[numRuptures];
+		} else {
+			Preconditions.checkState(initialSolution.length == numRuptures,
+					"Initial solution is wrong size: %s != %s", initialSolution.length, numRuptures);
+		}
+		
+		if (waterLevelRates != null)
+			Preconditions.checkState(waterLevelRates.length == numRuptures,
+					"Water level rates are wrong size: %s != %s", waterLevelRates.length, numRuptures);
+		
+		constraintRowRanges = new ArrayList<>();
+		
+		if (verbose)
+			System.out.println("Calculating constraint row counts");
+
+		Stopwatch watch = verbose ? Stopwatch.createStarted() : null;
+		Stopwatch watchTotal = verbose ? Stopwatch.createStarted() : null;
+
+		int numRows = 0;
+		int numIneqRows = 0;
+		for (InversionConstraint constraint : constraints) {
+			constraint.setQuickGetSets(!verbose);
+			ConstraintRange range;
+			if (constraint.isInequality()) {
+				range = calcRowRange(numIneqRows, constraint, verbose);
+				numIneqRows = range.endRow;
+			} else {
+				range = calcRowRange(numRows, constraint, verbose);
+				numRows = range.endRow;
+			}
+			constraintRowRanges.add(range);
+		}
+		
+		if (verbose) {
+			watch.stop();
+			System.out.println("Took "+getTimeStr(watch)+" to get row counts");
+		}
+		
+		if (numRows > 0) {
+			if (verbose)
+				System.out.println("Building A matrix with "+numRows
+						+" rows and "+numRuptures+" columns");
+			// Components of matrix equation to invert (A*x=d)
+			A = buildMatrix(clazz, numRows, numRuptures); // A matrix
+			d = new double[numRows];	// data vector d
+		}
+		
+		if (numIneqRows > 0) {
+			if (verbose)
+				System.out.println("Building A inequality matrix with "+numIneqRows
+						+" rows and "+numRuptures+" columns");
+			// inequality constraint matrix and data vector (A_ineq*x <= d_ineq)
+			A_ineq = buildMatrix(clazz, numIneqRows, numRuptures); // A matrix
+			d_ineq = new double[numIneqRows];	// data vector d
+		}
+		
+		if (verbose)
+			System.out.println("Encoding matrices");
+		
+		watch = verbose ? Stopwatch.createStarted() : null;
+		int numNonZero = 0;
+		
+		for (int i=0; i<constraints.size(); i++) {
+			InversionConstraint constraint = constraints.get(i);
+			ConstraintRange rowRange = constraintRowRanges.get(i);
+			
+			DoubleMatrix2D myA;
+			double[] myD;
+			if (constraint.isInequality()) {
+				myA = A_ineq;
+				myD = d_ineq;
+			} else {
+				myA = A;
+				myD = d;
+			}
+			
+			if (verbose)
+				System.out.println("\tEncoding "+constraint.getName()
+					+", ineq="+constraint.isInequality());
+			Stopwatch subWatch = verbose ? Stopwatch.createStarted() : null;
+			long myNonZero = constraint.encode(myA, myD, rowRange.startRow);
+			if (verbose) {
+				long maxNum = (rowRange.endRow - rowRange.startRow)*(long)numRuptures;
+				double density = 100d*(double)myNonZero/(double)maxNum;
+				System.out.println("\t\tDONE, took "+getTimeStr(subWatch)+" to encode "
+						+myNonZero+" values (density: "+oneDigit.format(density)+" %)");
+				subWatch.stop();
+			}
+			numNonZero += myNonZero;
+		}
+		
+		if (verbose) {
+			long maxNum = (numRows+numIneqRows)*(long)numRuptures;
+			double density = 100d*(double)numNonZero/(double)maxNum;
+			System.out.println("DONE encoding, took "+getTimeStr(watch)+" to encode "
+					+numNonZero+" values (density: "+oneDigit.format(density)+" %)");
+			watch.stop();
+		}
+		
+		if (waterLevelRates != null) {
+			// offset data vector: d = d-A*minimumRuptureRates
+			watch = verbose ? Stopwatch.createStarted() : null;
+			if (numRows > 0) {
+				if (verbose)
+					System.out.println("Applying minimum rupture rates to A matrix");
+				
+				A.forEachNonZero(new AdjustDataForMinRates(d, waterLevelRates));
+			}
+			if (numIneqRows > 0) {
+				if (verbose)
+					System.out.println("Applying minimum rupture rates to A_ineq matrix");
+				
+				A_ineq.forEachNonZero(new AdjustDataForMinRates(d_ineq, waterLevelRates));
+			}
+			
+			// also adjust the initial solution by the minimum rates
+			initialSolution = Arrays.copyOf(initialSolution, numRuptures);
+			for (int i=0; i<numRuptures; i++) {
+				double adjustedVal = initialSolution[i] - waterLevelRates[i];
+				if (adjustedVal < 0)
+					adjustedVal = 0;
+				initialSolution[i] = adjustedVal;
+			}
+			
+			if (verbose) {
+				System.out.println("Took "+getTimeStr(watch)+" to apply minimum rates");
+				watch.stop();
+			}
+		}
+		
+		if (verbose) {
+			System.out.println("Took "+getTimeStr(watchTotal)+" to generate inputs");
+			watchTotal.stop();
+		}
+	}
+	
+	private static class AdjustDataForMinRates implements IntIntDoubleFunction {
+		
+		private double[] d;
+		private double[] waterLevelRates;
+		
+		public AdjustDataForMinRates(double[] d, double[] waterLevelRates) {
+			this.d = d;
+			this.waterLevelRates = waterLevelRates;
+		}
+
+		@Override
+		public double apply(int row, int col, double val) {
+			// This is the offset data vector: d = d-A*waterLevelRates
+			d[row] -= val * waterLevelRates[col];
+			return val; // don't change A
+		}
+		
+	}
+	
+	private ConstraintRange calcRowRange(int startIndex, InversionConstraint constraint, boolean verbose) {
+		Stopwatch watch = verbose ? Stopwatch.createStarted() : null;
+		int numRows = constraint.getNumRows();
+		ConstraintRange range = new ConstraintRange(constraint.getName(), constraint.getShortName(),
+				startIndex, startIndex+numRows, constraint.isInequality());
+		if (verbose) {
+			System.out.println("\t"+range+" (took "+getTimeStr(watch)+")");
+			watch.stop();
+		}
+		return range;
+	}
+	
+	private static final DecimalFormat oneDigit = new DecimalFormat("0.0");
+	
+	protected String getTimeStr(Stopwatch watch) {
+		long millis = watch.elapsed(TimeUnit.MILLISECONDS);
+		if (millis < 1000)
+			return millis+" ms";
+		double secs = (double)millis/1000d;
+		if (secs < 60d)
+			return oneDigit.format(secs)+" s";
+		double mins = secs/60d;
+		return oneDigit.format(mins)+" m";
+	}
+	
+	protected static DoubleMatrix2D buildMatrix(Class<? extends DoubleMatrix2D> clazz, int rows, int cols) {
+		if (clazz == null || clazz.equals(SparseDoubleMatrix2D.class))
+			// default
+			return new SparseDoubleMatrix2D(rows, cols);
+		else if (clazz.equals(SparseRCDoubleMatrix2D.class))
+			return new SparseRCDoubleMatrix2D(rows, cols);
+		else if (clazz.equals(SparseCCDoubleMatrix2D.class))
+			return new SparseCCDoubleMatrix2D(rows, cols);
+		else
+			throw new IllegalArgumentException("Unknown matrix type: "+clazz);
+	}
+	
+	/**
+	 * Column compress the A matrices for faster multiplication
+	 */
+	public void columnCompress() {
+		A = getColumnCompressed(A);
+		if (A_ineq != null)
+			A_ineq = getColumnCompressed(A_ineq);
+	}
+	
+	private static SparseCCDoubleMatrix2D getColumnCompressed(DoubleMatrix2D mat) {
+		if (mat instanceof SparseCCDoubleMatrix2D)
+			return (SparseCCDoubleMatrix2D)mat;
+		if (mat instanceof SparseRCDoubleMatrix2D)
+			return ((SparseRCDoubleMatrix2D)mat).getColumnCompressed();
+		if (mat instanceof SparseDoubleMatrix2D)
+			return ((SparseDoubleMatrix2D)mat).getColumnCompressed(true);
+		throw new RuntimeException("Can't column compress matrix: "+mat);
+	}
+	
+	/**
+	 * This adds the water level rates back to the solution
+	 * @param solution
+	 * @return copy of the solution with water level rates added back in
+	 */
+	public double[] adjustSolutionForWaterLevel(double[] solution) {
+		return adjustSolutionForWaterLevel(solution, waterLevelRates);
+	}
+	
+	/**
+	 * This adds the water level rates back to the solution
+	 * @param solution
+	 * @param waterLevelRates
+	 * @return copy of the solution with water level rates added back in
+	 */
+	public static double[] adjustSolutionForWaterLevel(double[] solution, double[] waterLevelRates) {
+		solution = Arrays.copyOf(solution, solution.length);
+		
+		if (waterLevelRates != null) {
+			Preconditions.checkState(waterLevelRates.length == solution.length,
+					"minimum rates size mismatch!");
+			for (int i=0; i<solution.length; i++) {
+				solution[i] = solution[i] + waterLevelRates[i];
+			}
+		}
+		
+		return solution;
+	}
+	
+	public void writeZipFile(File file, boolean verbose) throws IOException {
+		File tempDir = FileUtils.createTempDir();
+		writeZipFile(file, FileUtils.createTempDir(), true, verbose);
+		tempDir.delete();
+	}
+	
+	/**
+	 * Writes the inputs to the given zip file, storing the binary files
+	 * in the given directory and optionally cleaning up (deleting them)
+	 * when done.
+	 * 
+	 * @param file target zip file
+	 * @param storeDir directory where they should be saved
+	 * @param cleanup if true, deletes input files after zipping
+	 * @param verbose print progress
+	 */
+	public void writeZipFile(File zipFile, File storeDir, boolean cleanup, boolean verbose)
+			throws IOException {
+		if(verbose) System.out.println("Saving to files...");
+		ArrayList<String> fileNames = new ArrayList<String>();
+		
+		fileNames.add("d.bin");			
+		MatrixIO.doubleArrayToFile(d, new File(storeDir, "d.bin"));
+		if(verbose) System.out.println("d.bin saved");
+		
+		fileNames.add("a.bin");			
+		MatrixIO.saveSparse(A, new File(storeDir, "a.bin"));
+		if(verbose) System.out.println("a.bin saved");
+		
+		fileNames.add("initial.bin");	
+		MatrixIO.doubleArrayToFile(initialSolution, new File(storeDir, "initial.bin"));
+		if(verbose) System.out.println("initial.bin saved");
+		
+		if (d_ineq != null) {
+			fileNames.add("d_ineq.bin");	
+			MatrixIO.doubleArrayToFile(d_ineq, new File(storeDir, "d_ineq.bin"));
+			if(verbose) System.out.println("d_ineq.bin saved");
+		}
+		
+		if (A_ineq != null) {
+			fileNames.add("a_ineq.bin");	
+			MatrixIO.saveSparse(A_ineq,new File(storeDir, "a_ineq.bin"));
+			if(verbose) System.out.println("a_ineq.bin saved");
+		}
+		
+		if (waterLevelRates != null) {
+			fileNames.add("minimumRuptureRates.bin");	
+			MatrixIO.doubleArrayToFile(waterLevelRates,new File(storeDir, "minimumRuptureRates.bin"));
+			if(verbose) System.out.println("minimumRuptureRates.bin saved");
+		}
+		
+		CSVFile<String> rangeCSV = new CSVFile<String>(true);
+		rangeCSV.addLine("Name", "Short Name", "Inequality?",
+				"Start Row (inclusive)", "End Row (exclusive)");
+		
+		for (ConstraintRange range : constraintRowRanges)
+			rangeCSV.addLine(range.name, range.shortName, range.inequality+"",
+					range.startRow+"", range.endRow+"");
+		fileNames.add("constraintRanges.csv");
+		rangeCSV.writeToFile(new File(storeDir, "constraintRanges.csv"));
+		if(verbose) System.out.println("constraintRanges.csv saved");
+		
+		FileUtils.createZipFile(zipFile.getAbsolutePath(), storeDir.getAbsolutePath(), fileNames);
+		if(verbose) System.out.println("Zip file saved");
+		if (cleanup) {
+			if(verbose) System.out.println("Cleaning up");
+			for (String fileName : fileNames) {
+				new File(storeDir, fileName).delete();
+			}
+		}
+	}
+	
+	public DoubleMatrix2D getA() {
+		return A;
+	}
+
+	public DoubleMatrix2D getA_ineq() {
+		return A_ineq;
+	}
+
+	public double[] getD() {
+		return d;
+	}
+
+	public double[] getD_ineq() {
+		return d_ineq;
+	}
+
+	public double[] getInitialSolution() {
+		return initialSolution;
+	}
+
+	public double[] getWaterLevelRates() {
+		return waterLevelRates;
+	}
+
+	public List<ConstraintRange> getConstraintRowRanges() {
+		return constraintRowRanges;
+	}
+
+	public List<InversionConstraint> getConstraints() {
+		return constraints;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/InversionInputGenerator.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/InversionInputGenerator.java
@@ -33,18 +33,18 @@ import scratch.UCERF3.utils.MatrixIO;
 public class InversionInputGenerator {
 	
 	// inputs
-	private int numRuptures;
-	private List<InversionConstraint> constraints;
-	private double[] initialSolution;
-	private double[] waterLevelRates;
+	protected int numRuptures;
+	protected List<InversionConstraint> constraints;
+	protected double[] initialSolution;
+	protected double[] waterLevelRates;
 	
 	// outputs
-	private DoubleMatrix2D A;
-	private double[] d;
-	private DoubleMatrix2D A_ineq;
-	private double[] d_ineq;
+	protected DoubleMatrix2D A;
+	protected double[] d;
+	protected DoubleMatrix2D A_ineq;
+	protected double[] d_ineq;
 	
-	private List<ConstraintRange> constraintRowRanges;
+	protected List<ConstraintRange> constraintRowRanges;
 
 	public InversionInputGenerator(FaultSystemRupSet rupSet, List<InversionConstraint> constraints) {
 		this(rupSet, constraints, null, null);

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/InversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/InversionConstraint.java
@@ -4,6 +4,12 @@ import org.opensha.commons.data.ShortNamed;
 
 import cern.colt.matrix.tdouble.DoubleMatrix2D;
 
+/**
+ * Abstract class for an inversion constraint
+ * 
+ * @author kevin
+ *
+ */
 public abstract class InversionConstraint implements ShortNamed {
 	
 	private boolean quickGetsSets = true;
@@ -29,6 +35,14 @@ public abstract class InversionConstraint implements ShortNamed {
 	 */
 	public abstract long encode(DoubleMatrix2D A, double[] d, int startRow);
 	
+	/**
+	 * Utility method to set a value in the given A matrix, respecting the quickGetsSets value
+	 * 
+	 * @param A
+	 * @param row
+	 * @param col
+	 * @param val
+	 */
 	protected void setA(DoubleMatrix2D A, int row, int col, double val) {
 		if (quickGetsSets)
 			A.setQuick(row, col, val);

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/InversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/InversionConstraint.java
@@ -51,6 +51,38 @@ public abstract class InversionConstraint implements ShortNamed {
 	}
 	
 	/**
+	 * Utility method to get a value in the given A matrix, respecting the quickGetsSets value
+	 * 
+	 * @param A
+	 * @param row
+	 * @param col
+	 * @return value at that location
+	 */
+	protected double getA(DoubleMatrix2D A, int row, int col) {
+		if (quickGetsSets)
+			return A.getQuick(row, col);
+		return A.get(row, col);
+	}
+	
+	/**
+	 * Utility method to add a value in the given A matrix, respecting the quickGetsSets value
+	 * 
+	 * @param A
+	 * @param row
+	 * @param col
+	 * @param val
+	 * @return true if the previous value was nonzero
+	 */
+	protected boolean addA(DoubleMatrix2D A, int row, int col, double val) {
+		double prevVal = getA(A, row, col);
+		if (quickGetsSets)
+			A.setQuick(row, col, val+prevVal);
+		else
+			A.set(row, col, val+prevVal);
+		return prevVal != 0d;
+	}
+	
+	/**
 	 * Sets whether or not we should use quick set/get methods on the A matrix. The quick
 	 * versions of these methods are faster, but don't do any input validation (range checking)
 	 * @param quickGetsSets

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/InversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/InversionConstraint.java
@@ -1,0 +1,48 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.constraints;
+
+import org.opensha.commons.data.ShortNamed;
+
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+
+public abstract class InversionConstraint implements ShortNamed {
+	
+	private boolean quickGetsSets = true;
+	
+	/**
+	 * @return the number of rows in the A matrix/d vector for this constraint
+	 */
+	public abstract int getNumRows();
+	
+	/**
+	 * @return true if this is an inequality constraint (A_ineq, d_ineq), else a regular
+	 * equality constraint
+	 */
+	public abstract boolean isInequality();
+	
+	/**
+	 * Encodes this constraint into the given A matrix and d vector, beginning at the
+	 * given starting row and ending before (startRow+getNumRows())
+	 * @param A
+	 * @param d
+	 * @param startRow
+	 * @return number of non-zero elements added
+	 */
+	public abstract long encode(DoubleMatrix2D A, double[] d, int startRow);
+	
+	protected void setA(DoubleMatrix2D A, int row, int col, double val) {
+		if (quickGetsSets)
+			A.setQuick(row, col, val);
+		else
+			A.set(row, col, val);
+	}
+	
+	/**
+	 * Sets whether or not we should use quick set/get methods on the A matrix. The quick
+	 * versions of these methods are faster, but don't do any input validation (range checking)
+	 * @param quickGetsSets
+	 */
+	public void setQuickGetSets(boolean quickGetsSets) {
+		this.quickGetsSets = quickGetsSets;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/APrioriInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/APrioriInversionConstraint.java
@@ -4,6 +4,15 @@ import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.Inversi
 
 import cern.colt.matrix.tdouble.DoubleMatrix2D;
 
+/**
+ * This will constrain a the inversion to stay near to a set of a priori rupture rates. It can apply
+ * different weights to ruptures with zero rates in the a priori model.
+ * 
+ * For UCERF3, this constraint allowed us to keep rates close to UCERF2, and we ultimately did not use it.
+ * 
+ * @author Morgan Page & Kevin Milner
+ *
+ */
 public class APrioriInversionConstraint extends InversionConstraint {
 	
 	private double weight;

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/APrioriInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/APrioriInversionConstraint.java
@@ -1,0 +1,74 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl;
+
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
+
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+
+public class APrioriInversionConstraint extends InversionConstraint {
+	
+	private double weight;
+	private double weightForZeroRates;
+	private double[] aPrioriRates;
+
+	public APrioriInversionConstraint(double weight, double weightForZeroRates,
+			double[] aPrioriRates) {
+		this.weight = weight;
+		this.weightForZeroRates = weightForZeroRates;
+		this.aPrioriRates = aPrioriRates;
+	}
+
+	@Override
+	public String getShortName() {
+		return "APriori";
+	}
+
+	@Override
+	public String getName() {
+		return "A Priori Rupture Rate";
+	}
+
+	@Override
+	public int getNumRows() {
+		int numNonZero = 0;
+		for (double rate : aPrioriRates)
+			if (rate > 0)
+				numNonZero++;
+		if (weightForZeroRates > 0)
+			return numNonZero +1;
+		return numNonZero;
+	}
+
+	@Override
+	public boolean isInequality() {
+		return false;
+	}
+
+	@Override
+	public long encode(DoubleMatrix2D A, double[] d, int startRow) {
+		long numNonZeroElements = 0;
+		int rowIndex = startRow;
+		if (weight > 0d) {
+			for(int rup=0; rup<aPrioriRates.length; rup++) {
+				// only apply if rupture-rate is greater than 0, this will keep ruptures on
+				// faults not in UCERF2 from being minimized
+				if (aPrioriRates[rup]>0) {
+					setA(A, rowIndex, rup, weight);
+					d[rowIndex]=aPrioriRates[rup]*weight;
+					numNonZeroElements++; rowIndex++;
+				}
+			}
+		}
+		if (weightForZeroRates > 0d) {
+			// constrain sum of all these rupture rates to be zero (minimize - adding only one row to A matrix)
+			for(int rup=0; rup<aPrioriRates.length; rup++) {
+				if (aPrioriRates[rup]==0) { 
+					setA(A, rowIndex, rup, weightForZeroRates);
+					numNonZeroElements++; 
+				}
+			}	
+			d[rowIndex]=0;
+		}
+		return numNonZeroElements;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDEqualityInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDEqualityInversionConstraint.java
@@ -12,6 +12,15 @@ import cern.colt.matrix.tdouble.DoubleMatrix2D;
 import scratch.UCERF3.FaultSystemRupSet;
 import scratch.UCERF3.utils.MFD_InversionConstraint;
 
+/**
+ * Constraints the solution to match the given MFD constraints, which can be region specific.
+ * 
+ * In UCERF3, we used an equality constraint up to large magnitudes, where we transitioned to
+ * an inequality constraint, and used separate constraints for northern and southern CA.
+ * 
+ * @author Morgan Page & Kevin Milner
+ *
+ */
 public class MFDEqualityInversionConstraint extends InversionConstraint {
 	
 	public static final String NAME = "MFD Equality";

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDEqualityInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDEqualityInversionConstraint.java
@@ -1,0 +1,101 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl;
+
+import java.util.HashSet;
+import java.util.List;
+
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
+import org.opensha.sha.magdist.IncrementalMagFreqDist;
+
+import com.google.common.base.Preconditions;
+
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+import scratch.UCERF3.FaultSystemRupSet;
+import scratch.UCERF3.utils.MFD_InversionConstraint;
+
+public class MFDEqualityInversionConstraint extends InversionConstraint {
+	
+	public static final String NAME = "MFD Equality";
+	public static final String SHORT_NAME = "MFDEquality";
+	
+	private FaultSystemRupSet rupSet;
+	private double weight;
+	private List<MFD_InversionConstraint> mfdEqualityConstraints;
+	private HashSet<Integer> excludeRupIndexes;
+
+	public MFDEqualityInversionConstraint(FaultSystemRupSet rupSet, double weight,
+			List<MFD_InversionConstraint> mfdEqualityConstraints, HashSet<Integer> excludeRupIndexes) {
+		this.rupSet = rupSet;
+		this.weight = weight;
+		this.mfdEqualityConstraints = mfdEqualityConstraints;
+		this.excludeRupIndexes = excludeRupIndexes;
+	}
+
+	@Override
+	public String getShortName() {
+		return SHORT_NAME;
+	}
+
+	@Override
+	public String getName() {
+		return NAME;
+	}
+
+	@Override
+	public int getNumRows() {
+		int totalNumMagFreqConstraints = 0;
+		for (MFD_InversionConstraint constr : mfdEqualityConstraints) {
+			IncrementalMagFreqDist targetMagFreqDist = constr.getMagFreqDist();
+			// Find number of rows used for MFD equality constraint
+			// only include mag bins between minimum and maximum magnitudes in rupture set
+			totalNumMagFreqConstraints += targetMagFreqDist.getClosestXIndex(rupSet.getMaxMag())
+					- targetMagFreqDist.getClosestXIndex(rupSet.getMinMag()) + 1;
+		}
+		return totalNumMagFreqConstraints;
+	}
+
+	@Override
+	public boolean isInequality() {
+		return false;
+	}
+
+	@Override
+	public long encode(DoubleMatrix2D A, double[] d, int startRow) {
+		long numNonZeroElements = 0;
+		// Loop over all MFD constraints in different regions
+		int numRuptures = rupSet.getNumRuptures();
+		for (int i=0; i < mfdEqualityConstraints.size(); i++) {
+			double[] fractRupsInside = rupSet.getFractRupsInsideRegion(mfdEqualityConstraints.get(i).getRegion(), false);
+			IncrementalMagFreqDist targetMagFreqDist = mfdEqualityConstraints.get(i).getMagFreqDist();
+			int minMagIndex = targetMagFreqDist.getClosestXIndex(rupSet.getMinMag());
+			int maxMagIndex = targetMagFreqDist.getClosestXIndex(rupSet.getMaxMag());
+			for(int rup=0; rup<numRuptures; rup++) {
+				double mag = rupSet.getMagForRup(rup);
+				double fractRupInside = fractRupsInside[rup];
+				if (fractRupInside > 0 && mag>targetMagFreqDist.getMinX()-targetMagFreqDist.getDelta()/2.0 && mag<targetMagFreqDist.getMaxX()+targetMagFreqDist.getDelta()/2.0) {
+					if (excludeRupIndexes != null && excludeRupIndexes.contains(rup))
+						continue;
+					int magIndex = targetMagFreqDist.getClosestXIndex(mag);
+					Preconditions.checkState(magIndex >= minMagIndex && magIndex <= maxMagIndex);
+					int rowIndex = startRow + magIndex - minMagIndex;
+					if (targetMagFreqDist.getClosestYtoX(mag) == 0) {
+						setA(A, rowIndex, rup, 0d);
+					} else {
+						setA(A, rowIndex, rup, weight * fractRupInside / targetMagFreqDist.getClosestYtoX(mag));
+						numNonZeroElements++;
+					}
+				}
+			}
+			for (int magIndex=minMagIndex; magIndex<=maxMagIndex; magIndex++) {
+				int rowIndex = startRow + magIndex - minMagIndex;
+				if (targetMagFreqDist.getY(magIndex)==0)
+					d[rowIndex]=0;
+				else
+					d[rowIndex] = weight;
+			}
+			// move startRow to point after this constraint
+			startRow += (maxMagIndex - minMagIndex) + 1;
+		}
+		return numNonZeroElements;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDInequalityInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDInequalityInversionConstraint.java
@@ -11,6 +11,15 @@ import cern.colt.matrix.tdouble.DoubleMatrix2D;
 import scratch.UCERF3.FaultSystemRupSet;
 import scratch.UCERF3.utils.MFD_InversionConstraint;
 
+/**
+ * Constraints the solution to not exceed the given MFD constraints, which can be region specific.
+ * 
+ * In UCERF3, we used an equality constraint up to large magnitudes, where we transitioned to
+ * an inequality constraint, and used separate constraints for northern and southern CA.
+ * 
+ * @author Morgan Page & Kevin Milner
+ * 
+ */
 public class MFDInequalityInversionConstraint extends InversionConstraint {
 	
 	private FaultSystemRupSet rupSet;

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDInequalityInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDInequalityInversionConstraint.java
@@ -1,0 +1,94 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl;
+
+import java.util.List;
+
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
+import org.opensha.sha.magdist.IncrementalMagFreqDist;
+
+import com.google.common.base.Preconditions;
+
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+import scratch.UCERF3.FaultSystemRupSet;
+import scratch.UCERF3.utils.MFD_InversionConstraint;
+
+public class MFDInequalityInversionConstraint extends InversionConstraint {
+	
+	private FaultSystemRupSet rupSet;
+	private double weight;
+	private List<MFD_InversionConstraint> mfdInequalityConstraints;
+
+	public MFDInequalityInversionConstraint(FaultSystemRupSet rupSet, double weight,
+			List<MFD_InversionConstraint> mfdInequalityConstraints) {
+		this.rupSet = rupSet;
+		this.weight = weight;
+		this.mfdInequalityConstraints = mfdInequalityConstraints;
+	}
+
+	@Override
+	public String getShortName() {
+		return "MFDInquality";
+	}
+
+	@Override
+	public String getName() {
+		return "MFD Inequality";
+	}
+
+	@Override
+	public int getNumRows() {
+		int numMFDRows = 0;
+		for (MFD_InversionConstraint constr : mfdInequalityConstraints) {
+			IncrementalMagFreqDist targetMagFreqDist = constr.getMagFreqDist();
+			// Add number of rows used for magnitude distribution constraint - only include mag bins between minimum and maximum magnitudes in rupture set				
+			numMFDRows += targetMagFreqDist.getClosestXIndex(rupSet.getMaxMag())
+					- targetMagFreqDist.getClosestXIndex(rupSet.getMinMag()) + 1;
+		}
+		return numMFDRows;
+	}
+
+	@Override
+	public boolean isInequality() {
+		return true;
+	}
+
+	@Override
+	public long encode(DoubleMatrix2D A, double[] d, int startRow) {
+		long numNonZeroElements = 0;
+		int numRuptures = rupSet.getNumRuptures();
+		// Loop over all MFD constraints in different regions
+		for (int i=0; i < mfdInequalityConstraints.size(); i++) {
+			double[] fractRupsInside = rupSet.getFractRupsInsideRegion(mfdInequalityConstraints.get(i).getRegion(), false);
+			IncrementalMagFreqDist targetMagFreqDist = mfdInequalityConstraints.get(i).getMagFreqDist();
+			double minMag = targetMagFreqDist.getMinX()-targetMagFreqDist.getDelta()/2.0;
+			double maxMag = targetMagFreqDist.getMaxX()+targetMagFreqDist.getDelta()/2.0;
+			int minMagIndex = targetMagFreqDist.getClosestXIndex(rupSet.getMinMag());
+			int maxMagIndex = targetMagFreqDist.getClosestXIndex(rupSet.getMaxMag());
+			for(int rup=0; rup<numRuptures; rup++) {
+				double mag = rupSet.getMagForRup(rup);
+				double fractRupInside = fractRupsInside[rup];
+				if (fractRupInside > 0 && mag>=minMag && mag<=maxMag) {
+					int magIndex = targetMagFreqDist.getClosestXIndex(mag);
+					Preconditions.checkState(magIndex >= minMagIndex && magIndex <= maxMagIndex);
+					int rowIndex = startRow + magIndex - minMagIndex;
+					if (targetMagFreqDist.getClosestYtoX(mag) == 0) {
+						setA(A, rowIndex, rup, 0d);
+					} else {
+						setA(A, rowIndex, rup, weight * fractRupInside / targetMagFreqDist.getClosestYtoX(mag));
+						numNonZeroElements++;
+					}
+				}
+			}		
+			for (int magIndex=minMagIndex; magIndex<=maxMagIndex; magIndex++) {
+				int rowIndex = startRow + magIndex - minMagIndex;
+				if (targetMagFreqDist.getY(magIndex)==0)
+					d[rowIndex]=0;
+				else
+					d[rowIndex] = weight;
+			}
+			// move startRow to point after this constraint
+			startRow += (maxMagIndex - minMagIndex) + 1;
+		}
+		return numNonZeroElements;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDLaplacianSmoothingInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDLaplacianSmoothingInversionConstraint.java
@@ -15,6 +15,15 @@ import cern.colt.matrix.tdouble.DoubleMatrix2D;
 import scratch.UCERF3.FaultSystemRupSet;
 import scratch.UCERF3.utils.SectionMFD_constraint;
 
+/**
+ * MFDs spatially smooth along adjacent subsections on a parent section (Laplacian smoothing).
+ * 
+ * This can be applied globally to all sections, or only to those which have paleoseismic constraints.
+ * In UCERF3, we used it only on paleo-constrained sections.
+ * 
+ * @author Morgan Page & Kevin Milner
+ *
+ */
 public class MFDLaplacianSmoothingInversionConstraint extends InversionConstraint {
 	
 	private FaultSystemRupSet rupSet;

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDLaplacianSmoothingInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDLaplacianSmoothingInversionConstraint.java
@@ -1,0 +1,201 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
+import org.opensha.sha.faultSurface.FaultSection;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+import scratch.UCERF3.FaultSystemRupSet;
+import scratch.UCERF3.utils.SectionMFD_constraint;
+
+public class MFDLaplacianSmoothingInversionConstraint extends InversionConstraint {
+	
+	private FaultSystemRupSet rupSet;
+	private double weight;
+	private double weightForPaleoParents;
+	private HashSet<Integer> paleoParentIDs;
+	private List<SectionMFD_constraint> constraints;
+
+	public MFDLaplacianSmoothingInversionConstraint(FaultSystemRupSet rupSet,
+			double weight, double weightForPaleoParents, HashSet<Integer> paleoParentIDs,
+			List<SectionMFD_constraint> constraints) {
+		this.rupSet = rupSet;
+		this.weight = weight;
+		this.weightForPaleoParents = weightForPaleoParents;
+		this.paleoParentIDs = paleoParentIDs;
+		this.constraints = constraints;
+	}
+
+	@Override
+	public String getShortName() {
+		return "LaplaceSmooth";
+	}
+
+	@Override
+	public String getName() {
+		return "MFD Laplacian Smoothing";
+	}
+
+	@Override
+	public int getNumRows() {
+		// Get list of parent sections
+		HashSet<Integer> parentIDs = new HashSet<Integer>();
+		for (FaultSection sect : rupSet.getFaultSectionDataList()) {
+			int parentID = sect.getParentSectionId();
+			parentIDs.add(parentID);
+		}
+		int totalNumMFDSmoothnessConstraints = 0;
+		for (int parentID: parentIDs) {
+			// Get list of subsections for parent 
+			ArrayList<Integer> sectsForParent = new ArrayList<Integer>();
+			for (FaultSection sect : rupSet.getFaultSectionDataList()) {
+				int sectParentID = sect.getParentSectionId();
+				if (sectParentID == parentID)
+					sectsForParent.add(sect.getSectionId());
+			}
+			// For each beginning section of subsection-pair, there will be numMagBins # of constraints
+			for (int j=1; j<sectsForParent.size()-2; j++) {
+				int sect2 = sectsForParent.get(j);
+				SectionMFD_constraint sectMFDConstraint = constraints.get(sect2);
+				if (sectMFDConstraint == null)
+					continue; // Parent sections with Mmax<6 have no MFD constraint; skip these
+				int numMagBins = sectMFDConstraint.getNumMags();
+				// Only add rows if this parent section will be included; it won't if it's not a paleo parent sect & MFDSmoothnessConstraintWt = 0
+				// CASE WHERE MFDSmoothnessConstraintWt != 0 & MFDSmoothnessConstraintWtForPaleoParents 0 IS NOT SUPPORTED
+				if (weight > 0d || (weightForPaleoParents > 0d && paleoParentIDs.contains(parentID))) {
+					totalNumMFDSmoothnessConstraints+=numMagBins;
+				}
+			}
+		}
+		return totalNumMFDSmoothnessConstraints;
+	}
+
+	@Override
+	public boolean isInequality() {
+		return false;
+	}
+
+	@Override
+	public long encode(DoubleMatrix2D A, double[] d, int startRow) {
+		long numNonZeroElements = 0;
+		int rowIndex = startRow;
+		
+		// Get list of parent IDs
+		Map<Integer, List<FaultSection>> parentSectsMap = Maps.newHashMap();
+		for (FaultSection sect : rupSet.getFaultSectionDataList()) {
+			Integer parentID = sect.getParentSectionId();
+			List<FaultSection> parentSects = parentSectsMap.get(parentID);
+			if (parentSects == null) {
+				parentSects = Lists.newArrayList();
+				parentSectsMap.put(parentID, parentSects);
+			}
+			parentSects.add(sect);
+		}
+		
+		List<HashSet<Integer>> sectRupsHashes = Lists.newArrayList();
+		for (int s=0; s<rupSet.getNumSections(); s++)
+			sectRupsHashes.add(new HashSet<Integer>(rupSet.getRupturesForSection(s)));
+
+		for (List<FaultSection> sectsForParent : parentSectsMap.values()) {		
+			
+			// Does this parent sect have a paleo constraint?
+			int parentID = rupSet.getFaultSectionDataList().get(sectsForParent.get(0).getSectionId()).getParentSectionId();
+			
+			// weight for this parent section depending whether it has paleo constraint or not
+			double constraintWeight = weight;
+			if (paleoParentIDs != null && paleoParentIDs.contains(parentID))
+				constraintWeight = weightForPaleoParents;
+			
+			if (constraintWeight==0)
+				continue;
+			
+			// Laplacian smoothing of event rates: r[i+1]-2*r[i]+r[i-1]=0 (minimize curvature of event rates)
+			// Don't need to worry about smoothing for subsection pairs at edges b/c they always share the same ruptures (no ruptures have only 1 subsection in a given parent section)
+			for (int j=1; j<sectsForParent.size()-2; j++) {
+				int sect1 = sectsForParent.get(j-1).getSectionId(); 
+				HashSet<Integer> sect1Hash = sectRupsHashes.get(sect1);
+				int sect2 = sectsForParent.get(j).getSectionId(); 
+				HashSet<Integer> sect2Hash = sectRupsHashes.get(sect2);
+				int sect3 = sectsForParent.get(j+1).getSectionId(); 
+				HashSet<Integer> sect3Hash = sectRupsHashes.get(sect3);
+				
+				List<Integer> sect1Rups = Lists.newArrayList();  
+				List<Integer> sect2Rups = Lists.newArrayList();
+				List<Integer> sect3Rups = Lists.newArrayList();
+				
+				// only rups that involve sect 1 but not in sect 2
+				for (Integer sect1Rup : sect1Hash)
+					if (!sect2Hash.contains(sect1Rup))
+						sect1Rups.add(sect1Rup);
+				// only rups that involve sect 2 but not sect 1, then add in rups that involve sect 2 but not sect 3
+				// Apparent double counting is OK, that is the factor of 2 in the center of the Laplacian
+				// Think of as: (r[i+1]-*r[i]) + (r[i-1]-r[i])=0 
+				for (Integer sect2Rup : sect2Hash)
+					if (!sect1Hash.contains(sect2Rup))
+						sect2Rups.add(sect2Rup); 
+				for (Integer sect2Rup : sect2Hash)
+					if (!sect3Hash.contains(sect2Rup))
+						sect2Rups.add(sect2Rup); 
+				// only rups that involve sect 3 but sect 2
+				for (Integer sect3Rup : sect3Hash) {
+					if (!sect2Hash.contains(sect3Rup))
+						sect3Rups.add(sect3Rup);
+				}
+				
+				// Get section MFD constraint -- we will use the irregular mag binning for the constraint (but not the rates)
+				SectionMFD_constraint sectMFDConstraint = constraints.get(sect2);
+				if (sectMFDConstraint == null)
+					continue; // Parent sections with Mmax<6 have no MFD constraint; skip these
+				int numMagBins = sectMFDConstraint.getNumMags();
+				// Loop over MFD constraints for this subsection
+				for (int magBin = 0; magBin<numMagBins; magBin++) {
+				
+					// Determine which ruptures are in this magBin
+					List<Integer> sect1RupsForMagBin = new ArrayList<Integer>();
+					for (int i=0; i<sect1Rups.size(); i++) {
+						double mag = rupSet.getMagForRup(sect1Rups.get(i));
+						if (sectMFDConstraint.isMagInBin(mag, magBin))
+							sect1RupsForMagBin.add(sect1Rups.get(i));
+					}
+					List<Integer> sect2RupsForMagBin = new ArrayList<Integer>();
+					for (int i=0; i<sect2Rups.size(); i++) {
+						double mag = rupSet.getMagForRup(sect2Rups.get(i));
+						if (sectMFDConstraint.isMagInBin(mag, magBin))
+							sect2RupsForMagBin.add(sect2Rups.get(i));
+					}
+					List<Integer> sect3RupsForMagBin = new ArrayList<Integer>();
+					for (int i=0; i<sect3Rups.size(); i++) {
+						double mag = rupSet.getMagForRup(sect3Rups.get(i));
+						if (sectMFDConstraint.isMagInBin(mag, magBin))
+							sect3RupsForMagBin.add(sect3Rups.get(i));
+					}
+					
+					// Loop over ruptures in this subsection-MFD bin
+					for (int rup: sect1RupsForMagBin) { 
+						setA(A, rowIndex, rup, constraintWeight);
+						numNonZeroElements++;
+					}
+					for (int rup: sect2RupsForMagBin) {
+						setA(A, rowIndex, rup, -constraintWeight);
+						numNonZeroElements++;
+					}
+					for (int rup: sect3RupsForMagBin) {
+						setA(A, rowIndex, rup, constraintWeight);
+						numNonZeroElements++;
+					}
+					d[rowIndex]=0;
+					rowIndex++;
+				}
+			}
+		}
+		return numNonZeroElements;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDParticipationSmoothnessInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDParticipationSmoothnessInversionConstraint.java
@@ -1,0 +1,135 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
+
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+import scratch.UCERF3.FaultSystemRupSet;
+
+public class MFDParticipationSmoothnessInversionConstraint extends InversionConstraint {
+	
+	private FaultSystemRupSet rupSet;
+	private double weight;
+	private double particMagBinSize;
+
+	public MFDParticipationSmoothnessInversionConstraint(FaultSystemRupSet rupSet, double weight,
+			double particMagBinSize) {
+		this.rupSet = rupSet;
+		this.weight = weight;
+		this.particMagBinSize = particMagBinSize;
+	}
+
+	@Override
+	public String getShortName() {
+		return "MFDParticSmooth";
+	}
+
+	@Override
+	public String getName() {
+		return "MFD Participation Smoothness";
+	}
+
+	@Override
+	public int getNumRows() {
+		int totalNumMagParticipationConstraints = 0;
+		int numSections = rupSet.getNumSections();
+		for (int sect=0; sect<numSections; sect++) { 
+			List<Integer> rupturesForSection = rupSet.getRupturesForSection(sect);
+			// Find minimum and maximum rupture-magnitudes for that subsection
+			double minMag = Double.POSITIVE_INFINITY; double maxMag = Double.NEGATIVE_INFINITY;
+			for (int rupIndex=0; rupIndex<rupturesForSection.size(); rupIndex++) {
+				double mag = rupSet.getMagForRup(rupIndex);
+				minMag = Math.min(minMag, mag);
+				maxMag = Math.max(maxMag, mag);
+			}
+			if (!Double.isFinite(minMag)) {
+				continue;  // Skip this section, go on to next section constraint
+			}
+			// Find total number of section magnitude-bins
+			for (double m=minMag; m<maxMag; m=m+particMagBinSize) { 
+				for (int rupIndex=0; rupIndex<rupturesForSection.size(); rupIndex++) {
+					double mag = rupSet.getMagForRup(rupIndex);
+					if (mag >=m && mag < m+particMagBinSize) {
+						totalNumMagParticipationConstraints++;
+						break;
+					}				
+				}
+			}
+		}
+		return totalNumMagParticipationConstraints;
+	}
+
+	@Override
+	public boolean isInequality() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public long encode(DoubleMatrix2D A, double[] d, int startRow) {
+		long numNonZeroElements = 0;
+		int numSections = rupSet.getNumSections();
+		List<Integer> numRupsForMagBin = new ArrayList<>();
+		int rowIndex = startRow;
+		for (int sect=0; sect<numSections; sect++) {
+			List<Integer> rupturesForSection = rupSet.getRupturesForSection(sect);
+			
+			// Find minimum and maximum rupture-magnitudes for that subsection
+			double minMag = Double.POSITIVE_INFINITY; double maxMag = Double.NEGATIVE_INFINITY;
+			for (int rupIndex=0; rupIndex<rupturesForSection.size(); rupIndex++) {
+				double mag = rupSet.getMagForRup(rupIndex);
+				minMag = Math.min(minMag, mag);
+				maxMag = Math.max(maxMag, mag);
+			}
+			if (!Double.isFinite(minMag)) {
+				System.out.println("NO RUPTURES FOR SECTION #"+sect);  
+				continue;  // Skip this section, go on to next section constraint
+			}
+			
+			// Find number of ruptures for this section for each magnitude bin & total number
+			// of magnitude-bins with ruptures
+			numRupsForMagBin.clear();
+			int numNonzeroMagBins = 0;
+			for (double m=minMag; m<maxMag; m=m+particMagBinSize) {
+				numRupsForMagBin.add(0);
+				for (int rupIndex=0; rupIndex<rupturesForSection.size(); rupIndex++) {
+					double mag = rupSet.getMagForRup(rupIndex);
+					if (mag >=m && mag < m+particMagBinSize)
+						numRupsForMagBin.set(numRupsForMagBin.size()-1,
+								numRupsForMagBin.get(numRupsForMagBin.size()-1)+1); // numRupsForMagBin(end)++
+				}
+				if (numRupsForMagBin.get(numRupsForMagBin.size()-1) > 0)
+					numNonzeroMagBins++;
+			}
+			
+			// Put together A matrix elements: A_avg_rate_per_mag_bin * x - A_rate_for_particular_mag_bin * x = 0
+			// Each mag bin (that contains ruptures) for each subsection adds one row to A & d
+			int magBinIndex=0;
+			for (double m=minMag; m<maxMag; m=m+particMagBinSize) {
+				if (numRupsForMagBin.get(magBinIndex) > 0) {
+					for (int rupIndex=0; rupIndex<rupturesForSection.size(); rupIndex++) {
+						// Average rate per magnitude bin for this section
+						int col = rupturesForSection.get(rupIndex);
+						double val = weight/numNonzeroMagBins;	
+						numNonZeroElements++;
+						double mag = rupSet.getMagForRup(rupIndex);
+						if (mag >=m && mag < m+particMagBinSize) {
+							// Subtract off rate for this mag bin (difference between average rate per mag bin
+							// & rate for this mag bin is set to 0)
+							val -= weight;
+						}
+						setA(A, rowIndex, col, val);
+					}
+					d[rowIndex] = 0;
+					rowIndex++;
+				}	
+				magBinIndex++;				
+			}	
+			
+		}
+		return numNonZeroElements;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDParticipationSmoothnessInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDParticipationSmoothnessInversionConstraint.java
@@ -8,6 +8,14 @@ import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.Inversi
 import cern.colt.matrix.tdouble.DoubleMatrix2D;
 import scratch.UCERF3.FaultSystemRupSet;
 
+/**
+ * MFD Smoothness Constraint - Constrain participation MFD to be uniform for each fault subsection.
+ * 
+ * This was not ultimately used in UCERF3
+ * 
+ * @author Morgan Page & Kevin Milner
+ *
+ */
 public class MFDParticipationSmoothnessInversionConstraint extends InversionConstraint {
 	
 	private FaultSystemRupSet rupSet;
@@ -40,7 +48,7 @@ public class MFDParticipationSmoothnessInversionConstraint extends InversionCons
 			// Find minimum and maximum rupture-magnitudes for that subsection
 			double minMag = Double.POSITIVE_INFINITY; double maxMag = Double.NEGATIVE_INFINITY;
 			for (int rupIndex=0; rupIndex<rupturesForSection.size(); rupIndex++) {
-				double mag = rupSet.getMagForRup(rupIndex);
+				double mag = rupSet.getMagForRup(rupturesForSection.get(rupIndex));
 				minMag = Math.min(minMag, mag);
 				maxMag = Math.max(maxMag, mag);
 			}
@@ -50,7 +58,7 @@ public class MFDParticipationSmoothnessInversionConstraint extends InversionCons
 			// Find total number of section magnitude-bins
 			for (double m=minMag; m<maxMag; m=m+particMagBinSize) { 
 				for (int rupIndex=0; rupIndex<rupturesForSection.size(); rupIndex++) {
-					double mag = rupSet.getMagForRup(rupIndex);
+					double mag = rupSet.getMagForRup(rupturesForSection.get(rupIndex));
 					if (mag >=m && mag < m+particMagBinSize) {
 						totalNumMagParticipationConstraints++;
 						break;
@@ -63,7 +71,6 @@ public class MFDParticipationSmoothnessInversionConstraint extends InversionCons
 
 	@Override
 	public boolean isInequality() {
-		// TODO Auto-generated method stub
 		return false;
 	}
 
@@ -79,7 +86,7 @@ public class MFDParticipationSmoothnessInversionConstraint extends InversionCons
 			// Find minimum and maximum rupture-magnitudes for that subsection
 			double minMag = Double.POSITIVE_INFINITY; double maxMag = Double.NEGATIVE_INFINITY;
 			for (int rupIndex=0; rupIndex<rupturesForSection.size(); rupIndex++) {
-				double mag = rupSet.getMagForRup(rupIndex);
+				double mag = rupSet.getMagForRup(rupturesForSection.get(rupIndex));
 				minMag = Math.min(minMag, mag);
 				maxMag = Math.max(maxMag, mag);
 			}
@@ -95,7 +102,7 @@ public class MFDParticipationSmoothnessInversionConstraint extends InversionCons
 			for (double m=minMag; m<maxMag; m=m+particMagBinSize) {
 				numRupsForMagBin.add(0);
 				for (int rupIndex=0; rupIndex<rupturesForSection.size(); rupIndex++) {
-					double mag = rupSet.getMagForRup(rupIndex);
+					double mag = rupSet.getMagForRup(rupturesForSection.get(rupIndex));
 					if (mag >=m && mag < m+particMagBinSize)
 						numRupsForMagBin.set(numRupsForMagBin.size()-1,
 								numRupsForMagBin.get(numRupsForMagBin.size()-1)+1); // numRupsForMagBin(end)++
@@ -114,7 +121,7 @@ public class MFDParticipationSmoothnessInversionConstraint extends InversionCons
 						int col = rupturesForSection.get(rupIndex);
 						double val = weight/numNonzeroMagBins;	
 						numNonZeroElements++;
-						double mag = rupSet.getMagForRup(rupIndex);
+						double mag = rupSet.getMagForRup(col);
 						if (mag >=m && mag < m+particMagBinSize) {
 							// Subtract off rate for this mag bin (difference between average rate per mag bin
 							// & rate for this mag bin is set to 0)

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDSubSectNuclInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDSubSectNuclInversionConstraint.java
@@ -1,0 +1,95 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
+
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+import scratch.UCERF3.FaultSystemRupSet;
+import scratch.UCERF3.utils.SectionMFD_constraint;
+
+public class MFDSubSectNuclInversionConstraint extends InversionConstraint {
+	
+	public static final String NAME = "MFD Subsection Nucleation";
+	public static final String SHORT_NAME = "MFDSubSectNucl";
+	
+	private FaultSystemRupSet rupSet;
+	private double weight;
+	private List<SectionMFD_constraint> constraints;
+
+	public MFDSubSectNuclInversionConstraint(FaultSystemRupSet rupSet, double weight,
+			List<SectionMFD_constraint> constraints) {
+		this.rupSet = rupSet;
+		this.weight = weight;
+		this.constraints = constraints;
+	}
+
+	@Override
+	public String getShortName() {
+		return "MFDSubSectNucl";
+	}
+
+	@Override
+	public String getName() {
+		return "MFD Subsection Nucleation";
+	}
+
+	@Override
+	public int getNumRows() {
+		int numRows = 0;
+		for (SectionMFD_constraint constraint : constraints)
+			if (constraint != null)
+				numRows += constraint.getNumMags();
+		return numRows;
+	}
+
+	@Override
+	public boolean isInequality() {
+		return false;
+	}
+
+	@Override
+	public long encode(DoubleMatrix2D A, double[] d, int startRow) {
+		long numNonZeroElements = 0;
+		
+		// Loop over all subsections
+		int numSections = rupSet.getNumSections();
+		int rowIndex = startRow;
+		for (int sect=0; sect<numSections; sect++) {
+			
+			SectionMFD_constraint sectMFDConstraint = constraints.get(sect);
+			if (sectMFDConstraint == null) continue; // Parent sections with Mmax<6 have no MFD constraint; skip these
+			int numMagBins = sectMFDConstraint.getNumMags();
+			List<Integer> rupturesForSect = rupSet.getRupturesForSection(sect);
+			
+			// Loop over MFD constraints for this subsection
+			for (int magBin = 0; magBin<numMagBins; magBin++) {
+				
+				// Only include non-empty magBins in constraint
+				if (sectMFDConstraint.getRate(magBin) > 0) {
+					// Determine which ruptures are in this magBin
+					List<Integer> rupturesForMagBin = new ArrayList<Integer>();
+					for (int i=0; i<rupturesForSect.size(); i++) {
+						double mag = rupSet.getMagForRup(rupturesForSect.get(i));
+						if (sectMFDConstraint.isMagInBin(mag, magBin))
+							rupturesForMagBin.add(rupturesForSect.get(i));
+					}
+					
+					// Loop over ruptures in this subsection-MFD bin
+					for (int i=0; i<rupturesForMagBin.size(); i++) {
+						int rup  = rupturesForMagBin.get(i);
+						double rupArea = rupSet.getAreaForRup(rup);
+						double sectArea = rupSet.getAreaForSection(sect);
+						setA(A, rowIndex, rup, weight * (sectArea / rupArea) / sectMFDConstraint.getRate(magBin));
+						numNonZeroElements++;	
+					}
+					d[rowIndex] = weight;
+					rowIndex++;
+				}
+			}
+		}
+		return numNonZeroElements;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDSubSectNuclInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDSubSectNuclInversionConstraint.java
@@ -9,6 +9,14 @@ import cern.colt.matrix.tdouble.DoubleMatrix2D;
 import scratch.UCERF3.FaultSystemRupSet;
 import scratch.UCERF3.utils.SectionMFD_constraint;
 
+/**
+ * MFD Subsection nucleation MFD constraint - constraints MFDs to conform to
+ * an a priori section MFD. In UCERF3, we weekly constrained section MFDs to match
+ * UCERF2.
+ * 
+ * @author Morgan Page & Kevin Milner
+ *
+ */
 public class MFDSubSectNuclInversionConstraint extends InversionConstraint {
 	
 	public static final String NAME = "MFD Subsection Nucleation";
@@ -40,7 +48,9 @@ public class MFDSubSectNuclInversionConstraint extends InversionConstraint {
 		int numRows = 0;
 		for (SectionMFD_constraint constraint : constraints)
 			if (constraint != null)
-				numRows += constraint.getNumMags();
+				for (int i=0; i<constraint.getNumMags(); i++)
+					if (constraint.getRate(i) > 0)
+						numRows++;
 		return numRows;
 	}
 

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/PaleoRateInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/PaleoRateInversionConstraint.java
@@ -1,0 +1,70 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl;
+
+import java.util.List;
+
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
+
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+import scratch.UCERF3.FaultSystemRupSet;
+import scratch.UCERF3.utils.paleoRateConstraints.PaleoProbabilityModel;
+import scratch.UCERF3.utils.paleoRateConstraints.PaleoRateConstraint;
+
+public class PaleoRateInversionConstraint extends InversionConstraint {
+	
+	public static final String NAME = "Paleoseismic Event Rate";
+	public static final String SHORT_NAME = "PaleoRate";
+	
+	private FaultSystemRupSet rupSet;
+	private double weight;
+	private List<PaleoRateConstraint> paleoRateConstraints;
+	private PaleoProbabilityModel paleoProbModel;
+
+	public PaleoRateInversionConstraint(FaultSystemRupSet rupSet, double weight,
+			List<PaleoRateConstraint> paleoRateConstraints, PaleoProbabilityModel paleoProbModel) {
+		this.rupSet = rupSet;
+		this.weight = weight;
+		this.paleoRateConstraints = paleoRateConstraints;
+		this.paleoProbModel = paleoProbModel;
+	}
+
+	@Override
+	public String getShortName() {
+		return SHORT_NAME;
+	}
+
+	@Override
+	public String getName() {
+		return NAME;
+	}
+
+	@Override
+	public int getNumRows() {
+		// one for each constraint
+		return paleoRateConstraints.size();
+	}
+
+	@Override
+	public boolean isInequality() {
+		return false;
+	}
+
+	@Override
+	public long encode(DoubleMatrix2D A, double[] d, int startRow) {
+		long numNonZeroElements = 0;
+		for (int i=0; i<paleoRateConstraints.size(); i++) {
+			PaleoRateConstraint constraint = paleoRateConstraints.get(i);
+			int row = startRow + i;
+			d[row] = weight * constraint.getMeanRate() / constraint.getStdDevOfMeanRate();
+			List<Integer> rupsForSect = rupSet.getRupturesForSection(constraint.getSectionIndex());
+			for (int rupIndex=0; rupIndex<rupsForSect.size(); rupIndex++) {
+				int rup = rupsForSect.get(rupIndex);
+				double probPaleoVisible = paleoProbModel.getProbPaleoVisible(
+						rupSet, rup, constraint.getSectionIndex());	
+				setA(A, row, rup, weight * probPaleoVisible / constraint.getStdDevOfMeanRate());
+				numNonZeroElements++;			
+			}
+		}
+		return numNonZeroElements;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/PaleoRateInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/PaleoRateInversionConstraint.java
@@ -9,6 +9,13 @@ import scratch.UCERF3.FaultSystemRupSet;
 import scratch.UCERF3.utils.paleoRateConstraints.PaleoProbabilityModel;
 import scratch.UCERF3.utils.paleoRateConstraints.PaleoRateConstraint;
 
+/**
+ * Constraint to match paleoseismic event rates at subsections, also taking into account
+ * the probability of a rupture being seen at a paleoseismic trench site.
+ * 
+ * @author Morgan Page & Kevin Milner
+ *
+ */
 public class PaleoRateInversionConstraint extends InversionConstraint {
 	
 	public static final String NAME = "Paleoseismic Event Rate";

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/PaleoSlipInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/PaleoSlipInversionConstraint.java
@@ -1,0 +1,77 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl;
+
+import java.util.List;
+
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
+
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+import scratch.UCERF3.FaultSystemRupSet;
+import scratch.UCERF3.SlipEnabledRupSet;
+import scratch.UCERF3.utils.aveSlip.AveSlipConstraint;
+
+public class PaleoSlipInversionConstraint extends InversionConstraint {
+	
+	public static final String NAME = "Paleoseismic Average Slip";
+	public static final String SHORT_NAME = "PaleoSlip";
+	
+	private SlipEnabledRupSet rupSet;
+	private double weight;
+	private List<AveSlipConstraint> constraints;
+	private double[] targetSlipRates;
+
+	public PaleoSlipInversionConstraint(SlipEnabledRupSet rupSet, double weight,
+			List<AveSlipConstraint> constraints, double[] targetSlipRates) {
+		this.rupSet = rupSet;
+		this.weight = weight;
+		this.constraints = constraints;
+		this.targetSlipRates = targetSlipRates;
+	}
+
+	@Override
+	public String getShortName() {
+		return SHORT_NAME;
+	}
+
+	@Override
+	public String getName() {
+		return NAME;
+	}
+
+	@Override
+	public int getNumRows() {
+		return constraints.size();
+	}
+
+	@Override
+	public boolean isInequality() {
+		return false;
+	}
+
+	@Override
+	public long encode(DoubleMatrix2D A, double[] d, int startRow) {
+		long numNonZeroElements = 0;
+		for (int i=0; i<constraints.size(); i++) {
+			AveSlipConstraint constraint = constraints.get(i);
+			int subsectionIndex = constraint.getSubSectionIndex();
+			double meanRate = targetSlipRates[subsectionIndex] / constraint.getWeightedMean();
+			double lowRateBound = targetSlipRates[subsectionIndex] / constraint.getUpperUncertaintyBound();
+			double highRateBound = targetSlipRates[subsectionIndex] / constraint.getLowerUncertaintyBound();
+			double constraintError = highRateBound - lowRateBound;
+			
+			int row = startRow+i;
+			
+			d[row] = weight * meanRate / constraintError;
+			List<Integer> rupsForSect = rupSet.getRupturesForSection(subsectionIndex);
+			for (int rupIndex=0; rupIndex<rupsForSect.size(); rupIndex++) {
+				int rup = rupsForSect.get(rupIndex);
+				int sectIndexInRup = rupSet.getSectionsIndicesForRup(rup).indexOf(subsectionIndex);
+				double slipOnSect = rupSet.getSlipOnSectionsForRup(rup)[sectIndexInRup]; 
+				double probVisible = AveSlipConstraint.getProbabilityOfObservedSlip(slipOnSect);
+				setA(A, row, rup, weight * probVisible / constraintError);
+				numNonZeroElements++;
+			}
+		}
+		return numNonZeroElements;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/PaleoSlipInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/PaleoSlipInversionConstraint.java
@@ -9,6 +9,13 @@ import scratch.UCERF3.FaultSystemRupSet;
 import scratch.UCERF3.SlipEnabledRupSet;
 import scratch.UCERF3.utils.aveSlip.AveSlipConstraint;
 
+/**
+ * Constraint to match paleoseismic event rates inferred from mean slip on
+ * subsections.
+ * 
+ * @author Morgan Page & Kevin Milner
+ *
+ */
 public class PaleoSlipInversionConstraint extends InversionConstraint {
 	
 	public static final String NAME = "Paleoseismic Average Slip";

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/PaleoVisibleEventRateSmoothnessInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/PaleoVisibleEventRateSmoothnessInversionConstraint.java
@@ -1,0 +1,113 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
+import org.opensha.sha.faultSurface.FaultSection;
+
+import com.google.common.collect.Lists;
+
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+import scratch.UCERF3.FaultSystemRupSet;
+import scratch.UCERF3.utils.paleoRateConstraints.PaleoProbabilityModel;
+
+public class PaleoVisibleEventRateSmoothnessInversionConstraint extends InversionConstraint {
+	
+	private FaultSystemRupSet rupSet;
+	private double weight;
+	private PaleoProbabilityModel paleoProbabilityModel;
+
+	public PaleoVisibleEventRateSmoothnessInversionConstraint(FaultSystemRupSet rupSet, double weight,
+			PaleoProbabilityModel paleoProbabilityModel) {
+		this.rupSet = rupSet;
+		this.weight = weight;
+		this.paleoProbabilityModel = paleoProbabilityModel;
+	}
+
+	@Override
+	public String getShortName() {
+		return "PaleoRateSmooth";
+	}
+
+	@Override
+	public String getName() {
+		return "Paleo-Visible Event Rate Smoothness";
+	}
+
+	@Override
+	public int getNumRows() {
+		HashSet<Integer> parentIDs = new HashSet<Integer>();
+		for (FaultSection sect : rupSet.getFaultSectionDataList()) {
+			int parentID = sect.getParentSectionId();
+			parentIDs.add(parentID);
+		}
+		int numParentSections=parentIDs.size();
+		// one constraint for each section, except minus 1 section on each parent
+		return rupSet.getNumSections()-numParentSections;
+	}
+
+	@Override
+	public boolean isInequality() {
+		return false;
+	}
+
+	@Override
+	public long encode(DoubleMatrix2D A, double[] d, int startRow) {
+		long numNonZeroElements = 0;
+		
+		// Get list of parent IDs
+		List<Integer> parentIDs = new ArrayList<Integer>();
+		for (FaultSection sect : rupSet.getFaultSectionDataList()) {
+			int parentID = sect.getParentSectionId();
+			if (!parentIDs.contains(parentID))
+				parentIDs.add(parentID);
+		}
+		
+		int rowIndex = startRow;
+
+		for (int parentID: parentIDs) {
+			// Find subsection IDs for given parent section
+			List<Integer> sectsForParent = new ArrayList<Integer>();
+			for (FaultSection sect : rupSet.getFaultSectionDataList()) {
+				int sectParentID = sect.getParentSectionId();
+				if (sectParentID == parentID)
+					sectsForParent.add(sect.getSectionId());
+			}
+			
+			// Constrain the event rate of each neighboring subsection pair (with same parent section) to be approximately equal
+			for (int j=0; j<sectsForParent.size()-1; j++) {
+				int sect1 = sectsForParent.get(j);
+				int sect2 = sectsForParent.get(j+1);
+				List<Integer> sect1Rups = Lists.newArrayList(rupSet.getRupturesForSection(sect1));  
+				List<Integer> sect2Rups = Lists.newArrayList(rupSet.getRupturesForSection(sect2));
+				
+				HashSet<Integer> prevRups = new HashSet<>();
+				
+				for (int rup: sect1Rups) { 
+					if (prevRups.contains(rup))
+						continue;
+					double probPaleoVisible = paleoProbabilityModel.getProbPaleoVisible(rupSet, rup, sect1);	
+					setA(A, rowIndex, rup, probPaleoVisible*weight);
+					if (probPaleoVisible > 0)
+						numNonZeroElements++;
+					prevRups.add(rup);
+				}
+				for (int rup: sect2Rups) {
+					if (prevRups.contains(rup))
+						continue;
+					double probPaleoVisible = paleoProbabilityModel.getProbPaleoVisible(rupSet, rup, sect2);
+					setA(A, rowIndex, rup, -probPaleoVisible*weight);
+					if (probPaleoVisible > 0)
+						numNonZeroElements++;
+					prevRups.add(rup);
+				}
+				d[rowIndex] = 0;
+				rowIndex++;
+			}
+		}
+		return numNonZeroElements;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/ParkfieldInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/ParkfieldInversionConstraint.java
@@ -1,0 +1,57 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl;
+
+import java.util.List;
+
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
+
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+
+public class ParkfieldInversionConstraint extends InversionConstraint {
+	
+	public static final String NAME = "Parkfield";
+	public static final String SHORT_NAME = "Parkfield";
+	
+	private double weight;
+	private double targetRate;
+	private List<Integer> parkfieldRups;
+
+	public ParkfieldInversionConstraint(double weight, double targetRate,
+			List<Integer> parkfieldRups) {
+		this.weight = weight;
+		this.targetRate = targetRate;
+		this.parkfieldRups = parkfieldRups;
+	}
+
+	@Override
+	public String getShortName() {
+		return SHORT_NAME;
+	}
+
+	@Override
+	public String getName() {
+		return NAME;
+	}
+
+	@Override
+	public int getNumRows() {
+		return 1;
+	}
+
+	@Override
+	public boolean isInequality() {
+		return false;
+	}
+
+	@Override
+	public long encode(DoubleMatrix2D A, double[] d, int startRow) {
+		long numNonZeroElements = 0;
+		for (int r=0; r<parkfieldRups.size(); r++)  {
+			int rup = parkfieldRups.get(r);
+			setA(A, startRow, rup, weight);
+			numNonZeroElements++;
+		}
+		d[startRow] = weight * targetRate;
+		return numNonZeroElements;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/ParkfieldInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/ParkfieldInversionConstraint.java
@@ -6,6 +6,14 @@ import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.Inversi
 
 import cern.colt.matrix.tdouble.DoubleMatrix2D;
 
+/**
+ * Constrains the summed rate across a set of ruptures to equal a given total rate.
+ * We used this in UCERF3 to constrain Parkfield M6's to have a 25 year recurrence interval,
+ * but it could be applied elsewhere as well.
+ * 
+ * @author Morgan Page & Kevin Milner
+ *
+ */
 public class ParkfieldInversionConstraint extends InversionConstraint {
 	
 	public static final String NAME = "Parkfield";

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/RupRateMinimizationConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/RupRateMinimizationConstraint.java
@@ -1,0 +1,52 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl;
+
+import java.util.List;
+
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
+
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+
+public class RupRateMinimizationConstraint extends InversionConstraint {
+	
+	private double weight;
+	private List<Integer> rupIndexes;
+
+	public RupRateMinimizationConstraint(double weight, List<Integer> rupIndexes) {
+		this.weight = weight;
+		this.rupIndexes = rupIndexes;
+	}
+
+	@Override
+	public String getShortName() {
+		return "RateMinimize";
+	}
+
+	@Override
+	public String getName() {
+		return "Rupture Rate Minimization";
+	}
+
+	@Override
+	public int getNumRows() {
+		return rupIndexes.size();
+	}
+
+	@Override
+	public boolean isInequality() {
+		return false;
+	}
+
+	@Override
+	public long encode(DoubleMatrix2D A, double[] d, int startRow) {
+		long numNonZeroElements = 0;
+		int rowIndex = startRow;
+		for (int rupIndex : rupIndexes) {
+			setA(A, rowIndex, rupIndex, weight);
+			d[rowIndex] = 0;
+			numNonZeroElements++;
+			rowIndex++;
+		}
+		return numNonZeroElements;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/RupRateMinimizationConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/RupRateMinimizationConstraint.java
@@ -6,6 +6,13 @@ import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.Inversi
 
 import cern.colt.matrix.tdouble.DoubleMatrix2D;
 
+/**
+ * This allows you to strongly minimize the rate of certain ruptures. We used this
+ * in UCERF3 to zero out rates for ruptures which were below the section minimum magnitude
+ * 
+ * @author Morgan Page & Kevin Milner
+ *
+ */
 public class RupRateMinimizationConstraint extends InversionConstraint {
 	
 	private double weight;

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/RupRateSmoothingInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/RupRateSmoothingInversionConstraint.java
@@ -13,6 +13,14 @@ import org.opensha.sha.faultSurface.FaultSection;
 import cern.colt.matrix.tdouble.DoubleMatrix2D;
 import scratch.UCERF3.FaultSystemRupSet;
 
+/**
+ * This constrains rates of ruptures that differ by only 1 subsection to be smooth.
+ * 
+ * We did not ultimately use this in UCERF3.
+ * 
+ * @author Morgan Page & Kevin Milner
+ *
+ */
 public class RupRateSmoothingInversionConstraint extends InversionConstraint {
 	
 	private double weight;

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/RupRateSmoothingInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/RupRateSmoothingInversionConstraint.java
@@ -1,0 +1,117 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.opensha.commons.util.IDPairing;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
+import org.opensha.sha.faultSurface.FaultSection;
+
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+import scratch.UCERF3.FaultSystemRupSet;
+
+public class RupRateSmoothingInversionConstraint extends InversionConstraint {
+	
+	private double weight;
+	private List<IDPairing> smoothingConstraintRupPairings;
+
+	public RupRateSmoothingInversionConstraint(double weight, FaultSystemRupSet rupSet) {
+		this(weight, getRupSmoothingPairings(rupSet));
+	}
+	
+	public RupRateSmoothingInversionConstraint(double weight, List<IDPairing> smoothingConstraintRupPairings) {
+		this.weight = weight;
+		this.smoothingConstraintRupPairings = smoothingConstraintRupPairings;
+	}
+
+	@Override
+	public String getShortName() {
+		return "RupRateSmooth";
+	}
+
+	@Override
+	public String getName() {
+		return "Rup Rate Smoothing";
+	}
+
+	@Override
+	public int getNumRows() {
+		return smoothingConstraintRupPairings.size();
+	}
+
+	@Override
+	public boolean isInequality() {
+		return false;
+	}
+
+	@Override
+	public long encode(DoubleMatrix2D A, double[] d, int startRow) {
+		long numNonZeroElements = 0;
+		for (int i=0; i<smoothingConstraintRupPairings.size(); i++) {
+			int rowIndex = startRow + i;
+			IDPairing rupPairings = smoothingConstraintRupPairings.get(i);
+			setA(A, rowIndex, rupPairings.getID1(), weight);
+			setA(A, rowIndex, rupPairings.getID2(), -weight);
+			d[rowIndex]=0;
+			numNonZeroElements += 2;
+		}
+		return numNonZeroElements;
+	}
+	
+	public static List<IDPairing> getRupSmoothingPairings(FaultSystemRupSet rupSet) {
+		List<IDPairing> pairings = new ArrayList<>();
+		int numRuptures = rupSet.getNumRuptures();
+		// This is a list of each rupture as a HashSet for quick contains(...) operations
+		List<HashSet<Integer>> rupHashList = new ArrayList<>();
+		// This is a list of the parent sections for each rupture as a HashSet
+		List<HashSet<Integer>> rupParentsHashList = new ArrayList<>();
+		// This is a mapping from each unique set of parent sections, to the ruptures which involve all/only those parent sections
+		Map<HashSet<Integer>, List<Integer>> parentsToRupsMap = new HashMap<>();
+		for (int r=0; r<numRuptures; r++) {
+			// create the hashSet for the rupture
+			rupHashList.add(new HashSet<Integer>(rupSet.getSectionsIndicesForRup(r)));
+			// build the hashSet of parents
+			HashSet<Integer> parentIDs = new HashSet<Integer>();
+			for (FaultSection sect : rupSet.getFaultSectionDataForRupture(r))
+				parentIDs.add(sect.getParentSectionId());	// this won't have duplicates since it's a hash set
+			rupParentsHashList.add(parentIDs);
+			// now add this rupture to the list of ruptures that involve this set of parents
+			List<Integer> rupsForParents = parentsToRupsMap.get(parentIDs);
+			if (rupsForParents == null) {
+				rupsForParents = new ArrayList<>();
+				parentsToRupsMap.put(parentIDs, rupsForParents);
+			}
+			rupsForParents.add(r);
+		}
+//		if (D) System.out.println("Rupture rate smoothing constraint: "+parentsToRupsMap.size()+" unique parent set combinations");
+
+		// Find set of rupture pairs for smoothing
+		for(int rup1=0; rup1<numRuptures; rup1++) {
+			List<Integer> sects = rupSet.getSectionsIndicesForRup(rup1);
+			HashSet<Integer> rup1Parents = rupParentsHashList.get(rup1);
+			ruptureLoop:
+				for(Integer rup2 : parentsToRupsMap.get(rup1Parents)) { // We only loop over ruptures that involve the same set of parents
+					// Only keep pair if rup1 < rup2 (don't need to include pair in each direction)
+					if (rup2 <= rup1) // Only keep pair if rup1 < rup2 (don't need to include pair in each direction)
+						continue;
+					HashSet<Integer> sects2 = rupHashList.get(rup2);
+					// Check that ruptures are same size
+					if (sects.size() != sects2.size()) continue ruptureLoop;
+					// Check that ruptures differ by at most one subsection
+					int numSectsDifferent = 0;
+					for(int i=0; i<sects.size(); i++) {
+						if (!sects2.contains(sects.get(i))) numSectsDifferent++;
+						if (numSectsDifferent > 1) continue ruptureLoop;
+					}
+					// The pair passes!
+					pairings.add(new IDPairing(rup1, rup2));
+				}
+		}
+		
+		return pairings;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/SlipRateInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/SlipRateInversionConstraint.java
@@ -8,6 +8,22 @@ import cern.colt.matrix.tdouble.DoubleMatrix2D;
 import scratch.UCERF3.SlipEnabledRupSet;
 import scratch.UCERF3.inversion.UCERF3InversionConfiguration.SlipRateConstraintWeightingType;
 
+/**
+ * Constraints section slip rates to match the given target rate. It can apply normalized or
+ * unnormalized constraints, or both:
+ * 
+ * If normalized, slip rate misfit is % difference for each section (recommended since it helps
+ * fit slow-moving faults). Note that constraints for sections w/ slip rate < 0.1 mm/yr is not
+ * normalized by slip rate -- otherwise misfit will be huge (GEOBOUND model has 10e-13 slip rates
+ * that will dominate misfit otherwise)
+ * 
+ * If unnormalized, misfit is absolute difference.
+ * 
+ * Set the weighting with the SlipRateConstraintWeightingType enum.
+ * 
+ * @author kevin
+ *
+ */
 public class SlipRateInversionConstraint extends InversionConstraint {
 	
 	public static final String NAME = "Slip Rate";

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/SlipRateInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/SlipRateInversionConstraint.java
@@ -1,0 +1,123 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl;
+
+import java.util.List;
+
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
+
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+import scratch.UCERF3.SlipEnabledRupSet;
+import scratch.UCERF3.inversion.UCERF3InversionConfiguration.SlipRateConstraintWeightingType;
+
+public class SlipRateInversionConstraint extends InversionConstraint {
+	
+	public static final String NAME = "Slip Rate";
+	public static final String SHORT_NAME = "SlipRate";
+	
+	private double weightNormalized;
+	private double weightUnnormalized;
+	private SlipRateConstraintWeightingType weightingType;
+	private SlipEnabledRupSet rupSet;
+	private double[] targetSlipRates;
+
+	public SlipRateInversionConstraint(double weightNormalized, double weightUnnormalized,
+			SlipRateConstraintWeightingType weightingType, SlipEnabledRupSet rupSet,
+			double[] targetSlipRates) {
+		this.weightNormalized = weightNormalized;
+		this.weightUnnormalized = weightUnnormalized;
+		this.weightingType = weightingType;
+		this.rupSet = rupSet;
+		this.targetSlipRates = targetSlipRates;
+	}
+
+	@Override
+	public String getShortName() {
+		return SHORT_NAME;
+	}
+
+	@Override
+	public String getName() {
+		return NAME;
+	}
+
+	@Override
+	public int getNumRows() {
+		if (weightingType == SlipRateConstraintWeightingType.BOTH)
+			// one row for each section and for each weight type
+			return 2*rupSet.getNumSections();
+		// one row for each section
+		return rupSet.getNumSections();
+	}
+
+	@Override
+	public boolean isInequality() {
+		return false;
+	}
+
+	@Override
+	public long encode(DoubleMatrix2D A, double[] d, int startRow) {
+		long numNonZeroElements = 0;
+		int numRuptures = rupSet.getNumRuptures();
+		int numSections = rupSet.getNumSections();
+		// A matrix component of slip-rate constraint 
+		for (int rup=0; rup<numRuptures; rup++) {
+			double[] slips = rupSet.getSlipOnSectionsForRup(rup);
+			List<Integer> sects = rupSet.getSectionsIndicesForRup(rup);
+			for (int i=0; i < slips.length; i++) {
+				int row = sects.get(i);
+				int col = rup;
+				double val;
+				if (weightingType == SlipRateConstraintWeightingType.UNNORMALIZED
+						|| weightingType == SlipRateConstraintWeightingType.BOTH) {
+					setA(A, startRow+row, col, weightUnnormalized*slips[i]);
+					numNonZeroElements++;		
+				}
+				if (weightingType == SlipRateConstraintWeightingType.NORMALIZED_BY_SLIP_RATE
+						|| weightingType == SlipRateConstraintWeightingType.BOTH) {  
+					if (weightingType == SlipRateConstraintWeightingType.BOTH)
+						row += numSections;
+					// Note that constraints for sections w/ slip rate < 0.1 mm/yr is not normalized by slip rate
+					// -- otherwise misfit will be huge (GEOBOUND model has 10e-13 slip rates that will dominate
+					// misfit otherwise)
+					if (targetSlipRates[sects.get(i)] < 1E-4 || Double.isNaN(targetSlipRates[sects.get(i)]))  
+						val = slips[i]/0.0001;  
+					else {
+						val = slips[i]/targetSlipRates[sects.get(i)]; 
+					}
+					setA(A, startRow+row, col, weightNormalized*val);
+					numNonZeroElements++;
+				}
+			}
+		}  
+		// d vector component of slip-rate constraint
+		for (int sect=0; sect<numSections; sect++) {
+			if (Double.isNaN(targetSlipRates[sect])) {
+				// Treat NaN slip rates as 0 (minimize)
+				d[startRow+sect] = 0;
+				if (weightingType == SlipRateConstraintWeightingType.BOTH)
+					d[startRow+numSections+sect] = 0;
+			}
+			if (weightingType == SlipRateConstraintWeightingType.UNNORMALIZED
+					|| weightingType == SlipRateConstraintWeightingType.BOTH)
+				d[startRow+sect] = weightUnnormalized * targetSlipRates[sect];
+			if (weightingType == SlipRateConstraintWeightingType.NORMALIZED_BY_SLIP_RATE
+					|| weightingType == SlipRateConstraintWeightingType.BOTH) {
+				double val;
+				if (targetSlipRates[sect]<1E-4)
+					// For very small slip rates, do not normalize by slip rate
+					//  (normalize by 0.0001 instead) so they don't dominate misfit
+					val = weightNormalized * targetSlipRates[sect]/0.0001;
+				else  // Normalize by slip rate
+					val = weightNormalized;
+				if (weightingType == SlipRateConstraintWeightingType.BOTH)
+					d[startRow+numSections+sect] = val;
+				else
+					d[startRow+sect] = val;
+			}
+			if (Double.isNaN(d[sect]) || d[sect]<0)
+				throw new IllegalStateException("d["+sect+"] is NaN or 0!  sectSlipRateReduced["
+						+sect+"] = "+targetSlipRates[sect]);
+		}
+		return numNonZeroElements;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/TotalMomentInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/TotalMomentInversionConstraint.java
@@ -1,0 +1,54 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl;
+
+import org.opensha.commons.eq.MagUtils;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
+
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+import scratch.UCERF3.FaultSystemRupSet;
+
+public class TotalMomentInversionConstraint extends InversionConstraint {
+	
+	private FaultSystemRupSet rupSet;
+	private double weight;
+	private double totalMomentTarget;
+
+	public TotalMomentInversionConstraint(FaultSystemRupSet rupSet, double weight,
+			double totalMomentTarget) {
+		this.rupSet = rupSet;
+		this.weight = weight;
+		this.totalMomentTarget = totalMomentTarget;
+	}
+
+	@Override
+	public String getShortName() {
+		return "TotMoment";
+	}
+
+	@Override
+	public String getName() {
+		return "Total Moment";
+	}
+
+	@Override
+	public int getNumRows() {
+		return 1;
+	}
+
+	@Override
+	public boolean isInequality() {
+		return false;
+	}
+
+	@Override
+	public long encode(DoubleMatrix2D A, double[] d, int startRow) {
+		long numNonZeroElements = 0;
+		int numRuptures = rupSet.getNumRuptures();
+		for (int rup=0; rup<numRuptures; rup++)  {
+			setA(A, startRow, rup, weight * MagUtils.magToMoment(rupSet.getMagForRup(rup)));
+			numNonZeroElements++;
+		}
+		d[startRow] = weight * totalMomentTarget;
+		return numNonZeroElements;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/TotalMomentInversionConstraint.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/TotalMomentInversionConstraint.java
@@ -6,6 +6,12 @@ import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.Inversi
 import cern.colt.matrix.tdouble.DoubleMatrix2D;
 import scratch.UCERF3.FaultSystemRupSet;
 
+/**
+ * Constraint solution moment to equal deformation-model moment. We did not use this in UCERF3.
+ * 
+ * @author Morgan Page & Kevin Milner
+ *
+ */
 public class TotalMomentInversionConstraint extends InversionConstraint {
 	
 	private FaultSystemRupSet rupSet;

--- a/src/scratch/UCERF3/AverageFaultSystemSolution.java
+++ b/src/scratch/UCERF3/AverageFaultSystemSolution.java
@@ -31,7 +31,7 @@ import org.opensha.commons.util.threads.ThreadedTaskComputer;
 import org.opensha.sha.magdist.IncrementalMagFreqDist;
 
 import scratch.UCERF3.inversion.CommandLineInversionRunner;
-import scratch.UCERF3.inversion.InversionConfiguration;
+import scratch.UCERF3.inversion.UCERF3InversionConfiguration;
 import scratch.UCERF3.inversion.InversionFaultSystemRupSet;
 import scratch.UCERF3.inversion.InversionFaultSystemSolution;
 import scratch.UCERF3.utils.FaultSystemIO;
@@ -95,7 +95,7 @@ public class AverageFaultSystemSolution extends InversionFaultSystemSolution imp
 	}
 
 	public AverageFaultSystemSolution(InversionFaultSystemRupSet rupSet,
-			List<double[]> ratesList, InversionConfiguration config, Map<String, Double> energies) {
+			List<double[]> ratesList, UCERF3InversionConfiguration config, Map<String, Double> energies) {
 		this(rupSet, toArrays(ratesList), config, energies);
 	}
 	
@@ -104,7 +104,7 @@ public class AverageFaultSystemSolution extends InversionFaultSystemSolution imp
 	 * @param rates 2 dimensional array of rates ordered by rupture index [numRups][numSols]
 	 */
 	public AverageFaultSystemSolution(InversionFaultSystemRupSet rupSet,
-			double[][] rates, InversionConfiguration config, Map<String, Double> energies) {
+			double[][] rates, UCERF3InversionConfiguration config, Map<String, Double> energies) {
 		super(rupSet, getMeanRates(rates), config, energies);
 		
 		this.ratesByRup = rates;

--- a/src/scratch/UCERF3/analysis/DeformationModelsCalc.java
+++ b/src/scratch/UCERF3/analysis/DeformationModelsCalc.java
@@ -68,7 +68,7 @@ import scratch.UCERF3.enumTreeBranches.ScalingRelationships;
 import scratch.UCERF3.enumTreeBranches.SlipAlongRuptureModels;
 import scratch.UCERF3.enumTreeBranches.SpatialSeisPDF;
 import scratch.UCERF3.enumTreeBranches.TotalMag5Rate;
-import scratch.UCERF3.inversion.InversionConfiguration;
+import scratch.UCERF3.inversion.UCERF3InversionConfiguration;
 import scratch.UCERF3.inversion.InversionFaultSystemRupSetFactory;
 import scratch.UCERF3.utils.DeformationModelFetcher;
 import scratch.UCERF3.utils.DeformationModelFileParser;

--- a/src/scratch/UCERF3/analysis/FaultBasedMapGen.java
+++ b/src/scratch/UCERF3/analysis/FaultBasedMapGen.java
@@ -70,7 +70,7 @@ import scratch.UCERF3.enumTreeBranches.DeformationModels;
 import scratch.UCERF3.enumTreeBranches.FaultModels;
 import scratch.UCERF3.erf.FaultSystemSolutionERF;
 import scratch.UCERF3.erf.ETAS.ETAS_Utils;
-import scratch.UCERF3.inversion.InversionConfiguration;
+import scratch.UCERF3.inversion.UCERF3InversionConfiguration;
 import scratch.UCERF3.inversion.InversionFaultSystemSolution;
 import scratch.UCERF3.inversion.UCERF2_ComparisonSolutionFetcher;
 import scratch.UCERF3.utils.DeformationModelFileParser;

--- a/src/scratch/UCERF3/analysis/FaultSystemRupSetCalc.java
+++ b/src/scratch/UCERF3/analysis/FaultSystemRupSetCalc.java
@@ -53,7 +53,7 @@ import scratch.UCERF3.griddedSeismicity.GriddedSeisUtils;
 import scratch.UCERF3.inversion.InversionFaultSystemRupSet;
 import scratch.UCERF3.inversion.InversionFaultSystemRupSetFactory;
 import scratch.UCERF3.inversion.InversionFaultSystemSolution;
-import scratch.UCERF3.inversion.InversionInputGenerator;
+import scratch.UCERF3.inversion.UCERF3InversionInputGenerator;
 import scratch.UCERF3.inversion.InversionTargetMFDs;
 import scratch.UCERF3.inversion.UCERF2_ComparisonSolutionFetcher;
 import scratch.UCERF3.inversion.laughTest.UCERF3PlausibilityConfig;
@@ -1875,8 +1875,8 @@ public class FaultSystemRupSetCalc {
 		
 		// lets first compute the average magnitude for Parkfield events
 		double aveParkfieldMag=0;
-		List<Integer> parkRupIndexList = InversionInputGenerator.findParkfieldRups(fltSystRupSet);
-		for( int parkRupIndex: InversionInputGenerator.findParkfieldRups(fltSystRupSet)) {
+		List<Integer> parkRupIndexList = UCERF3InversionInputGenerator.findParkfieldRups(fltSystRupSet);
+		for( int parkRupIndex: UCERF3InversionInputGenerator.findParkfieldRups(fltSystRupSet)) {
 			aveParkfieldMag += fltSystRupSet.getMagForRup(parkRupIndex)/(double)parkRupIndexList.size();
 		}
 		if(D) System.out.println("aveParkfieldMag = "+aveParkfieldMag);
@@ -2244,7 +2244,7 @@ public class FaultSystemRupSetCalc {
 						InversionModels.CHAR_CONSTRAINED, scaleRel, SlipAlongRuptureModels.TAPERED, 
 						TotalMag5Rate.RATE_7p9, MaxMagOffFault.MAG_7p6, MomentRateFixes.NONE, SpatialSeisPDF.UCERF3);
 				
-				List<Integer> parkfileRupIndexList = InversionInputGenerator.findParkfieldRups(rupSet);
+				List<Integer> parkfileRupIndexList = UCERF3InversionInputGenerator.findParkfieldRups(rupSet);
 				
 				ArrayList<Integer> parkfileRupThatFallBelowMinMag = new ArrayList<Integer>();
 				
@@ -2301,7 +2301,7 @@ public class FaultSystemRupSetCalc {
 					InversionModels.CHAR_CONSTRAINED, scaleRel, SlipAlongRuptureModels.TAPERED, 
 					TotalMag5Rate.RATE_7p9, MaxMagOffFault.MAG_7p6, MomentRateFixes.NONE, SpatialSeisPDF.UCERF3);
 
-			List<Integer> parkfileRupIndexList = InversionInputGenerator.findParkfieldRups(rupSet);
+			List<Integer> parkfileRupIndexList = UCERF3InversionInputGenerator.findParkfieldRups(rupSet);
 			
 			for(int index:parkfileRupIndexList) {
 				info += "\t"+index+"\t"+(float)rupSet.getMagForRup(index)+"\t"+(float)rupSet.getAveSlipForRup(index)+

--- a/src/scratch/UCERF3/analysis/RupRateConvergenceGUI.java
+++ b/src/scratch/UCERF3/analysis/RupRateConvergenceGUI.java
@@ -38,7 +38,7 @@ import org.opensha.sha.faultSurface.FaultSection;
 
 import scratch.UCERF3.AverageFaultSystemSolution;
 import scratch.UCERF3.enumTreeBranches.FaultModels;
-import scratch.UCERF3.inversion.InversionConfiguration;
+import scratch.UCERF3.inversion.UCERF3InversionConfiguration;
 import scratch.UCERF3.utils.FaultSystemIO;
 import scratch.UCERF3.utils.UCERF3_DataUtils;
 import scratch.UCERF3.utils.FindEquivUCERF2_Ruptures.FindEquivUCERF2_FM2pt1_Ruptures;
@@ -317,7 +317,7 @@ public class RupRateConvergenceGUI extends JFrame implements ParameterChangeList
 			sdomNParam.setValue(sol.getNumSolutions());
 			sdomNParam.getEditor().refreshParamEditor();
 			
-			ArrayList<double[]> ucerf2_magsAndRates = InversionConfiguration.getUCERF2MagsAndrates(sol.getRupSet());
+			ArrayList<double[]> ucerf2_magsAndRates = UCERF3InversionConfiguration.getUCERF2MagsAndrates(sol.getRupSet());
 			
 			for (int r=0; r<numRups; r++) {
 				double mean = sol.getRateForRup(r);

--- a/src/scratch/UCERF3/erf/ETAS/ETAS_SimAnalysisTools.java
+++ b/src/scratch/UCERF3/erf/ETAS/ETAS_SimAnalysisTools.java
@@ -1856,7 +1856,6 @@ public class ETAS_SimAnalysisTools {
 
 	    NumberFormat format = NumberFormat.getInstance();
 
-	    StringBuilder sb = new StringBuilder();
 	    long maxMemory = runtime.maxMemory();
 	    long allocatedMemory = runtime.totalMemory();
 	    long freeMemory = runtime.freeMemory();

--- a/src/scratch/UCERF3/inversion/CommandLineInversionRunner.java
+++ b/src/scratch/UCERF3/inversion/CommandLineInversionRunner.java
@@ -464,7 +464,7 @@ public class CommandLineInversionRunner {
 				Preconditions.checkState(synrates.length == initialState.length,
 						"synthetic starting solution has different num rups!");
 				// subtract min rates
-				synrates = gen.adjustSolutionForMinimumRates(synrates);
+				synrates = gen.adjustSolutionForWaterLevel(synrates);
 				
 				DoubleMatrix1D synMatrix = new DenseDoubleMatrix1D(synrates);
 				
@@ -576,7 +576,7 @@ public class CommandLineInversionRunner {
 				loadedRupSet.setInfoString(info);
 				double[] rupRateSolution = tsa.getBestSolution();
 				// this adds back in the minimum rupture rates (waterlevel) if present
-				rupRateSolution = UCERF3InversionInputGenerator.adjustSolutionForMinimumRates(
+				rupRateSolution = UCERF3InversionInputGenerator.adjustSolutionForWaterLevel(
 						rupRateSolution, minimumRuptureRates);
 				Map<ConstraintRange, Double> energies = tsa.getEnergies();
 				Map<String, Double> energiesMap = null;

--- a/src/scratch/UCERF3/inversion/InversionFaultSystemSolution.java
+++ b/src/scratch/UCERF3/inversion/InversionFaultSystemSolution.java
@@ -43,7 +43,7 @@ import scratch.UCERF3.enumTreeBranches.SpatialSeisPDF;
 import scratch.UCERF3.enumTreeBranches.TotalMag5Rate;
 import scratch.UCERF3.griddedSeismicity.GridSourceProvider;
 import scratch.UCERF3.griddedSeismicity.UCERF3_GridSourceGenerator;
-import scratch.UCERF3.inversion.InversionConfiguration.SlipRateConstraintWeightingType;
+import scratch.UCERF3.inversion.UCERF3InversionConfiguration.SlipRateConstraintWeightingType;
 import scratch.UCERF3.logicTree.LogicTreeBranch;
 import scratch.UCERF3.logicTree.LogicTreeBranchNode;
 import scratch.UCERF3.utils.FaultSystemIO;
@@ -77,7 +77,7 @@ public class InversionFaultSystemSolution extends SlipEnabledSolution {
 	 * Inversion constraint weights and such. Note that this won't include the initial rup model or
 	 * target MFDs and cannot be used as input to InversionInputGenerator.
 	 */
-	private InversionConfiguration inversionConfiguration;
+	private UCERF3InversionConfiguration inversionConfiguration;
 	
 	private Map<String, Double> energies;
 	private Map<String, Double> misfits;
@@ -101,7 +101,7 @@ public class InversionFaultSystemSolution extends SlipEnabledSolution {
 	 * @param energies can be null
 	 */
 	public InversionFaultSystemSolution(InversionFaultSystemRupSet rupSet, double[] rates,
-			InversionConfiguration config, Map<String, Double> energies) {
+			UCERF3InversionConfiguration config, Map<String, Double> energies) {
 		super();
 		
 		init(rupSet, rates, config, energies);
@@ -171,7 +171,7 @@ public class InversionFaultSystemSolution extends SlipEnabledSolution {
 	}
 	
 	protected void init(InversionFaultSystemRupSet rupSet, double[] rates,
-			InversionConfiguration config, Map<String, Double> energies) {
+			UCERF3InversionConfiguration config, Map<String, Double> energies) {
 		super.init(rupSet, rates, rupSet.getInfoString(), null);
 		this.rupSet = rupSet;
 		this.branch = rupSet.getLogicTreeBranch();
@@ -383,7 +383,7 @@ public class InversionFaultSystemSolution extends SlipEnabledSolution {
 		if (props.containsKey("minimumRuptureRateFraction"))
 			minimumRuptureRateFraction = Double.parseDouble(props.get("minimumRuptureRateFraction"));
 		
-		inversionConfiguration = new InversionConfiguration(
+		inversionConfiguration = new UCERF3InversionConfiguration(
 				slipRateConstraintWt_normalized, slipRateConstraintWt_unnormalized, slipRateWeighting, paleoRateConstraintWt, paleoSlipConstraintWt,
 				magnitudeEqualityConstraintWt, magnitudeInequalityConstraintWt, rupRateConstraintWt,
 				participationSmoothnessConstraintWt, participationConstraintMagBinSize, nucleationMFDConstraintWt,
@@ -423,7 +423,7 @@ public class InversionFaultSystemSolution extends SlipEnabledSolution {
 	}
 	
 	public static Map<String, Double> getMisfits(
-			Map<String, Double> energies, InversionConfiguration inversionConfiguration) {
+			Map<String, Double> energies, UCERF3InversionConfiguration inversionConfiguration) {
 		Map<String, Double> misfits = Maps.newHashMap();
 		
 		if (energies == null)
@@ -511,7 +511,7 @@ public class InversionFaultSystemSolution extends SlipEnabledSolution {
 	 * target MFDs and cannot be used as input to InversionInputGenerator.
 	 * @return
 	 */
-	public InversionConfiguration getInversionConfiguration() {
+	public UCERF3InversionConfiguration getInversionConfiguration() {
 		return inversionConfiguration;
 	}
 

--- a/src/scratch/UCERF3/inversion/RunInversion.java
+++ b/src/scratch/UCERF3/inversion/RunInversion.java
@@ -194,7 +194,7 @@ public class RunInversion {
 		double[] solution_raw = sa.getBestSolution();
 		
 		// adjust for minimum rates if applicable
-		double[] solution_adjusted = gen.adjustSolutionForMinimumRates(solution_raw);
+		double[] solution_adjusted = gen.adjustSolutionForWaterLevel(solution_raw);
 		Map<String, Double> energies = null;
 //		if (sa instanceof ThreadedSimulatedAnnealing)
 //			energies = ((ThreadedSimulatedAnnealing)sa).getEnergies();

--- a/src/scratch/UCERF3/inversion/RunInversion.java
+++ b/src/scratch/UCERF3/inversion/RunInversion.java
@@ -84,8 +84,8 @@ public class RunInversion {
 		if (D) System.out.println("Total Final (creep & subseismogenic rup reduced) Moment Rate = "+rupSet.getTotalReducedMomentRate());
 		
 		// get the inversion configuration
-		InversionConfiguration config;
-		config = InversionConfiguration.forModel(inversionModel, rupSet);
+		UCERF3InversionConfiguration config;
+		config = UCERF3InversionConfiguration.forModel(inversionModel, rupSet);
 		config.updateRupSetInfoString(rupSet);
 		
 		File precomputedDataDir = UCERF3_DataUtils.DEFAULT_SCRATCH_DATA_DIR;
@@ -108,7 +108,7 @@ public class RunInversion {
 		// paleo probability model
 		PaleoProbabilityModel paleoProbabilityModel = null;
 		try {
-			paleoProbabilityModel = InversionInputGenerator.loadDefaultPaleoProbabilityModel();
+			paleoProbabilityModel = UCERF3InversionInputGenerator.loadDefaultPaleoProbabilityModel();
 		} catch (IOException e) {
 			e.printStackTrace();
 			// exit
@@ -124,7 +124,7 @@ public class RunInversion {
 		}
 		
 		// create the input generator
-		InversionInputGenerator gen = new InversionInputGenerator(rupSet, config, paleoRateConstraints, aveSlipConstraints,
+		UCERF3InversionInputGenerator gen = new UCERF3InversionInputGenerator(rupSet, config, paleoRateConstraints, aveSlipConstraints,
 				improbabilityConstraint, paleoProbabilityModel);
 		
 		// generate the inputs
@@ -135,7 +135,7 @@ public class RunInversion {
 		// write solution to disk (optional)
 		if (writeMatrixZipFiles) {
 			try {
-				gen.writeZipFile(new File(precomputedDataDir, fileName+"_inputs.zip"), precomputedDataDir, false);
+				gen.writeZipFile(new File(precomputedDataDir, fileName+"_inputs.zip"), precomputedDataDir, false, true);
 			} catch (IOException e) {
 				// a failure here is actually not the end of the world. just print the trace and move on
 				e.printStackTrace();
@@ -150,8 +150,8 @@ public class RunInversion {
 		double[] d = gen.getD();
 		DoubleMatrix2D A_ineq = gen.getA_ineq();
 		double[] d_ineq = gen.getD_ineq();
-		double[] initial = gen.getInitial();
-		double[] minimumRuptureRates = gen.getMinimumRuptureRates();
+		double[] initial = gen.getInitialSolution();
+		double[] minimumRuptureRates = gen.getWaterLevelRates();
 		
 		// now lets the run the inversion!
 		CompletionCriteria criteria;
@@ -179,7 +179,7 @@ public class RunInversion {
 			ThreadedSimulatedAnnealing tsa = new ThreadedSimulatedAnnealing(A, d, initial, relativeSmoothnessWt,
 					A_ineq, d_ineq, minimumRuptureRates, numThreads, subCompetionCriteria);
 			
-			tsa.setRanges(gen.getRangeEndRows(), gen.getRangeNames());
+			tsa.setConstraintRanges(gen.getConstraintRowRanges());
 			
 			sa = tsa;
 		} else {
@@ -196,8 +196,8 @@ public class RunInversion {
 		// adjust for minimum rates if applicable
 		double[] solution_adjusted = gen.adjustSolutionForMinimumRates(solution_raw);
 		Map<String, Double> energies = null;
-		if (sa instanceof ThreadedSimulatedAnnealing)
-			energies = ((ThreadedSimulatedAnnealing)sa).getEnergies();
+//		if (sa instanceof ThreadedSimulatedAnnealing)
+//			energies = ((ThreadedSimulatedAnnealing)sa).getEnergies();
 		InversionFaultSystemSolution solution = new InversionFaultSystemSolution(
 				rupSet, solution_adjusted, config, energies);
 		

--- a/src/scratch/UCERF3/inversion/UCERF2_ComparisonSolutionFetcher.java
+++ b/src/scratch/UCERF3/inversion/UCERF2_ComparisonSolutionFetcher.java
@@ -72,7 +72,7 @@ public class UCERF2_ComparisonSolutionFetcher {
 	}
 	
 	public static InversionFaultSystemSolution getUCERF2Solution(InversionFaultSystemRupSet rupSet) {
-		ArrayList<double[]> ucerf2_magsAndRates = InversionConfiguration.getUCERF2MagsAndrates(rupSet);
+		ArrayList<double[]> ucerf2_magsAndRates = UCERF3InversionConfiguration.getUCERF2MagsAndrates(rupSet);
 		
 		double[] mags = new double[ucerf2_magsAndRates.size()];
 		double[] rates = new double[ucerf2_magsAndRates.size()];

--- a/src/scratch/UCERF3/simulatedAnnealing/ConstraintRange.java
+++ b/src/scratch/UCERF3/simulatedAnnealing/ConstraintRange.java
@@ -1,0 +1,46 @@
+package scratch.UCERF3.simulatedAnnealing;
+
+/**
+ * Class to keep track of the rows in the inversion A matrix and data vector which
+ * below to a given constraint
+ * 
+ * @author kevin
+ *
+ */
+public class ConstraintRange {
+	
+	public final String name;
+	public final String shortName;
+	/**
+	 * First row for this constraint (inclusive)
+	 */
+	public final int startRow;
+	/**
+	 * Last for for this constraint (exclusive)
+	 */
+	public final int endRow;
+	public final boolean inequality;
+	
+	public ConstraintRange(String name, String shortName,
+			int startRow, int endRow, boolean inequality) {
+		this.name = name;
+		this.shortName = shortName;
+		this.startRow = startRow;
+		this.endRow = endRow;
+		this.inequality = inequality;
+	}
+	
+	@Override
+	public String toString() {
+		return shortName+": ["+startRow+".."+endRow+"), "+(endRow-startRow)+" rows";
+	}
+	
+	public boolean contains(int row) {
+		return row >= startRow && row < endRow;
+	}
+	
+	public boolean contains(int row, boolean inequality) {
+		return this.inequality == inequality && row >= startRow && row < endRow;
+	}
+
+}

--- a/src/scratch/UCERF3/simulatedAnnealing/ThreadedSimulatedAnnealing.java
+++ b/src/scratch/UCERF3/simulatedAnnealing/ThreadedSimulatedAnnealing.java
@@ -23,7 +23,6 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.time.StopWatch;
-import org.apache.commons.math3.stat.StatUtils;
 import org.opensha.commons.data.CSVFile;
 import org.opensha.commons.data.function.ArbitrarilyDiscretizedFunc;
 import org.opensha.commons.data.function.DiscretizedFunc;
@@ -33,14 +32,16 @@ import org.opensha.commons.gui.plot.HeadlessGraphPanel;
 import org.opensha.commons.gui.plot.PlotCurveCharacterstics;
 import org.opensha.commons.gui.plot.PlotLineType;
 import org.opensha.commons.util.ClassUtils;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.InversionInputGenerator;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.primitives.Doubles;
 
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+import cern.colt.matrix.tdouble.impl.SparseCCDoubleMatrix2D;
 import scratch.UCERF3.inversion.CommandLineInversionRunner;
-import scratch.UCERF3.inversion.UCERF3InversionInputGenerator;
 import scratch.UCERF3.simulatedAnnealing.completion.CompletionCriteria;
 import scratch.UCERF3.simulatedAnnealing.completion.CompoundCompletionCriteria;
 import scratch.UCERF3.simulatedAnnealing.completion.EnergyChangeCompletionCriteria;
@@ -53,8 +54,6 @@ import scratch.UCERF3.simulatedAnnealing.params.CoolingScheduleType;
 import scratch.UCERF3.simulatedAnnealing.params.GenerationFunctionType;
 import scratch.UCERF3.simulatedAnnealing.params.NonnegativityConstraintType;
 import scratch.UCERF3.utils.MatrixIO;
-import cern.colt.matrix.tdouble.DoubleMatrix2D;
-import cern.colt.matrix.tdouble.impl.SparseCCDoubleMatrix2D;
 
 public class ThreadedSimulatedAnnealing implements SimulatedAnnealing {
 	
@@ -834,7 +833,7 @@ public class ThreadedSimulatedAnnealing implements SimulatedAnnealing {
 			MatrixIO.doubleArrayToFile(solution, outputOrigFile);
 			
 			System.out.println("Applying minimum rupture rates");
-			solution = UCERF3InversionInputGenerator.adjustSolutionForMinimumRates(solution, minimumRuptureRates);
+			solution = InversionInputGenerator.adjustSolutionForWaterLevel(solution, minimumRuptureRates);
 		}
 		
 		System.out.println("Writing solution to: "+outputFile.getAbsolutePath());
@@ -851,8 +850,8 @@ public class ThreadedSimulatedAnnealing implements SimulatedAnnealing {
 		double[] solutionRates = getBestSolution();
 		double[] adjustedRates = null;
 		if (minimumRuptureRates != null) {
-			adjustedRates =
-				UCERF3InversionInputGenerator.adjustSolutionForMinimumRates(getBestSolution(), minimumRuptureRates);
+			adjustedRates = InversionInputGenerator.adjustSolutionForWaterLevel(
+					getBestSolution(), minimumRuptureRates);
 		}
 		writeRateVsRankPlot(prefix, solutionRates, adjustedRates, initialState);
 	}

--- a/src/scratch/UCERF3/simulatedAnnealing/completion/ProgressTrackingCompletionCriteria.java
+++ b/src/scratch/UCERF3/simulatedAnnealing/completion/ProgressTrackingCompletionCriteria.java
@@ -11,6 +11,7 @@ import org.opensha.commons.data.function.ArbitrarilyDiscretizedFunc;
 import org.opensha.commons.gui.plot.PlotCurveCharacterstics;
 import org.opensha.commons.gui.plot.GraphWindow;
 
+import scratch.UCERF3.simulatedAnnealing.ConstraintRange;
 import scratch.UCERF3.simulatedAnnealing.ThreadedSimulatedAnnealing;
 
 import com.google.common.collect.Lists;
@@ -32,7 +33,7 @@ public class ProgressTrackingCompletionCriteria implements CompletionCriteria {
 	
 	private File automaticFile;
 	
-	private List<String> rangeNames;
+	private List<ConstraintRange> constraintRanges;
 	
 	private long iterMod = 0;
 	
@@ -71,8 +72,9 @@ public class ProgressTrackingCompletionCriteria implements CompletionCriteria {
 		
 		ArrayList<String> header = Lists.newArrayList("Iterations", "Time (millis)", "Energy (total)",
 				"Energy (equality)", "Energy (entropy)", "Energy (inequality)");
-		if (rangeNames != null)
-			header.addAll(rangeNames);
+		if (constraintRanges != null)
+			for (ConstraintRange range : constraintRanges)
+				header.add(range.shortName);
 		header.add("Total Perterbations Kept");
 		csv.addLine(header);
 		
@@ -137,9 +139,9 @@ public class ProgressTrackingCompletionCriteria implements CompletionCriteria {
 			funcs.add(new ArbitrarilyDiscretizedFunc("Equality Energy"));
 			funcs.add(new ArbitrarilyDiscretizedFunc("Entropy Energy"));
 			funcs.add(new ArbitrarilyDiscretizedFunc("Inequality Energy"));
-			if (rangeNames != null) {
-				for (String name : rangeNames)
-					funcs.add(new ArbitrarilyDiscretizedFunc(name+" Energy"));
+			if (constraintRanges != null) {
+				for (ConstraintRange name : constraintRanges)
+					funcs.add(new ArbitrarilyDiscretizedFunc(name.shortName+" Energy"));
 			} else {
 				for (int i=4; i<energies.get(0).length; i++) {
 					funcs.add(new ArbitrarilyDiscretizedFunc("Unknown Energy "+(i+1)));
@@ -199,8 +201,8 @@ public class ProgressTrackingCompletionCriteria implements CompletionCriteria {
 		return energies;
 	}
 	
-	public void setRangeNames(List<String> rangeNames) {
-		this.rangeNames = rangeNames;
+	public void setConstraintRanges(List<ConstraintRange> constraintRanges) {
+		this.constraintRanges = constraintRanges;
 	}
 	
 	public CompletionCriteria getCriteria() {

--- a/src/scratch/UCERF3/simulatedAnnealing/hpc/LogicTreePBSWriter.java
+++ b/src/scratch/UCERF3/simulatedAnnealing/hpc/LogicTreePBSWriter.java
@@ -37,7 +37,7 @@ import scratch.UCERF3.enumTreeBranches.SlipAlongRuptureModels;
 import scratch.UCERF3.enumTreeBranches.SpatialSeisPDF;
 import scratch.UCERF3.enumTreeBranches.TotalMag5Rate;
 import scratch.UCERF3.inversion.CommandLineInversionRunner;
-import scratch.UCERF3.inversion.InversionConfiguration;
+import scratch.UCERF3.inversion.UCERF3InversionConfiguration;
 import scratch.UCERF3.inversion.InversionFaultSystemRupSetFactory;
 import scratch.UCERF3.inversion.CommandLineInversionRunner.InversionOptions;
 import scratch.UCERF3.logicTree.DiscreteListTreeTrimmer;

--- a/src/scratch/UCERF3/utils/FaultSystemIO.java
+++ b/src/scratch/UCERF3/utils/FaultSystemIO.java
@@ -47,7 +47,7 @@ import scratch.UCERF3.enumTreeBranches.FaultModels;
 import scratch.UCERF3.enumTreeBranches.SlipAlongRuptureModels;
 import scratch.UCERF3.griddedSeismicity.GridSourceFileReader;
 import scratch.UCERF3.griddedSeismicity.GridSourceProvider;
-import scratch.UCERF3.inversion.InversionConfiguration;
+import scratch.UCERF3.inversion.UCERF3InversionConfiguration;
 import scratch.UCERF3.inversion.InversionFaultSystemRupSet;
 import scratch.UCERF3.inversion.InversionFaultSystemSolution;
 import scratch.UCERF3.inversion.laughTest.UCERF3PlausibilityConfig;
@@ -544,16 +544,16 @@ public class FaultSystemIO {
 			if (DD) System.out.println("loading inversion metadata");
 			ZipEntry invXMLEntry = zip.getEntry(getRemappedName("inv_sol_metadata.xml", nameRemappings));
 			
-			InversionConfiguration conf = null;
+			UCERF3InversionConfiguration conf = null;
 			Map<String, Double> energies = null;
 			if (invXMLEntry != null) {
 				// new file, we can load directly from XML
 				Document invDoc = XMLUtils.loadDocument(zip.getInputStream(invXMLEntry));
 				Element invRoot = invDoc.getRootElement().element("InversionFaultSystemSolution");
 				
-				Element confEl = invRoot.element(InversionConfiguration.XML_METADATA_NAME);
+				Element confEl = invRoot.element(UCERF3InversionConfiguration.XML_METADATA_NAME);
 				if (confEl != null)
-					conf = InversionConfiguration.fromXMLMetadata(confEl);
+					conf = UCERF3InversionConfiguration.fromXMLMetadata(confEl);
 				
 				Element energiesEl = invRoot.element("Energies");
 				if (energiesEl != null) {
@@ -1004,7 +1004,7 @@ public class FaultSystemIO {
 		Element el = root.addElement("InversionFaultSystemSolution");
 		
 		// add InversionConfiguration
-		InversionConfiguration conf = invSol.getInversionConfiguration();
+		UCERF3InversionConfiguration conf = invSol.getInversionConfiguration();
 		if (conf != null)
 			conf.toXMLMetadata(el);
 		

--- a/src/scratch/UCERF3/utils/paleoRateConstraints/PaleoProbabilityModel.java
+++ b/src/scratch/UCERF3/utils/paleoRateConstraints/PaleoProbabilityModel.java
@@ -9,7 +9,7 @@ import org.opensha.sha.faultSurface.FaultSection;
 import com.google.common.collect.Maps;
 
 import scratch.UCERF3.FaultSystemRupSet;
-import scratch.UCERF3.inversion.InversionInputGenerator;
+import scratch.UCERF3.inversion.UCERF3InversionInputGenerator;
 
 /**
  * This loads in Glenn's paleoseismic trench probabilities.
@@ -28,7 +28,7 @@ public abstract class PaleoProbabilityModel {
 	public abstract double getProbPaleoVisible(double mag, double distAlongRup);
 	
 	double getDistAlongRup(List<FaultSection> rupSections, int sectIndex) {
-		return InversionInputGenerator.getDistanceAlongRupture(
+		return UCERF3InversionInputGenerator.getDistanceAlongRupture(
 				rupSections, sectIndex, traceLengthCache);
 	}
 

--- a/src/scratch/UCERF3/utils/paleoRateConstraints/UCERF3_PaleoRateConstraintFetcher.java
+++ b/src/scratch/UCERF3/utils/paleoRateConstraints/UCERF3_PaleoRateConstraintFetcher.java
@@ -27,7 +27,7 @@ import scratch.UCERF3.FaultSystemSolution;
 import scratch.UCERF3.enumTreeBranches.DeformationModels;
 import scratch.UCERF3.enumTreeBranches.FaultModels;
 import scratch.UCERF3.inversion.InversionFaultSystemRupSetFactory;
-import scratch.UCERF3.inversion.InversionInputGenerator;
+import scratch.UCERF3.inversion.UCERF3InversionInputGenerator;
 import scratch.UCERF3.utils.DeformationModelFetcher;
 import scratch.UCERF3.utils.UCERF3_DataUtils;
 import scratch.UCERF3.utils.aveSlip.AveSlipConstraint;

--- a/test/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/InversionConstraintImplTests.java
+++ b/test/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/InversionConstraintImplTests.java
@@ -66,10 +66,6 @@ public class InversionConstraintImplTests {
 			allParents.add(sect.getParentSectionId());
 	}
 
-	@Before
-	public void setUp() throws Exception {
-	}
-
 	@Test
 	public void testAPriori() {
 		double[] aPrioriRates = new double[numRuptures];

--- a/test/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/InversionConstraintImplTests.java
+++ b/test/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/InversionConstraintImplTests.java
@@ -1,0 +1,286 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
+import org.opensha.sha.faultSurface.FaultSection;
+import org.opensha.sha.magdist.GutenbergRichterMagFreqDist;
+import org.opensha.sha.magdist.IncrementalMagFreqDist;
+
+import cern.colt.list.tdouble.DoubleArrayList;
+import cern.colt.list.tint.IntArrayList;
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+import cern.colt.matrix.tdouble.impl.SparseDoubleMatrix2D;
+import scratch.UCERF3.analysis.FaultSystemRupSetCalc;
+import scratch.UCERF3.enumTreeBranches.InversionModels;
+import scratch.UCERF3.erf.FSS_ERF_ParamTest;
+import scratch.UCERF3.inversion.InversionFaultSystemRupSet;
+import scratch.UCERF3.inversion.UCERF3InversionConfiguration;
+import scratch.UCERF3.inversion.UCERF3InversionInputGenerator;
+import scratch.UCERF3.inversion.UCERF3InversionConfiguration.SlipRateConstraintWeightingType;
+import scratch.UCERF3.utils.MFD_InversionConstraint;
+import scratch.UCERF3.utils.SectionMFD_constraint;
+import scratch.UCERF3.utils.aveSlip.AveSlipConstraint;
+import scratch.UCERF3.utils.paleoRateConstraints.PaleoRateConstraint;
+import scratch.UCERF3.utils.paleoRateConstraints.UCERF3_PaleoProbabilityModel;
+
+public class InversionConstraintImplTests {
+	
+	private static InversionFaultSystemRupSet rupSet;
+	private static int numRuptures;
+	private static int numSections;
+	private static Random r = new Random();
+	
+	private static UCERF3InversionConfiguration config;
+	
+	private static IncrementalMagFreqDist testMFD;
+	
+	private static HashSet<Integer> allParents;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		rupSet = FSS_ERF_ParamTest.buildSmallTestRupSet();
+		numRuptures = rupSet.getNumRuptures();
+		numSections = rupSet.getNumSections();
+		
+		System.out.println("Test rupSet has "+numRuptures+" rups and "+numSections+" sects");
+		System.out.println("Mag range: "+rupSet.getMinMag()+" "+rupSet.getMaxMag());
+		
+		config = UCERF3InversionConfiguration.forModel(InversionModels.CHAR_CONSTRAINED, rupSet);
+		
+		testMFD = new GutenbergRichterMagFreqDist(1d, 10d, 5.05, 8.95, 50);
+		
+		allParents = new HashSet<>();
+		for (FaultSection sect : rupSet.getFaultSectionDataList())
+			allParents.add(sect.getParentSectionId());
+	}
+
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	@Test
+	public void testAPriori() {
+		double[] aPrioriRates = new double[numRuptures];
+		for (int r=0; r<numRuptures; r++)
+			aPrioriRates[r] = 0.1d*(r % 10);
+		APrioriInversionConstraint constr = new APrioriInversionConstraint(1d, 0d, aPrioriRates);
+		
+		testConstraint(constr);
+		
+		constr = new APrioriInversionConstraint(0d, 1d, aPrioriRates);
+		
+		testConstraint(constr);
+		
+		constr = new APrioriInversionConstraint(1d, 1d, aPrioriRates);
+		
+		testConstraint(constr);
+	}
+
+	@Test
+	public void testMFDEquality() {
+		List<MFD_InversionConstraint> eqConstr = config.getMfdEqualityConstraints();
+		for (MFD_InversionConstraint mfd : eqConstr)
+			mfd.setMagFreqDist(testMFD);
+		MFDEqualityInversionConstraint constr = new MFDEqualityInversionConstraint(
+				rupSet, 1d, eqConstr, null);
+		
+		testConstraint(constr);
+	}
+
+	@Test
+	public void testMFDInquality() {
+		List<MFD_InversionConstraint> ineqConstr = config.getMfdInequalityConstraints();
+		for (MFD_InversionConstraint mfd : ineqConstr)
+			mfd.setMagFreqDist(testMFD);
+//		System.out.println("have "+ineqConstr.size()+" ineq constraints");
+		MFDInequalityInversionConstraint constr = new MFDInequalityInversionConstraint(
+				rupSet, 1d, ineqConstr);
+		
+		testConstraint(constr);
+	}
+
+	@Test
+	public void testMFDLaplace() {
+		ArrayList<SectionMFD_constraint> constraints =
+				FaultSystemRupSetCalc.getCharInversionSectMFD_Constraints(rupSet);
+		MFDLaplacianSmoothingInversionConstraint constr = new MFDLaplacianSmoothingInversionConstraint(
+				rupSet, 1d, 0d, null, constraints);
+		
+		testConstraint(constr);
+		
+		constr = new MFDLaplacianSmoothingInversionConstraint(
+				rupSet, 0d, 1d, allParents, constraints);
+		
+		testConstraint(constr);
+		
+		constr = new MFDLaplacianSmoothingInversionConstraint(
+				rupSet, 1d, 1d, allParents, constraints);
+		
+		testConstraint(constr);
+	}
+
+	@Test
+	public void testMFDParticSmooth() {
+		MFDParticipationSmoothnessInversionConstraint constr =
+				new MFDParticipationSmoothnessInversionConstraint(rupSet, 1d, 0.2);
+		
+		testConstraint(constr);
+	}
+
+	@Test
+	public void testMFDSubSectNucl() {
+		ArrayList<SectionMFD_constraint> constraints =
+				FaultSystemRupSetCalc.getCharInversionSectMFD_Constraints(rupSet);
+		MFDSubSectNuclInversionConstraint constr = new MFDSubSectNuclInversionConstraint(
+				rupSet, 1d, constraints);
+		
+		testConstraint(constr);
+	}
+	
+	@Test
+	public void testPaleoRate() throws IOException {
+		UCERF3_PaleoProbabilityModel paleoProbModel = UCERF3_PaleoProbabilityModel.load();
+		List<PaleoRateConstraint> paleoRateConstraints = new ArrayList<>();
+		paleoRateConstraints.add(new PaleoRateConstraint(
+				"", null, r.nextInt(numSections), 1d,
+				0.5d, 1.5d));
+		paleoRateConstraints.add(new PaleoRateConstraint(
+				"", null, r.nextInt(numSections), 2d,
+				1d, 3d));
+		PaleoRateInversionConstraint constr = new PaleoRateInversionConstraint(
+				rupSet, 1d, paleoRateConstraints, paleoProbModel);
+		
+		testConstraint(constr);
+	}
+
+	@Test
+	public void testPaleoSlip() {
+		List<AveSlipConstraint> constraints = new ArrayList<>();
+		constraints.add(new AveSlipConstraint(r.nextInt(numSections), "",
+				1d, 1.5d, 0.5d, null));
+		constraints.add(new AveSlipConstraint(r.nextInt(numSections), "",
+				3d, 4d, 2d, null));
+		PaleoSlipInversionConstraint constr = new PaleoSlipInversionConstraint(
+				rupSet, 1d, constraints, rupSet.getSlipRateForAllSections());
+		
+		testConstraint(constr);
+	}
+
+	@Test
+	public void testPaleoVisibleEventRateSmooth() throws IOException {
+		UCERF3_PaleoProbabilityModel paleoProbModel = UCERF3_PaleoProbabilityModel.load();
+		PaleoVisibleEventRateSmoothnessInversionConstraint constr =
+				new PaleoVisibleEventRateSmoothnessInversionConstraint(rupSet, 1d, paleoProbModel);
+		
+		testConstraint(constr);
+	}
+
+	@Test
+	public void testParkfield() throws IOException {
+		List<Integer> parkfieldRups = UCERF3InversionInputGenerator.findParkfieldRups(rupSet);
+		ParkfieldInversionConstraint constr = new ParkfieldInversionConstraint(1d, 1d/25d,
+				parkfieldRups);
+		
+		testConstraint(constr);
+	}
+
+	@Test
+	public void testMinimization() throws IOException {
+		List<Integer> rupIndexes = new ArrayList<>();
+		for (int r=0; r<numRuptures; r++)
+			if (r % 3 == 0)
+				rupIndexes.add(r);
+		RupRateMinimizationConstraint constr = new RupRateMinimizationConstraint(1d, rupIndexes);
+		
+		testConstraint(constr);
+	}
+
+	@Test
+	public void testRateSmoothing() throws IOException {
+		RupRateSmoothingInversionConstraint constr = new RupRateSmoothingInversionConstraint(1d, rupSet);
+		
+		testConstraint(constr);
+	}
+
+	@Test
+	public void testSlipRate() throws IOException {
+		double[] targetSlipRates = rupSet.getSlipRateForAllSections();
+		
+		SlipRateInversionConstraint constr = new SlipRateInversionConstraint(
+				1d, 1d, SlipRateConstraintWeightingType.BOTH, rupSet, targetSlipRates);
+		
+		testConstraint(constr);
+		
+		constr = new SlipRateInversionConstraint(
+				1d, 1d, SlipRateConstraintWeightingType.NORMALIZED_BY_SLIP_RATE, rupSet, targetSlipRates);
+		
+		testConstraint(constr);
+		
+		constr = new SlipRateInversionConstraint(
+				1d, 1d, SlipRateConstraintWeightingType.UNNORMALIZED, rupSet, targetSlipRates);
+		
+		testConstraint(constr);
+	}
+
+	@Test
+	public void testTotalMoment() throws IOException {
+		TotalMomentInversionConstraint constr = new TotalMomentInversionConstraint(
+				rupSet, 1d, rupSet.getTotalReducedMomentRate());
+		
+		testConstraint(constr);
+	}
+	
+	private void testConstraint(InversionConstraint constraint) {
+		int numRows = constraint.getNumRows();
+		System.out.println(constraint.getName()+" has "+numRows+" rows");
+		assertTrue("numRows="+numRows+" for "+constraint.getName(), numRows > 0);
+		DoubleMatrix2D A1 = new SparseDoubleMatrix2D(numRows, numRuptures);
+		double[] d1 = new double[numRows];
+		long count1 = constraint.encode(A1, d1, 0); 
+		int offsetBefore = r.nextInt(1000);
+		int offsetAfter = r.nextInt(1000);
+		DoubleMatrix2D A2 = new SparseDoubleMatrix2D(numRows+offsetBefore+offsetAfter, numRuptures);
+		double[] d2 = new double[numRows+offsetBefore+offsetAfter];
+		long count2 = constraint.encode(A2, d2, offsetBefore);
+		assertEquals("Counts inconsistent for multiple encodings of "+constraint.getName(), count1, count2);
+		assertTrue("Count="+count1+" for "+constraint.getName(), count1 > 0);
+		
+		IntArrayList rows1 = new IntArrayList();
+		IntArrayList cols1 = new IntArrayList();
+		DoubleArrayList vals1 = new DoubleArrayList();
+		
+		A1.getNonZeros(rows1, cols1, vals1);
+		
+		assertEquals("Count is wrong for zero-offset "+constraint.getName(), count1, vals1.size());
+		
+		IntArrayList rows2 = new IntArrayList();
+		IntArrayList cols2 = new IntArrayList();
+		DoubleArrayList vals2 = new DoubleArrayList();
+		
+		A2.getNonZeros(rows2, cols2, vals2);
+		
+		assertEquals("Count is wrong for offset "+constraint.getName(), count2, vals2.size());
+		
+		for (int i=0; i<rows1.size(); i++) {
+			int row1 = rows1.get(i);
+			int col = cols1.get(i);
+			double val1 = vals1.get(i);
+			
+			int row2 = row1+offsetBefore;
+			double val2 = A2.get(row2, col);
+			assertEquals("Value mismatch between offset and non-offset for "+constraint.getName(),
+					val1, val2, 1e-15);
+		}
+	}
+
+}

--- a/test/scratch/UCERF3/erf/FSS_ERF_ParamTest.java
+++ b/test/scratch/UCERF3/erf/FSS_ERF_ParamTest.java
@@ -147,8 +147,8 @@ public class FSS_ERF_ParamTest {
 		// build the subsections
 		int sectIndex = 0;
 		for (FaultSection parentSect : fsd) {
-			if (parentSect.getSectionId() != 301)
-				// only one fault, Mojave S
+			if (parentSect.getSectionId() != 301 && parentSect.getSectionId() != 32)
+				// only Mojave S and Parkfield
 				continue;
 			double ddw = parentSect.getOrigDownDipWidth();
 			double maxSectLength = ddw*maxSubSectionLength;


### PR DESCRIPTION
UCERF3 inversion constraints were encoded into the A matrix/d vector via a long method in an unwieldy and complicated class (was scratch.ucerf3.inversion.InversionInputGenerator). This worked fine, but didn't provide a good way to implement new constraints which don't apply to UCERF3. This further flexibility is required for UCERF4, NZ (cc: @chrisbc), and non-CA NSHMP work. I have created a new inversion constraint framework described below, and successfully ported all of the UCERF3 constraints (including those unused in the final model) over to the new framework.

I have validated the new implementations against the original implementation on a per-value basis in the generated A matrix/d vector. This validation is too computationally intensive for a unit test, but it can be re-run with the main method of scratch.UCERF3.inversion.UCERF3InversionInputGenerator (it requires tons of memory, ~40 GB, and some patience). I also added additional unit tests that verify that the constraints report the correct number of rows and non-zero values (e.g., that they don't overrun into areas beyond the declared A matrix range), but these tests do not validate their scientific implementation.

# Implementation details

Everything is in the package `org.opensha.sha.earthquake.faultSysSolution.inversion` and it's children

## InversionConstraint

Core abstract class for an inversion constraint. The primary methods are:

* public abstract int getNumRows(): returns the number of rows in the A matrix/d vector for this constraint
* public abstract boolean isInequality(): true if this is an inequality constraint (A_ineq, d_ineq), else a regular equality constraint
* public abstract long encode(DoubleMatrix2D A, double[] d, int startRow): Encodes this constraint into the given A matrix and d vector, beginning at the given starting row and ending before (startRow+getNumRows()). It returns the number of non-zero values, which is mostly used for reporting but is also useful when testing implementations.

All implementations are int he `impl` sub-package

## InversionInputGenerator

New input generator which uses the InversionConstraint implementations to build all relevant inversion inputs (A/A_ineq/d/d_ineq, water levels, initial solutions, etc). It takes a FaultSystemRupSet and list of constraints, and optionally an initial solution (otherwise defaults to zeroes) and water level.

This is also now the parent class for UCERF3InversionInputGenerator, which also has the old building/construction available via the deprecated generateInputsOld() method.

# Notes

I tried to copy over relevant comments and such to the new classes and give the new classes meaningful names, but I can't quite remember the details on some of these constraints.

Something seems off with the Paleo-Visible Event Rate Smoothness constraint, which we did not end up using in UCERF3 (so we don't have to sweat it too much), but I could use your eyes @mtpage. It creates a new row in the A matrix for each pair of neighboring subsections within a parent section. Within that row, for each rupture for the first section of that pair, it sets A[row, rupIndex]=+paleoVisibleProb. It then sets, for each rupture for the second section of that pair, A[row, rupIndex]=-paleoVisibleProb. The problem is that there will be lots of overlap between the ruptures for each section (as they're neighbors), and it ends up overwriting the +paleoVisibleProb with -paleoVisibleProb. It should probably add them instead, such that it only penalized ruptures which only include one section (or with large differences in paleo visible probabilities). Anyway, I left it as is and included a note in order to be able to compare it directly against the old UCERF3 code, but we should probably fix it.