### PR TITLE
Plausibility config serialization, cluster rupture memory improvements, threaded rupture set building, rup set diagnostics

### DIFF
--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRupture.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRupture.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.RuptureConnectionSearch;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.RuptureTreeNavigator;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.UniqueRupture;
 import org.opensha.sha.faultSurface.FaultSection;
@@ -57,36 +58,15 @@ public class ClusterRupture {
 	 */
 	public final ImmutableMap<Jump, ClusterRupture> splays;
 	
-	// these are for navigating the rupture section tree
-	/**
-	 * Multimap from each fault section to each descendant (section(s) immediately downstream) of 
-	 * that section. If this rupture has splays or clusters have multiple endpoints, then multiple 
-	 * descendants are possible for a single parent
-	 */
-	public final ImmutableMultimap<FaultSection, FaultSection> sectDescendantsMap;
-	/**
-	 * Map from each fault section to the predecessor (section immediately upstream) of that section
-	 */
-	public final ImmutableMap<FaultSection, FaultSection> sectPredecessorsMap;
-	
-	// these are for navigating the rupture cluster tree
-	/**
-	 * Multimap from each cluster to each descendant (cluster(s) immediately downstream) of 
-	 * that cluster
-	 */
-	public final ImmutableMultimap<FaultSubsectionCluster, FaultSubsectionCluster> clusterDescendantsMap;
-	/**
-	 * Map from each cluster to the predecessor (cluster immediately upstream) of that section
-	 */
-	public final ImmutableMap<FaultSubsectionCluster, FaultSubsectionCluster> clusterPredecessorsMap;
-	
 	/**
 	 * UniqueRupture instance, useful for determining if this rupture has already been built and included
 	 * in a rupture set (as defined by the set of subsection IDs included, regardless of order)
 	 */
 	public final UniqueRupture unique;
 	
-	private final Set<FaultSection> internalSects;
+	private RuptureTreeNavigator navigator;
+	
+	private final UniqueRupture internalUnique;
 	
 	/**
 	 * Initiate a ClusterRupture with the given starting cluster. You can grow it later with the
@@ -95,44 +75,18 @@ public class ClusterRupture {
 	 */
 	public ClusterRupture(FaultSubsectionCluster cluster) {
 		this(new FaultSubsectionCluster[] {cluster}, ImmutableSet.of(),
-				ImmutableMap.of(), initialDescendentsMap(cluster), initialPredecessorsMap(cluster),
-				ImmutableMultimap.of(), ImmutableMap.of(),
-				new HashSet<>(cluster.subSects), new UniqueRupture(cluster));
-	}
-	
-	private static ImmutableMultimap<FaultSection, FaultSection> initialDescendentsMap(
-			FaultSubsectionCluster cluster) {
-		ImmutableMultimap.Builder<FaultSection, FaultSection> builder = ImmutableMultimap.builder();
-		for (int i=0; i<cluster.subSects.size()-1; i++)
-			builder.put(cluster.subSects.get(i), cluster.subSects.get(i+1));
-		return builder.build();
-	}
-	
-	private static ImmutableMap<FaultSection, FaultSection> initialPredecessorsMap(
-			FaultSubsectionCluster cluster) {
-		ImmutableMap.Builder<FaultSection, FaultSection> builder = ImmutableMap.builder();
-		for (int i=0; i<cluster.subSects.size()-1; i++)
-			builder.put(cluster.subSects.get(i+1), cluster.subSects.get(i));
-		return builder.build();
+				ImmutableMap.of(), cluster.unique, cluster.unique);
 	}
 
 	private ClusterRupture(FaultSubsectionCluster[] clusters, ImmutableSet<Jump> internalJumps,
-			ImmutableMap<Jump, ClusterRupture> splays,
-			ImmutableMultimap<FaultSection, FaultSection> sectDescendantsMap,
-			ImmutableMap<FaultSection, FaultSection> sectPredecessorsMap,
-			ImmutableMultimap<FaultSubsectionCluster, FaultSubsectionCluster> clusterDescendantsMap,
-			ImmutableMap<FaultSubsectionCluster, FaultSubsectionCluster> clusterPredecessorsMap,
-			Set<FaultSection> internalSects, UniqueRupture unique) {
+			ImmutableMap<Jump, ClusterRupture> splays, UniqueRupture unique, UniqueRupture internalUnique) {
 		super();
 		this.clusters = clusters;
 		this.internalJumps = internalJumps;
 		this.splays = splays;
-		this.sectDescendantsMap = sectDescendantsMap;
-		this.sectPredecessorsMap = sectPredecessorsMap;
-		this.clusterDescendantsMap = clusterDescendantsMap;
-		this.clusterPredecessorsMap = clusterPredecessorsMap;
-		this.internalSects = internalSects;
 		this.unique = unique;
+		this.internalUnique = internalUnique;
+		Preconditions.checkState(internalUnique.size() <= unique.size());
 	}
 	
 	/**
@@ -140,7 +94,7 @@ public class ClusterRupture {
 	 * @return true if the primary strand of this rupture contains the given section
 	 */
 	public boolean containsInternal(FaultSection sect) {
-		return internalSects.contains(sect);
+		return internalUnique.contains(sect.getSectionId());
 	}
 	
 	/**
@@ -161,10 +115,7 @@ public class ClusterRupture {
 	 * @return total number of sections across this and any splays
 	 */
 	public int getTotalNumSects() {
-		int tot = internalSects.size();
-		for (ClusterRupture splay : splays.values())
-			tot += splay.getTotalNumSects();
-		return tot;
+		return unique.size();
 	}
 	
 	/**
@@ -172,7 +123,7 @@ public class ClusterRupture {
 	 * @return the number of sections on the primary strand of this rupture
 	 */
 	public int getNumInternalSects() {
-		return internalSects.size();
+		return internalUnique.size();
 	}
 	
 	/**
@@ -187,6 +138,17 @@ public class ClusterRupture {
 	}
 	
 	/**
+	 * 
+	 * @return total number of clusters across this and any splays
+	 */
+	public int getTotalNumClusters() {
+		int tot = clusters.length;
+		for (ClusterRupture splay : splays.values())
+			tot += splay.clusters.length;
+		return tot;
+	}
+	
+	/**
 	 * Creates and returns a new rupture which has taken the given jump. The jump can be from any section
 	 * on any splay, so long as the toCluster does not contain any sections already included in this rupture
 	 * @param jump
@@ -197,58 +159,19 @@ public class ClusterRupture {
 				"Cannot take jump because this rupture doesn't have the fromSection: %s", jump);
 		Preconditions.checkState(!contains(jump.toSection),
 				"Cannot take jump because this rupture already has the toSection: %s", jump);
-		ImmutableMap.Builder<FaultSection, FaultSection> predecessorBuilder = ImmutableMap.builder();
-		predecessorBuilder.putAll(sectPredecessorsMap);
-		predecessorBuilder.put(jump.toSection, jump.fromSection);
-		ImmutableMultimap.Builder<FaultSection, FaultSection> descendentsBuilder = ImmutableMultimap.builder();
-		descendentsBuilder.putAll(sectDescendantsMap);
-		descendentsBuilder.put(jump.fromSection, jump.toSection);
-		
-		int toIndex = jump.toCluster.subSects.indexOf(jump.toSection);
-		Preconditions.checkState(toIndex >= 0, "toSection not found in toCluster subsection list");
-		// build in both direction from toIndex
-		for (int i=toIndex; i<jump.toCluster.subSects.size()-1; i++) {
-			FaultSection sect1 = jump.toCluster.subSects.get(i);
-			FaultSection sect2 = jump.toCluster.subSects.get(i+1);
-			descendentsBuilder.put(sect1, sect2);
-			predecessorBuilder.put(sect2, sect1);
-		}
-		for (int i=toIndex; --i>=0;) {
-			FaultSection sect1 = jump.toCluster.subSects.get(i+1);
-			FaultSection sect2 = jump.toCluster.subSects.get(i);
-			descendentsBuilder.put(sect1, sect2);
-			predecessorBuilder.put(sect2, sect1);
-		}
 		
 		UniqueRupture newUnique = new UniqueRupture(this.unique, jump.toCluster);
 		int expectedCount = this.unique.size() + jump.toCluster.subSects.size();
 		Preconditions.checkState(newUnique.size() == expectedCount,
 				"Duplicate subsections. Have %s unique, %s total", newUnique.size(), expectedCount);
 		
-		ImmutableMultimap<FaultSection, FaultSection> newDescendentsMap = descendentsBuilder.build();
-		ImmutableMap<FaultSection, FaultSection> newPredecessorMap = predecessorBuilder.build();
-		
-		ImmutableMap.Builder<FaultSubsectionCluster, FaultSubsectionCluster>
-			clusterPredecessorBuilder = ImmutableMap.builder();
-		clusterPredecessorBuilder.putAll(clusterPredecessorsMap);
-		clusterPredecessorBuilder.put(jump.toCluster, jump.fromCluster);
-		ImmutableMultimap.Builder<FaultSubsectionCluster, FaultSubsectionCluster>
-			clusterDescendentsBuilder = ImmutableMultimap.builder();
-		clusterDescendentsBuilder.putAll(clusterDescendantsMap);
-		clusterDescendentsBuilder.put(jump.fromCluster, jump.toCluster);
-		
-		ImmutableMultimap<FaultSubsectionCluster, FaultSubsectionCluster>
-			newClusterDescendentsMap = clusterDescendentsBuilder.build();
-		ImmutableMap<FaultSubsectionCluster, FaultSubsectionCluster>
-			newClusterPredecessorMap = clusterPredecessorBuilder.build();
-		
-		if (internalSects.contains(jump.fromSection)) {
+		if (containsInternal(jump.fromSection)) {
 			// it's on the main strand
 			FaultSubsectionCluster lastCluster = clusters[clusters.length-1];
 			FaultSubsectionCluster[] newClusters;
 			ImmutableMap<Jump, ClusterRupture> newSplays;
 			ImmutableSet<Jump> newInternalJumps;
-			HashSet<FaultSection> newInternalSects;
+			UniqueRupture newInternalUnique;
 			if (lastCluster.endSects.contains(jump.fromSection)) {
 				// regular jump from the end
 //				System.out.println("Taking a regular jump to extend a strand");
@@ -260,8 +183,7 @@ public class ClusterRupture {
 				internalJumpBuild.addAll(internalJumps);
 				internalJumpBuild.add(jump);
 				newInternalJumps = internalJumpBuild.build();
-				newInternalSects = new HashSet<>(internalSects);
-				newInternalSects.addAll(jump.toCluster.subSects);
+				newInternalUnique = new UniqueRupture(internalUnique, jump.toCluster);
 			} else {
 				// it's a new splay
 //				System.out.println("it's a new splay!");
@@ -271,11 +193,9 @@ public class ClusterRupture {
 				splayBuilder.put(jump, new ClusterRupture(jump.toCluster));
 				newSplays = splayBuilder.build();
 				newInternalJumps = internalJumps;
-				newInternalSects = new HashSet<>(internalSects);
+				newInternalUnique = internalUnique;
 			}
-			return new ClusterRupture(newClusters, newInternalJumps, newSplays, newDescendentsMap,
-					newPredecessorMap, newClusterDescendentsMap, newClusterPredecessorMap,
-					newInternalSects, newUnique);
+			return new ClusterRupture(newClusters, newInternalJumps, newSplays, newUnique, newInternalUnique);
 		} else {
 			// it's on a splay, grow that
 			boolean found = false;
@@ -296,8 +216,7 @@ public class ClusterRupture {
 			Preconditions.checkState(found,
 					"From section for jump not found in rupture (including splays): %s", jump);
 			return new ClusterRupture(clusters, internalJumps, splayBuilder.build(),
-					newDescendentsMap, newPredecessorMap, newClusterDescendentsMap, newClusterPredecessorMap,
-					internalSects, newUnique);
+					newUnique, internalUnique);
 		}
 	}
 	
@@ -329,24 +248,6 @@ public class ClusterRupture {
 	public ClusterRupture reversed() {
 		Preconditions.checkState(splays.isEmpty(), "Can't reverse a splayed rupture");
 		
-		ImmutableMultimap.Builder<FaultSection, FaultSection> descendentsBuilder = ImmutableMultimap.builder();
-		ImmutableMap.Builder<FaultSection, FaultSection> predecessorsBuilder = ImmutableMap.builder();
-		for (FaultSection sect1 : sectDescendantsMap.keys())
-			for (FaultSection sect2 : sectDescendantsMap.get(sect1))
-				predecessorsBuilder.put(sect1, sect2);
-		for (FaultSection sect1 : sectPredecessorsMap.keySet())
-			descendentsBuilder.put(sect1, sectPredecessorsMap.get(sect1));
-		
-		ImmutableMultimap.Builder<FaultSubsectionCluster, FaultSubsectionCluster>
-			clusterDescendentsBuilder = ImmutableMultimap.builder();
-		ImmutableMap.Builder<FaultSubsectionCluster, FaultSubsectionCluster>
-			clusterPredecessorsBuilder = ImmutableMap.builder();
-		for (FaultSubsectionCluster cluster1 : clusterDescendantsMap.keys())
-			for (FaultSubsectionCluster cluster2 : clusterDescendantsMap.get(cluster1))
-				clusterPredecessorsBuilder.put(cluster1, cluster2);
-		for (FaultSubsectionCluster cluster1 : clusterPredecessorsMap.keySet())
-			clusterDescendentsBuilder.put(cluster1, clusterPredecessorsMap.get(cluster1));
-		
 		List<FaultSubsectionCluster> clusterList = new ArrayList<>();
 		for (int i=clusters.length; --i>=0;)
 			clusterList.add(clusters[i].reversed());
@@ -369,8 +270,7 @@ public class ClusterRupture {
 		}
 		
 		return new ClusterRupture(clusterList.toArray(new FaultSubsectionCluster[0]), jumpsBuilder.build(),
-				ImmutableMap.of(), descendentsBuilder.build(), predecessorsBuilder.build(),
-				clusterDescendentsBuilder.build(), clusterPredecessorsBuilder.build(), internalSects, unique);
+				ImmutableMap.of(), unique, internalUnique);
 	}
 	
 	/**
@@ -420,8 +320,17 @@ public class ClusterRupture {
 		return inversions;
 	}
 	
+	/**
+	 * @return Rupture tree navigator (lazily initialized)
+	 */
+	public RuptureTreeNavigator getTreeNavigator() {
+		if (navigator == null)
+			navigator = new RuptureTreeNavigator(this);
+		return navigator;
+	}
+	
 	private void getEndSects(List<FaultSubsectionCluster> endClusters, FaultSubsectionCluster curCluster) {
-		ImmutableCollection<FaultSubsectionCluster> descendants = clusterDescendantsMap.get(curCluster);
+		List<FaultSubsectionCluster> descendants = getTreeNavigator().getDescendants(curCluster);
 		if (descendants == null || descendants.isEmpty()) {
 			// this is an end section
 			endClusters.add(curCluster);
@@ -455,26 +364,6 @@ public class ClusterRupture {
 		}
 		clusterList.add(new FaultSubsectionCluster(curSects));
 		
-		ImmutableMultimap.Builder<FaultSection, FaultSection> descendentsBuilder = ImmutableMultimap.builder();
-		ImmutableMap.Builder<FaultSection, FaultSection> predecessorsBuilder = ImmutableMap.builder();
-		for (int i=1; i<sects.size(); i++) {
-			FaultSection sect1 = sects.get(i-1);
-			FaultSection sect2 = sects.get(i);
-			descendentsBuilder.put(sect1, sect2);
-			predecessorsBuilder.put(sect2, sect1);
-		}
-		
-		ImmutableMultimap.Builder<FaultSubsectionCluster, FaultSubsectionCluster>
-			clusterDescendentsBuilder = ImmutableMultimap.builder();
-		ImmutableMap.Builder<FaultSubsectionCluster, FaultSubsectionCluster>
-			clusterPredecessorsBuilder = ImmutableMap.builder();
-		for (int i=1; i<clusterList.size(); i++) {
-			FaultSubsectionCluster cluster1 = clusterList.get(i-1);
-			FaultSubsectionCluster cluster2 = clusterList.get(i);
-			clusterDescendentsBuilder.put(cluster1, cluster2);
-			clusterPredecessorsBuilder.put(cluster2, cluster1);
-		}
-		
 		FaultSubsectionCluster[] clusters = clusterList.toArray(new FaultSubsectionCluster[0]);
 		
 		ImmutableSet.Builder<Jump> jumpsBuilder = ImmutableSet.builder();
@@ -490,10 +379,9 @@ public class ClusterRupture {
 			toCluster.addConnection(jump.reverse());
 		}
 		
-		return new ClusterRupture(clusters, jumpsBuilder.build(), ImmutableMap.of(),
-				descendentsBuilder.build(), predecessorsBuilder.build(),
-				clusterDescendentsBuilder.build(), clusterPredecessorsBuilder.build(),
-				new HashSet<>(sects), new UniqueRupture(sectIDs));
+		UniqueRupture unique = UniqueRupture.forClusters(clusters);
+		
+		return new ClusterRupture(clusters, jumpsBuilder.build(), ImmutableMap.of(), unique, unique);
 	}
 	
 	@Override

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRuptureBuilder.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRuptureBuilder.java
@@ -34,6 +34,7 @@ import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.Pa
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterConnectionStrategy;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterPermutationStrategy;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.DistCutoffClosestSectClusterConnectionStrategy;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ConnectionPointsPermutationStrategy;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.UCERF3ClusterConnectionStrategy;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.UCERF3ClusterPermuationStrategy;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
@@ -289,6 +290,9 @@ public class ClusterRuptureBuilder {
 				if (!uniques.contains(rup.unique)) {
 					masterRups.add(rup);
 					uniques.add(rup.unique);
+					// make sure that contains now returns 
+					Preconditions.checkState(uniques.contains(rup.unique));
+//					Preconditions.checkState(uniques.contains(rup.reversed().unique));
 					added++;
 				}
 			}
@@ -702,6 +706,10 @@ public class ClusterRuptureBuilder {
 		
 		RupDebugCriteria debugCriteria = null;
 		boolean stopAfterDebug = false;
+		
+//		RupDebugCriteria debugCriteria = new ParentSectsRupDebugCriteria(false, false, 672, 668);
+////		RupDebugCriteria debugCriteria = new StartEndSectRupDebugCriteria(672, -1, true, false);
+//		boolean stopAfterDebug = true;
 
 //		FaultSystemRupSet compRupSet = FaultSystemIO.loadRupSet(new File(
 //				"/home/kevin/workspace/OpenSHA/dev/scratch/UCERF3/data/scratch/InversionSolutions/"
@@ -721,7 +729,8 @@ public class ClusterRuptureBuilder {
 		/*
 		 * To reproduce UCERF3
 		 */
-//		PlausibilityConfiguration config = PlausibilityConfiguration.getUCERF3(subSects, distAzCalc, fm);
+		PlausibilityConfiguration config = PlausibilityConfiguration.getUCERF3(subSects, distAzCalc, fm);
+		ClusterPermutationStrategy permStrat = new UCERF3ClusterPermuationStrategy();
 		
 		/*
 		 * For other experiements
@@ -730,20 +739,22 @@ public class ClusterRuptureBuilder {
 //		ClusterConnectionStrategy connectionStrategy =
 //				new UCERF3ClusterConnectionStrategy(subSects,
 //						distAzCalc, 5d, CoulombRates.loadUCERF3CoulombRates(fm));
-		ClusterConnectionStrategy connectionStrategy =
-			new DistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, 5d);
-		SubSectStiffnessCalculator stiffnessCalc = new SubSectStiffnessCalculator(subSects, 2d, 3e4, 3e4, 0.5);
-		Builder configBuilder = PlausibilityConfiguration.builder(connectionStrategy, subSects);
-		configBuilder.maxNumClusters(2); // for connection only testing
-		configBuilder.parentCoulomb(stiffnessCalc, StiffnessAggregationMethod.MEDIAN, 0f, Directionality.EITHER);
-		configBuilder.cumulativeAzChange(560f);
-		configBuilder.cumulativeRakeChange(180f);
-//		configBuilder.u3Azimuth();
-//		configBuilder.clusterCoulomb(stiffnessCalc, StiffnessAggregationMethod.MEDIAN, 0f);
+////		ClusterConnectionStrategy connectionStrategy =
+////			new DistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, 5d);
+//		SubSectStiffnessCalculator stiffnessCalc = new SubSectStiffnessCalculator(subSects, 2d, 3e4, 3e4, 0.5);
+//		Builder configBuilder = PlausibilityConfiguration.builder(connectionStrategy, subSects);
+////		configBuilder.maxNumClusters(2); // for connection only testing
+////		configBuilder.parentCoulomb(stiffnessCalc, StiffnessAggregationMethod.MEDIAN, 0f, Directionality.EITHER);
+//		configBuilder.cumulativeAzChange(560f);
+////		configBuilder.cumulativeRakeChange(180f);
+////		configBuilder.u3Azimuth();
+////		configBuilder.clusterCoulomb(stiffnessCalc, StiffnessAggregationMethod.MEDIAN, 0f);
 //		configBuilder.clusterPathCoulomb(stiffnessCalc, StiffnessAggregationMethod.MEDIAN, 0f);
-		configBuilder.maxSplays(0);
-		configBuilder.minSectsPerParent(2, true);
-		PlausibilityConfiguration config = configBuilder.build();
+//		configBuilder.maxSplays(0);
+//		configBuilder.minSectsPerParent(2, true);
+//		PlausibilityConfiguration config = configBuilder.build();
+//		ClusterPermutationStrategy permStrat = new UCERF3ClusterPermuationStrategy();
+////		ClusterPermutationStrategy permStrat = new ConnectionPointsPermutationStrategy();
 		
 		File cacheFile = new File("/tmp/dist_az_cache_"+fm.encodeChoiceString()+"_"+subSects.size()
 			+"_sects_"+parentSects.size()+"_parents.csv");
@@ -771,7 +782,7 @@ public class ClusterRuptureBuilder {
 //		int threads = 1;
 		System.out.println("Building ruptures with "+threads+" threads...");
 		Stopwatch watch = Stopwatch.createStarted();
-		List<ClusterRupture> rups = builder.build(new UCERF3ClusterPermuationStrategy(), threads);
+		List<ClusterRupture> rups = builder.build(permStrat, threads);
 		watch.stop();
 		double secs = watch.elapsed(TimeUnit.MILLISECONDS)/1000d;
 		double mins = (secs / 60d);

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRuptureBuilder.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRuptureBuilder.java
@@ -642,7 +642,7 @@ public class ClusterRuptureBuilder {
 		public CompareRupSetNewInclusionCriteria(FaultSystemRupSet rupSet) {
 			uniques = new HashSet<>();
 			for (List<Integer> rupSects : rupSet.getSectionIndicesForAllRups())
-				uniques.add(new UniqueRupture(rupSects));
+				uniques.add(UniqueRupture.forIDs(rupSects));
 		}
 
 		@Override
@@ -669,7 +669,7 @@ public class ClusterRuptureBuilder {
 		public CompareRupSetExclusionCriteria(FaultSystemRupSet rupSet) {
 			uniques = new HashSet<>();
 			for (List<Integer> rupSects : rupSet.getSectionIndicesForAllRups())
-				uniques.add(new UniqueRupture(rupSects));
+				uniques.add(UniqueRupture.forIDs(rupSects));
 		}
 
 		@Override
@@ -734,12 +734,13 @@ public class ClusterRuptureBuilder {
 			new DistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, 5d);
 		SubSectStiffnessCalculator stiffnessCalc = new SubSectStiffnessCalculator(subSects, 2d, 3e4, 3e4, 0.5);
 		Builder configBuilder = PlausibilityConfiguration.builder(connectionStrategy, subSects);
+		configBuilder.maxNumClusters(2); // for connection only testing
 		configBuilder.parentCoulomb(stiffnessCalc, StiffnessAggregationMethod.MEDIAN, 0f, Directionality.EITHER);
 		configBuilder.cumulativeAzChange(560f);
-//		configBuilder.cumulativeRakeChange(180f);
+		configBuilder.cumulativeRakeChange(180f);
 //		configBuilder.u3Azimuth();
 //		configBuilder.clusterCoulomb(stiffnessCalc, StiffnessAggregationMethod.MEDIAN, 0f);
-		configBuilder.clusterPathCoulomb(stiffnessCalc, StiffnessAggregationMethod.MEDIAN, 0f);
+//		configBuilder.clusterPathCoulomb(stiffnessCalc, StiffnessAggregationMethod.MEDIAN, 0f);
 		configBuilder.maxSplays(0);
 		configBuilder.minSectsPerParent(2, true);
 		PlausibilityConfiguration config = configBuilder.build();

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRuptureBuilder.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRuptureBuilder.java
@@ -2,14 +2,24 @@ package org.opensha.sha.earthquake.faultSysSolution.ruptures;
 
 import java.io.File;
 import java.io.IOException;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.dom4j.DocumentException;
+import org.opensha.commons.util.ExceptionUtils;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityConfiguration;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityConfiguration.Builder;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
-import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.CoulombJunctionFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.U3CoulombJunctionFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.ClusterCoulombCompatibilityFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.CumulativeAzimuthChangeFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.CumulativeRakeChangeFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.JumpAzimuthChangeFilter;
@@ -21,18 +31,23 @@ import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.U3
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.JumpAzimuthChangeFilter.AzimuthCalc;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterConnectionStrategy;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterPermutationStrategy;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.DistCutoffClosestSectClusterConnectionStrategy;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.UCERF3ClusterConnectionStrategy;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.UCERF3ClusterPermuationStrategy;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.UniqueRupture;
 import org.opensha.sha.faultSurface.FaultSection;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessAggregationMethod;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
 import com.google.common.primitives.Ints;
 
 import scratch.UCERF3.FaultSystemRupSet;
 import scratch.UCERF3.enumTreeBranches.DeformationModels;
 import scratch.UCERF3.enumTreeBranches.FaultModels;
+import scratch.UCERF3.inversion.SectionConnectionStrategy;
 import scratch.UCERF3.inversion.coulomb.CoulombRates;
 import scratch.UCERF3.inversion.coulomb.CoulombRatesTester;
 import scratch.UCERF3.inversion.coulomb.CoulombRatesTester.TestType;
@@ -55,58 +70,19 @@ public class ClusterRuptureBuilder {
 	private boolean stopAfterDebugMatch;
 	
 	/**
-	 * Constructor which builds clusters from the given parent sections
-	 * @param subSections sub section list
-	 * @param connectionStrategy connection strategy which defines cluster connection points
-	 * @param distAzCalc distance/azimuth calculator
-	 * @param filters list of plausibility filters
-	 * @param maxNumSplays the maximum number of splays per rupture (use 0 to disable splays)
-	 */
-	public ClusterRuptureBuilder(List<? extends FaultSection> subSections,
-			ClusterConnectionStrategy connectionStrategy, SectionDistanceAzimuthCalculator distAzCalc,
-			List<PlausibilityFilter> filters, int maxNumSplays) {
-		this(buildClusters(subSections, connectionStrategy, distAzCalc), filters, maxNumSplays);
-	}
-	
-	/**
+	 * Constructor which gets everything from the PlausibilityConfiguration
 	 * 
-	 * @param subSections sub section list
-	 * @param connectionStrategy connection strategy which defines cluster connection points
-	 * @param distAzCalc distance/azimuth calculator
-	 * @return Cluster list (with connections added) binned by parent-section ID
+	 * @param configuration plausibilty configuration
 	 */
-	public static List<FaultSubsectionCluster> buildClusters(List<? extends FaultSection> subSections,
-			ClusterConnectionStrategy connectionStrategy, SectionDistanceAzimuthCalculator distAzCalc) {
-		List<FaultSubsectionCluster> clusters = new ArrayList<>();
-		
-		List<FaultSection> curClusterSects = null;
-		int curParentID = -1;
-		
-		for (FaultSection subSect : subSections) {
-			int parentID = subSect.getParentSectionId();
-			Preconditions.checkState(parentID >= 0,
-					"Subsections are required, but this section doesn't have a parent ID set: %s. %s",
-					subSect.getSectionId(), subSect.getSectionName());
-			if (parentID != curParentID) {
-				if (curClusterSects != null)
-					clusters.add(new FaultSubsectionCluster(curClusterSects));
-				curParentID = parentID;
-				curClusterSects = new ArrayList<>();
-			}
-			curClusterSects.add(subSect);
-		}
-		clusters.add(new FaultSubsectionCluster(curClusterSects));
-		System.out.println("Building connections for "+subSections.size()
-			+" subsections on "+clusters.size()+" parent sections");
-		int count = connectionStrategy.addConnections(clusters, distAzCalc);
-		System.out.println("Found "+count+" possible section connections");
-		
-		return clusters;
+	public ClusterRuptureBuilder(PlausibilityConfiguration configuration) {
+		this(configuration.getConnectionStrategy().getClusters(), configuration.getFilters(),
+				configuration.getMaxNumSplays());
 	}
 	
 	/**
 	 * Constructor which uses previously built clusters (with connections added)
-	 * @param clusters list of clusters
+	 * 
+	 * @param clusters list of clusters (with connections added)
 	 * @param filters list of plausibility filters
 	 * @param maxNumSplays the maximum number of splays per rupture (use 0 to disable splays)
 	 */
@@ -140,11 +116,125 @@ public class ClusterRuptureBuilder {
 	 * @return list of unique ruptures which were build
 	 */
 	public List<ClusterRupture> build(ClusterPermutationStrategy permutationStrategy) {
+		return build(permutationStrategy, 1);
+	}
+	
+	/**
+	 * This builds ruptures using the given cluster permutation strategy with the given number of threads
+	 * 
+	 * @param permutationStrategy strategy for determining unique & viable subsection permutations 
+	 * for each cluster 
+	 * @param numThreads
+	 * @return list of unique ruptures which were build
+	 */
+	public List<ClusterRupture> build(ClusterPermutationStrategy permutationStrategy, int numThreads) {
 		List<ClusterRupture> rups = new ArrayList<>();
 		HashSet<UniqueRupture> uniques = new HashSet<>();
 		largestRup = 0;
 		
-		for (FaultSubsectionCluster cluster : clusters) {
+		if (numThreads <= 1) {
+			for (FaultSubsectionCluster cluster : clusters) {
+				ClusterBuildCallable build = new ClusterBuildCallable(permutationStrategy, cluster, uniques);
+				try {
+					build.call();
+				} catch (Exception e) {
+					throw ExceptionUtils.asRuntimeException(e);
+				}
+				build.merge(rups);
+				if (build.debugStop)
+					break;
+//				for (FaultSection startSection : cluster.subSects) {
+//					for (FaultSubsectionCluster permutation : permutationStrategy.getPermutations(
+//							cluster, startSection)) {
+//						ClusterRupture rup = new ClusterRupture(permutation);
+//						PlausibilityResult result = testRup(rup, false);
+//						if (debugCriteria != null && debugCriteria.isMatch(rup)
+//								&& debugCriteria.appliesTo(result)) {
+//							System.out.println("\tPermutation "+permutation+" result="+result);
+//							testRup(rup, true);
+//							if (stopAfterDebugMatch) {
+//								return rups;
+//							}
+//						}
+//						if (!result.canContinue())
+//							// stop building here
+//							continue;
+//						if (result.isPass()) {
+//							// passes as is, add it if it's new
+//							if (!uniques.contains(rup.unique)) {
+//								rups.add(rup);
+//								uniques.add(rup.unique); // will add in merge below
+//								int count = rup.getTotalNumSects();
+//								if (count > largestRup) {
+//									largestRup = count;
+//									if (largestRup % largestRupPrintMod == 0)
+//										System.out.println("\tNew largest rup has "+largestRup
+//												+" subsections with "+rup.getTotalNumJumps()+" jumps and "
+//												+rup.splays.size()+" splays. "+rups.size()+" rups in total");
+//								}
+//							}
+//						}
+//						// continue to build this rupture
+//						boolean canContinue = addRuptures(rups, uniques, rup, rup, 
+//								result.isPass(), permutationStrategy);
+//						if (!canContinue) {
+//							System.out.println("Stopping due to debug criteria match with "+rups.size()+" ruptures");
+//							return rups;
+//						}
+//					}
+//				}
+			}
+		} else {
+			// multi threaded
+			ExecutorService exec = Executors.newFixedThreadPool(numThreads);
+			
+			List<Future<ClusterBuildCallable>> futures = new ArrayList<>();
+			
+			for (FaultSubsectionCluster cluster : clusters) {
+				ClusterBuildCallable build = new ClusterBuildCallable(permutationStrategy, cluster, uniques);
+				futures.add(exec.submit(build));
+			}
+			
+			System.out.println("Waiting on "+futures.size()+" cluster build futures");
+			for (Future<ClusterBuildCallable> future : futures) {
+				ClusterBuildCallable build;
+				try {
+					build = future.get();
+				} catch (Exception e) {
+					throw ExceptionUtils.asRuntimeException(e);
+				}
+				build.merge(rups);
+				if (build.debugStop) {
+					exec.shutdownNow();
+					break;
+				}
+			}
+			
+			exec.shutdown();
+		}
+		
+		
+		return rups;
+	}
+	
+	private class ClusterBuildCallable implements Callable<ClusterBuildCallable> {
+		
+		private ClusterPermutationStrategy permutationStrategy;
+		private FaultSubsectionCluster cluster;
+		private HashSet<UniqueRupture> uniques;
+		private List<ClusterRupture> rups;
+		private boolean debugStop = false;
+
+		public ClusterBuildCallable(ClusterPermutationStrategy permutationStrategy,
+				FaultSubsectionCluster cluster, HashSet<UniqueRupture> uniques) {
+			this.permutationStrategy = permutationStrategy;
+			this.cluster = cluster;
+			this.uniques = uniques;
+		}
+
+		@Override
+		public ClusterBuildCallable call() throws Exception {
+			this.rups = new ArrayList<>();
 			for (FaultSection startSection : cluster.subSects) {
 				for (FaultSubsectionCluster permutation : permutationStrategy.getPermutations(
 						cluster, startSection)) {
@@ -154,8 +244,10 @@ public class ClusterRuptureBuilder {
 							&& debugCriteria.appliesTo(result)) {
 						System.out.println("\tPermutation "+permutation+" result="+result);
 						testRup(rup, true);
-						if (stopAfterDebugMatch)
-							return rups;
+						if (stopAfterDebugMatch) {
+							debugStop = true;
+							return this;
+						}
 					}
 					if (!result.canContinue())
 						// stop building here
@@ -164,7 +256,7 @@ public class ClusterRuptureBuilder {
 						// passes as is, add it if it's new
 						if (!uniques.contains(rup.unique)) {
 							rups.add(rup);
-							uniques.add(rup.unique);
+//							uniques.add(rup.unique); // will add in merge below
 							int count = rup.getTotalNumSects();
 							if (count > largestRup) {
 								largestRup = count;
@@ -180,15 +272,28 @@ public class ClusterRuptureBuilder {
 							result.isPass(), permutationStrategy);
 					if (!canContinue) {
 						System.out.println("Stopping due to debug criteria match with "+rups.size()+" ruptures");
-						return rups;
+						debugStop = true;
+						return this;
 					}
 				}
 			}
-			System.out.println("Have "+rups.size()+" ruptures after processing cluster "
-					+cluster.parentSectionID+": "+cluster.parentSectionName);
+			return this;
 		}
 		
-		return rups;
+		public void merge(List<ClusterRupture> masterRups) {
+			int added = 0;
+			for (ClusterRupture rup : rups) {
+				if (!uniques.contains(rup.unique)) {
+					masterRups.add(rup);
+					uniques.add(rup.unique);
+					added++;
+				}
+			}
+			System.out.println("Have "+masterRups.size()+" ruptures after processing cluster "
+					+cluster.parentSectionID+": "+cluster.parentSectionName
+					+" ("+added+" new, "+rups.size()+" incl. possible duplicates)");
+		}
+		
 	}
 	
 	private PlausibilityResult testRup(ClusterRupture rupture, final boolean debug) {
@@ -263,7 +368,7 @@ public class ClusterRuptureBuilder {
 			ClusterRupture currentStrand, boolean testJumpOnly, ClusterPermutationStrategy permutationStrategy, Jump jump) {
 		Preconditions.checkNotNull(jump);
 		for (FaultSubsectionCluster permutation : permutationStrategy.getPermutations(
-				jump.toCluster, jump.toSection)) {
+				currentRupture, jump.toCluster, jump.toSection)) {
 			boolean hasLoopback = false;
 			for (FaultSection sect : permutation.subSects) {
 				if (currentRupture.contains(sect)) {
@@ -310,7 +415,7 @@ public class ClusterRuptureBuilder {
 				// passes as is, add it if it's new
 				if (!uniques.contains(candidateRupture.unique)) {
 					rups.add(candidateRupture);
-					uniques.add(candidateRupture.unique);
+//					uniques.add(candidateRupture.unique); // now merged in later
 				}
 				int count = candidateRupture.getTotalNumSects();
 				if (count > largestRup) {
@@ -606,11 +711,34 @@ public class ClusterRuptureBuilder {
 //		RupDebugCriteria debugCriteria = new SectsRupDebugCriteria(false, false,
 //				loadRupString(rupStr, false));
 //		boolean stopAfterDebug = true;
-		
-		CoulombRates coulombRates = CoulombRates.loadUCERF3CoulombRates(fm);
-		ClusterConnectionStrategy connectionStrategy = new UCERF3ClusterConnectionStrategy(5d, coulombRates);
-//		ClusterConnectionStrategy connectionStrategy = new DistCutoffSingleConnectionClusterConnectionStrategy(5d);
+
 		SectionDistanceAzimuthCalculator distAzCalc = new SectionDistanceAzimuthCalculator(subSects);
+		
+		/*
+		 * To reproduce UCERF3
+		 */
+//		PlausibilityConfiguration config = PlausibilityConfiguration.getUCERF3(subSects, distAzCalc, fm);
+		
+		/*
+		 * For other experiements
+		 */
+		// the exact same connections as UCERF3
+//		ClusterConnectionStrategy connectionStrategy =
+//				new UCERF3ClusterConnectionStrategy(subSects,
+//						distAzCalc, 5d, CoulombRates.loadUCERF3CoulombRates(fm));
+		ClusterConnectionStrategy connectionStrategy =
+			new DistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, 5d);
+		Builder configBuilder = PlausibilityConfiguration.builder(connectionStrategy, subSects);
+		configBuilder.cumulativeAzChange(560f);
+		configBuilder.cumulativeRakeChange(180f);
+//		configBuilder.u3Azimuth();
+		SubSectStiffnessCalculator stiffnessCalc = new SubSectStiffnessCalculator(subSects, 2d, 3e4, 3e4, 0.5);
+//		configBuilder.clusterCoulomb(stiffnessCalc, StiffnessAggregationMethod.MEDIAN, 0f);
+		configBuilder.clusterPathCoulomb(stiffnessCalc, StiffnessAggregationMethod.MEDIAN, 0f);
+		configBuilder.maxSplays(0);
+		configBuilder.minSectsPerParent(2, true);
+		PlausibilityConfiguration config = configBuilder.build();
+		
 		File cacheFile = new File("/tmp/dist_az_cache_"+fm.encodeChoiceString()+"_"+subSects.size()
 			+"_sects_"+parentSects.size()+"_parents.csv");
 		if (cacheFile.exists()) {
@@ -619,7 +747,7 @@ public class ClusterRuptureBuilder {
 		}
 		int numAzCached = distAzCalc.getCachedAzimuths().size();
 		int numDistCached = distAzCalc.getCachedDistances().size();
-		List<FaultSubsectionCluster> clusters = buildClusters(subSects, connectionStrategy, distAzCalc);
+		config.getConnectionStrategy().getClusters();
 		if (numAzCached < distAzCalc.getCachedAzimuths().size()
 				|| numDistCached < distAzCalc.getCachedDistances().size()) {
 			System.out.println("Writing dist/az cache to "+cacheFile.getAbsolutePath());
@@ -628,32 +756,22 @@ public class ClusterRuptureBuilder {
 			numDistCached = distAzCalc.getCachedDistances().size();
 		}
 		
-		List<PlausibilityFilter> filters = new ArrayList<>();
-		AzimuthCalc u3AzCalc = new JumpAzimuthChangeFilter.UCERF3LeftLateralFlipAzimuthCalc(distAzCalc);
-		filters.add(new JumpAzimuthChangeFilter(u3AzCalc, 60f));
-		filters.add(new TotalAzimuthChangeFilter(u3AzCalc, 60f, true, true));
-		filters.add(new CumulativeAzimuthChangeFilter(
-				new JumpAzimuthChangeFilter.SimpleAzimuthCalc(distAzCalc), 560f));
-//		filters.add(new CumulativeRakeChangeFilter(180f));
-//		filters.add(new JumpCumulativeRakeChangeFilter(180f));
-		filters.add(new U3CompatibleCumulativeRakeChangeFilter(180d));
-		filters.add(new MinSectsPerParentFilter(2, true, clusters));
-		CoulombRatesTester coulombTester = new CoulombRatesTester(
-				TestType.COULOMB_STRESS, 0.04, 0.04, 1.25d, true, true);
-		filters.add(new CoulombJunctionFilter(coulombTester, coulombRates));
-		
-		int maxNumSplays = 0;
-		if (maxNumSplays > 0)
-			filters.add(new SplayLengthFilter(0.2, true, maxNumSplays > 1));
-		
-		ClusterRuptureBuilder builder = new ClusterRuptureBuilder(clusters, filters, maxNumSplays);
+		ClusterRuptureBuilder builder = new ClusterRuptureBuilder(config);
 		
 		if (debugCriteria != null)
 			builder.setDebugCriteria(debugCriteria, stopAfterDebug);
 		
-		System.out.println("Building ruptures...");
-		List<ClusterRupture> rups = builder.build(new UCERF3ClusterPermuationStrategy());
-		System.out.println("Built "+rups.size()+" ruptures");
+		int threads = Runtime.getRuntime().availableProcessors();
+//		int threads = 1;
+		System.out.println("Building ruptures with "+threads+" threads...");
+		Stopwatch watch = Stopwatch.createStarted();
+		List<ClusterRupture> rups = builder.build(new UCERF3ClusterPermuationStrategy(), threads);
+		watch.stop();
+		double secs = watch.elapsed(TimeUnit.MILLISECONDS)/1000d;
+		double mins = (secs / 60d);
+		DecimalFormat timeDF = new DecimalFormat("0.00");
+		System.out.println("Built "+rups.size()+" ruptures in "+timeDF.format(secs)
+			+" secs = "+timeDF.format(mins)+" mins");
 		
 		if (debugCriteria == null || !stopAfterDebug) {
 			// write out test rup set
@@ -673,6 +791,7 @@ public class ClusterRuptureBuilder {
 			}
 			FaultSystemRupSet rupSet = new FaultSystemRupSet(subSects, null, null, null, 
 				sectionForRups, mags, rakes, rupAreas, null, "");
+			rupSet.setPlausibilityConfiguration(config);
 			FaultSystemIO.writeRupSet(rupSet, new File("/tmp/test_rup_set.zip"));
 		}
 

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/FaultSubsectionCluster.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/FaultSubsectionCluster.java
@@ -92,7 +92,8 @@ public class FaultSubsectionCluster implements Comparable<FaultSubsectionCluster
 				parentSectionID = subSect.getParentSectionId();
 				parentSectionName = subSect.getParentSectionName();
 			} else {
-				Preconditions.checkState(subSect.getParentSectionId() == parentSectionID);
+				Preconditions.checkState(subSect.getParentSectionId() == parentSectionID,
+						"Cluster subSects list has sedctios with multiple parentSectionIDs");
 			}
 		}
 		this.parentSectionID = parentSectionID;
@@ -190,6 +191,40 @@ public class FaultSubsectionCluster implements Comparable<FaultSubsectionCluster
 				return cmp;
 		}
 		return 0;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((endSects == null) ? 0 : endSects.hashCode());
+		result = prime * result + parentSectionID;
+		result = prime * result + ((subSects == null) ? 0 : subSects.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		FaultSubsectionCluster other = (FaultSubsectionCluster) obj;
+		if (endSects == null) {
+			if (other.endSects != null)
+				return false;
+		} else if (!endSects.equals(other.endSects))
+			return false;
+		if (parentSectionID != other.parentSectionID)
+			return false;
+		if (subSects == null) {
+			if (other.subSects != null)
+				return false;
+		} else if (!subSects.equals(other.subSects))
+			return false;
+		return true;
 	}
 
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/PlausibilityConfiguration.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/PlausibilityConfiguration.java
@@ -1,0 +1,615 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.opensha.commons.util.ExceptionUtils;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter.PlausibilityFilterTypeAdapter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.ClusterCoulombCompatibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.ClusterPathCoulombCompatibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.CumulativeAzimuthChangeFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.CumulativeRakeChangeFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.JumpAzimuthChangeFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.JumpAzimuthChangeFilter.AzimuthCalc;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.MinSectsPerParentFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.SplayLengthFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.TotalAzimuthChangeFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.U3CompatibleCumulativeRakeChangeFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.U3CoulombJunctionFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterConnectionStrategy;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterConnectionStrategy.ConnStratTypeAdapter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.DistCutoffClosestSectClusterConnectionStrategy;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.UCERF3ClusterConnectionStrategy;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
+import org.opensha.sha.faultSurface.FaultSection;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessAggregationMethod;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import scratch.UCERF3.enumTreeBranches.DeformationModels;
+import scratch.UCERF3.enumTreeBranches.FaultModels;
+import scratch.UCERF3.inversion.coulomb.CoulombRates;
+import scratch.UCERF3.inversion.coulomb.CoulombRatesTester;
+import scratch.UCERF3.inversion.coulomb.CoulombRatesTester.TestType;
+import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
+import scratch.UCERF3.utils.DeformationModelFetcher;
+
+public class PlausibilityConfiguration {
+	
+	public static PlausibilityConfiguration getUCERF3(
+			List<? extends FaultSection> subSects, SectionDistanceAzimuthCalculator distAzCalc,
+			FaultModels fm) throws IOException {
+		return getUCERF3(subSects, distAzCalc, CoulombRates.loadUCERF3CoulombRates(fm));
+	}
+	
+	public static PlausibilityConfiguration getUCERF3(
+			List<? extends FaultSection> subSects, SectionDistanceAzimuthCalculator distAzCalc,
+			CoulombRates coulombRates) {
+		ClusterConnectionStrategy connectionStrategy = new UCERF3ClusterConnectionStrategy(
+				subSects, distAzCalc, 5d, coulombRates);
+		return builder(connectionStrategy, distAzCalc).maxSplays(0).u3All(coulombRates).build();
+	}
+	
+	private List<PlausibilityFilter> filters;
+	private int maxNumSplays;
+	private ClusterConnectionStrategy connectionStrategy;
+	private SectionDistanceAzimuthCalculator distAzCalc;
+
+	public PlausibilityConfiguration(List<PlausibilityFilter> filters, int maxNumSplays,
+			ClusterConnectionStrategy connectionStrategy, SectionDistanceAzimuthCalculator distAzCalc) {
+		this.filters = filters;
+		this.maxNumSplays = maxNumSplays;
+		this.connectionStrategy = connectionStrategy;
+		this.distAzCalc = distAzCalc;
+	}
+	
+	public List<PlausibilityFilter> getFilters() {
+		return filters;
+	}
+
+	public int getMaxNumSplays() {
+		return maxNumSplays;
+	}
+
+	public ClusterConnectionStrategy getConnectionStrategy() {
+		return connectionStrategy;
+	}
+
+	public SectionDistanceAzimuthCalculator getDistAzCalc() {
+		return distAzCalc;
+	}
+	
+	/*
+	 * Builder for convenience
+	 */
+
+	public static class Builder {
+		
+		private ClusterConnectionStrategy connectionStrategy;
+		private SectionDistanceAzimuthCalculator distAzCalc;
+		private int maxSplays;
+		private List<PlausibilityFilter> filters;
+
+		private Builder(ClusterConnectionStrategy connectionStrategy,
+				SectionDistanceAzimuthCalculator distAzCalc) {
+			this.connectionStrategy = connectionStrategy;
+			this.distAzCalc = distAzCalc;
+			this.maxSplays = 0;
+			this.filters = new ArrayList<>();
+		}
+		
+		public Builder maxSplays(int maxSplays) {
+			this.maxSplays = maxSplays;
+			return this;
+		}
+		
+		public Builder add(PlausibilityFilter filter) {
+			this.filters.add(filter);
+			return this;
+		}
+		
+		/**
+		 * Adds all UCERF3 plausibility filters
+		 * @param coulombRates
+		 * @return
+		 */
+		public Builder u3All(CoulombRates coulombRates) {
+			u3Azimuth();
+			u3Cumulatives();
+			minSectsPerParent(2, true);
+			u3Coulomb(coulombRates);
+			return this;
+		}
+		
+		/**
+		 * Adds the UCERF3 jump and total (start-to-end, not cumulative) azimuth change filters
+		 * @return
+		 */
+		public Builder u3Azimuth() {
+			AzimuthCalc u3AzCalc = new JumpAzimuthChangeFilter.UCERF3LeftLateralFlipAzimuthCalc(distAzCalc);
+			filters.add(new JumpAzimuthChangeFilter(u3AzCalc, 60f));
+			filters.add(new TotalAzimuthChangeFilter(u3AzCalc, 60f, true, true));
+			return this;
+		}
+		
+		/**
+		 * Adds the UCERF3 cumulative azimuth and rake filters. Note that the latter suffers from
+		 * floating point precision issues and should not be used unless reproducing UCERF3 exactly
+		 * @return
+		 */
+		public Builder u3Cumulatives() {
+			cumulativeAzChange(new JumpAzimuthChangeFilter.SimpleAzimuthCalc(distAzCalc), 560f);
+			filters.add(new U3CompatibleCumulativeRakeChangeFilter(180d));
+			return this;
+		}
+		
+		public Builder u3Coulomb(CoulombRates coulombRates) {
+			CoulombRatesTester coulombTester = new CoulombRatesTester(
+					TestType.COULOMB_STRESS, 0.04, 0.04, 1.25d, true, true);
+			filters.add(new U3CoulombJunctionFilter(coulombTester, coulombRates));
+			return this;
+		}
+		
+		public Builder minSectsPerParent(int minPerParent, boolean allowIfNoDirect) {
+			filters.add(new MinSectsPerParentFilter(minPerParent, allowIfNoDirect, connectionStrategy));
+			return this;
+		}
+		
+		public Builder clusterCoulomb(SubSectStiffnessCalculator subSectCalc,
+				StiffnessAggregationMethod aggMethod, float threshold) {
+			filters.add(new ClusterCoulombCompatibilityFilter(subSectCalc, aggMethod, threshold));
+			return this;
+		}
+		
+		public Builder clusterPathCoulomb(SubSectStiffnessCalculator subSectCalc,
+				StiffnessAggregationMethod aggMethod, float threshold) {
+			filters.add(new ClusterPathCoulombCompatibilityFilter(subSectCalc, aggMethod, threshold));
+			return this;
+		}
+		
+		public Builder cumulativeRakeChange(float threshold) {
+			filters.add(new CumulativeRakeChangeFilter(threshold));
+			return this;
+		}
+		
+		public Builder cumulativeAzChange(float threshold) {
+			return cumulativeAzChange(new JumpAzimuthChangeFilter.SimpleAzimuthCalc(distAzCalc), threshold);
+		}
+		
+		public Builder cumulativeAzChange(AzimuthCalc azCalc, float threshold) {
+			filters.add(new CumulativeAzimuthChangeFilter(azCalc, threshold));
+			return this;
+		}
+		
+		public Builder jumpAzChange(AzimuthCalc azCalc, float threshold) {
+			filters.add(new JumpAzimuthChangeFilter(azCalc, threshold));
+			return this;
+		}
+		
+		public Builder totAzChange(AzimuthCalc azCalc, float threshold, boolean multiFaultOnly,
+				boolean testFullEnd) {
+			filters.add(new TotalAzimuthChangeFilter(azCalc, threshold, multiFaultOnly, testFullEnd));
+			return this;
+		}
+		
+		/**
+		 * 
+		 * @param maxLen maximum splay length
+		 * @param isFractOfMain if true, maxLen is a fractional length of the primary rupture
+		 * @param totalAcrossSplays if true, maxLen is applied as a sum of all splays
+		 */
+		public Builder splayLength(double maxLen, boolean isFractOfMain, boolean totalAcrossSplays) {
+			filters.add(new SplayLengthFilter(maxLen, isFractOfMain, totalAcrossSplays));
+			return this;
+		}
+		
+		public PlausibilityConfiguration build() {
+			return new PlausibilityConfiguration(filters, maxSplays, connectionStrategy, distAzCalc);
+		}
+	}
+	
+	public static Builder builder(ClusterConnectionStrategy connectionStrategy,
+			SectionDistanceAzimuthCalculator distAzCalc) {
+		return new Builder(connectionStrategy, distAzCalc);
+	}
+	
+	public static Builder builder(ClusterConnectionStrategy connectionStrategy,
+			List<? extends FaultSection> subSects) {
+		return new Builder(connectionStrategy, new SectionDistanceAzimuthCalculator(subSects));
+	}
+	
+	/*
+	 * JSON [de]serialization
+	 */
+	
+	public String toJSON() {
+		Gson gson = buildGson(connectionStrategy.getSubSections());
+		return gson.toJson(this);
+	}
+	
+	public void writeJSON(File jsonFile) throws IOException {
+		FileWriter fw = new FileWriter(jsonFile);
+		fw.write(toJSON());
+		fw.write("\n");
+		fw.close();
+	}
+	
+	public static PlausibilityConfiguration readJSON(File jsonFile, List<? extends FaultSection> subSects)
+			throws IOException {
+		BufferedReader reader = new BufferedReader(new FileReader(jsonFile));
+		return readJSON(reader, subSects);
+	}
+	
+	public static PlausibilityConfiguration readJSON(String json, List<? extends FaultSection> subSects) {
+		return readJSON(new StringReader(json), subSects);
+	}
+	
+	public static PlausibilityConfiguration readJSON(Reader json, List<? extends FaultSection> subSects) {
+		Gson gson = buildGson(subSects);
+		PlausibilityConfiguration conf = gson.fromJson(json, PlausibilityConfiguration.class);
+		try {
+			json.close();
+		} catch (IOException e) {}
+		return conf;
+	}
+	
+	private static Gson buildGson(List<? extends FaultSection> subSects) {
+		GsonBuilder builder = new GsonBuilder();
+		builder.setPrettyPrinting();
+
+		ConnStratTypeAdapter connStratAdapter = new ConnStratTypeAdapter(subSects);
+		builder.registerTypeHierarchyAdapter(ClusterConnectionStrategy.class, connStratAdapter);
+		builder.registerTypeHierarchyAdapter(FaultSection.class, new FaultSectTypeAdapter(subSects));
+		DistAzCalcTypeAdapter distAzAdapter = new DistAzCalcTypeAdapter(
+				new SectionDistanceAzimuthCalculator(subSects));
+		builder.registerTypeAdapter(SectionDistanceAzimuthCalculator.class, distAzAdapter);
+		PlausibilityConfigTypeAdapter configAdapter = new PlausibilityConfigTypeAdapter(
+				connStratAdapter, distAzAdapter);
+		builder.registerTypeAdapter(PlausibilityConfiguration.class, configAdapter);
+		builder.registerTypeAdapter(AzimuthCalc.class,
+				new JumpAzimuthChangeFilter.AzimuthCalcTypeAdapter(distAzAdapter.distAzCalc));
+		Gson gson = builder.create();
+		configAdapter.setGson(gson);
+		
+		return gson;
+	}
+	
+	
+	
+	private static class PlausibilityConfigTypeAdapter extends TypeAdapter<PlausibilityConfiguration> {
+
+		private ConnStratTypeAdapter connStratAdapter;
+		private DistAzCalcTypeAdapter distAzAdapter;
+		private Gson gson;
+
+		public PlausibilityConfigTypeAdapter(ConnStratTypeAdapter connStratAdapter,
+				DistAzCalcTypeAdapter distAzAdapter) {
+			this.connStratAdapter = connStratAdapter;
+			this.distAzAdapter = distAzAdapter;
+		}
+		
+		public void setGson(Gson gson) {
+			this.gson = gson;
+		}
+
+		@Override
+		public void write(JsonWriter out, PlausibilityConfiguration config) throws IOException {
+			out.beginObject();
+			
+			out.name("connectionStrategy");
+			connStratAdapter.write(out, config.getConnectionStrategy());
+			out.name("maxNumSplays").value(config.getMaxNumSplays());
+			out.name("filters").beginArray(); // [
+			for (PlausibilityFilter filter : config.getFilters()) {
+				out.beginObject(); // {
+				
+				out.name("name").value(filter.getName());
+				out.name("shortName").value(filter.getShortName());
+				out.name("class").value(filter.getClass().getName());
+				TypeAdapter<PlausibilityFilter> adapter = filter.getTypeAdapter();
+				if (adapter == null) {
+					// use default Gson serialization
+					out.name("filter");
+					gson.toJson(filter, filter.getClass(), out);
+				} else {
+					if (adapter instanceof PlausibilityFilterTypeAdapter) {
+						PlausibilityFilterTypeAdapter pAdapt = (PlausibilityFilterTypeAdapter)adapter;
+						pAdapt.init(config.getConnectionStrategy(), config.getDistAzCalc());
+					}
+					out.name("adapter").value(adapter.getClass().getName());
+					out.name("filter");
+					adapter.write(out, filter);
+				}
+				
+				out.endObject(); // }
+			}
+			out.endArray(); // ]
+			
+			out.endObject();
+		}
+
+		@Override
+		public PlausibilityConfiguration read(JsonReader in) throws IOException {
+			in.beginObject();
+			
+			Integer maxNumSplays = null;
+			ClusterConnectionStrategy connectionStrategy = null;
+			List<PlausibilityFilter> filters = null;
+			
+			while (in.hasNext()) {
+				switch (in.nextName()) {
+				case "connectionStrategy":
+					connectionStrategy = connStratAdapter.read(in);
+					break;
+				case "maxNumSplays":
+					maxNumSplays = in.nextInt();
+					break;
+				case "filters":
+					Preconditions.checkNotNull(connectionStrategy,
+							"Connection strategy must be before filters in JSON");
+					filters = loadFilters(in, connectionStrategy, distAzAdapter.distAzCalc);
+					break;
+
+				default:
+					break;
+				}
+			}
+			
+			in.endObject();
+			return new PlausibilityConfiguration(filters, maxNumSplays,
+					connectionStrategy, distAzAdapter.distAzCalc);
+		}
+		
+		private List<PlausibilityFilter> loadFilters(
+				JsonReader in, ClusterConnectionStrategy connectionStrategy,
+				SectionDistanceAzimuthCalculator distAzCalc) throws IOException {
+			List<PlausibilityFilter> filters = new ArrayList<>();
+			
+			in.beginArray();
+			
+			while (in.hasNext()) {
+				Class<PlausibilityFilter> type = null;
+				TypeAdapter<PlausibilityFilter> adapter = null;
+				PlausibilityFilter filter = null;
+				String name = null;
+				String shortName = null;
+				
+				in.beginObject();
+				
+				while (in.hasNext()) {
+					switch (in.nextName()) {
+					case "class":
+						type = getDeclaredTypeClass(in.nextString());
+//						System.out.println("new class at "+in.getPath()+": "+type);
+						break;
+					case "adapter":
+						Preconditions.checkState(filter == null, "adapter must be before filter in JSON");
+						Class<TypeAdapter<PlausibilityFilter>> adapterClass =
+							getDeclaredTypeClass(in.nextString());
+						try {
+							Constructor<TypeAdapter<PlausibilityFilter>> constructor = adapterClass.getConstructor();
+							adapter = constructor.newInstance();
+						} catch (Exception e) {
+							throw ExceptionUtils.asRuntimeException(e);
+						}
+						if (adapter instanceof PlausibilityFilterTypeAdapter)
+							((PlausibilityFilterTypeAdapter)adapter).init(connectionStrategy, distAzCalc);
+						break;
+					case "name":
+						name = in.nextString();
+						break;
+					case "shortName":
+						shortName = in.nextString();
+						break;
+					case "filter":
+						Preconditions.checkNotNull(type, "filter must be last in json object");
+						if (adapter == null) {
+							String startPath = in.getPath();
+							try {
+								// use Gson default
+								filter = gson.fromJson(in, type);
+							} catch (Exception e) {
+								e.printStackTrace();
+								System.err.println("Warning: couldn't de-serialize filter "
+										+ "(using stub instead): "+type.getName());
+								System.err.flush();
+//								System.out.println("PATH after read: "+in.getPath());
+								filter = new PlausibilityFilterStub(name, shortName);
+								// this is where it gets tricky. we have descended into the filter object
+								// and need to back the reader out
+//								System.out.println("Looking to back out to: "+startPath);
+								while (true) {
+									String path = in.getPath();
+									JsonToken peek = in.peek();
+									if (peek == JsonToken.END_OBJECT && path.equals(startPath)) {
+										// we're ready to break
+//										System.out.println("DONE, new path: "+in.getPath());
+										break;
+									}
+//									System.out.println("Still in the thick of it at: "+path);
+									if (peek == JsonToken.END_ARRAY) {
+//										System.out.println("\tending array");
+										in.endArray();
+									} else if (peek == JsonToken.END_OBJECT) {
+//										System.out.println("\tending object");
+										in.endObject();
+									} else {
+//										System.out.println("\tskipping "+peek);
+										in.skipValue();
+									}
+								}
+							}
+						} else {
+							// use specified adapter
+							filter = adapter.read(in);
+						}
+						break;
+
+					default:
+						break;
+					}
+				}
+				
+				Preconditions.checkNotNull(filter, "Filter not found in JSON object");
+				filters.add(filter);
+				
+				in.endObject();
+			}
+			
+			in.endArray();
+			
+			return filters;
+		}
+		
+		@SuppressWarnings("unchecked")
+		private <T> Class<T> getDeclaredTypeClass(String className) {
+			Class<?> raw;
+			try {
+				raw = Class.forName(className);
+			} catch (ClassNotFoundException e) {
+				throw ExceptionUtils.asRuntimeException(e);
+			}
+			return (Class<T>)raw;
+		}
+		
+	}
+	
+	private static class PlausibilityFilterStub implements PlausibilityFilter {
+		
+		private String name;
+		private String shortName;
+
+		public PlausibilityFilterStub(String name, String shortName) {
+			this.name = name;
+			this.shortName = shortName;
+		}
+
+		@Override
+		public String getShortName() {
+			return name;
+		}
+
+		@Override
+		public String getName() {
+			return shortName;
+		}
+
+		@Override
+		public PlausibilityResult apply(ClusterRupture rupture, boolean verbose) {
+			throw new UnsupportedOperationException(getShortName()+" could not be deserialized from "
+					+ "JSON and cannot be used for filtering");
+		}
+
+		@Override
+		public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
+			throw new UnsupportedOperationException(getShortName()+" could not be deserialized from "
+					+ "JSON and cannot be used for filtering");
+		}
+		
+	}
+	
+	private static class FaultSectTypeAdapter extends TypeAdapter<FaultSection> {
+
+		private List<? extends FaultSection> subSects;
+		
+		public FaultSectTypeAdapter(List<? extends FaultSection> subSects) {
+			this.subSects = subSects;
+		}
+		
+		@Override
+		public void write(JsonWriter out, FaultSection value) throws IOException {
+			out.value(value.getSectionId());
+		}
+
+		@Override
+		public FaultSection read(JsonReader in) throws IOException {
+			int id = in.nextInt();
+			return subSects.get(id);
+		}
+		
+	}
+	
+	private static class DistAzCalcTypeAdapter extends TypeAdapter<SectionDistanceAzimuthCalculator> {
+		
+		private SectionDistanceAzimuthCalculator distAzCalc;
+
+		public DistAzCalcTypeAdapter(SectionDistanceAzimuthCalculator distAzCalc) {
+			Preconditions.checkNotNull(distAzCalc);
+			this.distAzCalc = distAzCalc;
+		}
+
+		@Override
+		public void write(JsonWriter out, SectionDistanceAzimuthCalculator value) throws IOException {
+			out.beginObject();
+			out.name("numSects").value(value.getSubSections().size());
+			out.endObject();
+		}
+
+		@Override
+		public SectionDistanceAzimuthCalculator read(JsonReader in) throws IOException {
+			in.beginObject();
+			int numSects = in.nextInt();
+			Preconditions.checkState(numSects == distAzCalc.getSubSections().size());
+			in.endObject();
+			return distAzCalc;
+		}
+		
+	}
+	
+	public static void main(String[] args) {
+		FaultModels fm = FaultModels.FM3_1;
+		DeformationModels dm = fm.getFilterBasis();
+		
+		DeformationModelFetcher dmFetch = new DeformationModelFetcher(fm, dm,
+				null, 0.1);
+		
+
+		List<? extends FaultSection> subSects = dmFetch.getSubSectionList();
+		// small subset
+		subSects = subSects.subList(0, 30);
+		double maxDist = 50d;
+		
+//		double maxDist = 5d;
+		
+		SectionDistanceAzimuthCalculator distAzCalc = new SectionDistanceAzimuthCalculator(subSects);
+		
+		DistCutoffClosestSectClusterConnectionStrategy connStrat =
+				new DistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, maxDist);
+		
+		Builder builder = builder(connStrat, subSects);
+		builder.u3Azimuth();
+		builder.u3Cumulatives();
+		builder.minSectsPerParent(2, true);
+		builder.clusterCoulomb(new SubSectStiffnessCalculator(subSects, 2d, 3e4, 3e4, 0.5),
+				StiffnessAggregationMethod.MEDIAN, 0f);
+		
+		PlausibilityConfiguration config = builder.build();
+		
+		Gson gson = buildGson(subSects);
+		
+		String json = gson.toJson(config);
+		System.out.println(json);
+		
+		System.out.println("Deserializing");
+		gson = buildGson(subSects);
+		PlausibilityConfiguration config2 = gson.fromJson(json, PlausibilityConfiguration.class);
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/PlausibilityConfiguration.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/PlausibilityConfiguration.java
@@ -23,6 +23,7 @@ import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.Cu
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.JumpAzimuthChangeFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.JumpAzimuthChangeFilter.AzimuthCalc;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.MinSectsPerParentFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.NumClustersFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.ParentCoulombCompatibilityFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.ParentCoulombCompatibilityFilter.Directionality;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.SplayLengthFilter;
@@ -227,6 +228,11 @@ public class PlausibilityConfiguration {
 		 */
 		public Builder splayLength(double maxLen, boolean isFractOfMain, boolean totalAcrossSplays) {
 			filters.add(new SplayLengthFilter(maxLen, isFractOfMain, totalAcrossSplays));
+			return this;
+		}
+		
+		public Builder maxNumClusters(int maxNumClusters) {
+			filters.add(new NumClustersFilter(maxNumClusters));
 			return this;
 		}
 		

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/PlausibilityFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/PlausibilityFilter.java
@@ -1,8 +1,15 @@
 package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility;
 
+import java.util.List;
+
 import org.opensha.commons.data.ShortNamed;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterConnectionStrategy;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
+import org.opensha.sha.faultSurface.FaultSection;
+
+import com.google.gson.TypeAdapter;
 
 import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
 
@@ -24,5 +31,26 @@ public interface PlausibilityFilter extends ShortNamed {
 	 * @return
 	 */
 	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose);
+	
+	/**
+	 * This returns a TypeAdapter for JSON [de]serialization. Default implementation returns null
+	 * which will use standard Gson [de]serialization.
+	 * 
+	 * The returned class must be static and have a public, no-arg constructor. If the returned
+	 * value is of type PlausibilityFilterTypeAdapter, then the init(connStrategy, distAzCalc)
+	 * method will be called before [de]serialization.
+	 * 
+	 * @return
+	 */
+	public default TypeAdapter<PlausibilityFilter> getTypeAdapter() {
+		return null;
+	}
+	
+	public static abstract class PlausibilityFilterTypeAdapter extends TypeAdapter<PlausibilityFilter> {
+		
+		public abstract void init(ClusterConnectionStrategy connStrategy,
+				SectionDistanceAzimuthCalculator distAzCalc);
+		
+	}
 
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/PlausibilityFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/PlausibilityFilter.java
@@ -9,6 +9,7 @@ import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterCo
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
 import org.opensha.sha.faultSurface.FaultSection;
 
+import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 
 import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
@@ -25,12 +26,26 @@ public interface PlausibilityFilter extends ShortNamed {
 	
 	/**
 	 * Apply the plausibility filter to the given jump, assuming that existing rupture already passes
+	 * or failed with FAIL_CAN_CONTINUE
 	 * @param rupture
 	 * @param newJump
 	 * @param verbose
 	 * @return
 	 */
 	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose);
+	
+	/**
+	 * This allows filters to declare that they are directional, i.e., they might fail for a rupture
+	 * presented in one direction but pass for a reversed version of that rupture. In that case,
+	 * evaluation of an existing set of ruptures with this filter should wrap it in the 
+	 * MultiDirectionalPlausibilityFilter which will test all possible paths through a rupture and pass
+	 * if any pass. Default implementation returns false.
+	 * 
+	 * @return true if it is directional
+	 */
+	public default boolean isDirectional() {
+		return false;
+	}
 	
 	/**
 	 * This returns a TypeAdapter for JSON [de]serialization. Default implementation returns null
@@ -49,8 +64,9 @@ public interface PlausibilityFilter extends ShortNamed {
 	public static abstract class PlausibilityFilterTypeAdapter extends TypeAdapter<PlausibilityFilter> {
 		
 		public abstract void init(ClusterConnectionStrategy connStrategy,
-				SectionDistanceAzimuthCalculator distAzCalc);
+				SectionDistanceAzimuthCalculator distAzCalc, Gson gson);
 		
 	}
+
 
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/ScalarValuePlausibiltyFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/ScalarValuePlausibiltyFilter.java
@@ -1,0 +1,38 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility;
+
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+
+import com.google.common.collect.Range;
+
+/**
+ * Interface for a plausibility filter which is produces a scalar value (e.g., integer, double, float)
+ * for each rupture. This is mostly a helper interface to allow diagnostic plots when comparing rupture
+ * sets.
+ * 
+ * @author kevin
+ *
+ * @param <E>
+ */
+public interface ScalarValuePlausibiltyFilter<E extends Number & Comparable<E>> extends PlausibilityFilter {
+	
+	/**
+	 * @param rupture
+	 * @return scalar value for the given rupture
+	 */
+	public E getValue(ClusterRupture rupture);
+	
+	/**
+	 * @param rupture
+	 * @param newJump
+	 * @return scalar value for the new jump, assuming that existing rupture already passes
+	 * or failed with FAIL_CAN_CONTINUE
+	 */
+	public E getValue(ClusterRupture rupture, Jump newJump);
+	
+	/**
+	 * @return acceptable range of values, or null if rules are more complex
+	 */
+	public Range<E> getAcceptableRange();
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/ClusterCoulombCompatibilityFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/ClusterCoulombCompatibilityFilter.java
@@ -1,22 +1,12 @@
 package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl;
 
-import java.io.IOException;
-
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.JumpPlausibilityFilter;
-import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
-import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterConnectionStrategy;
-import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
 import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator;
 import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessAggregationMethod;
 import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessResult;
 import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessType;
-
-import com.google.common.base.Preconditions;
-import com.google.gson.TypeAdapter;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 
 import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
 
@@ -31,21 +21,21 @@ import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
  */
 public class ClusterCoulombCompatibilityFilter extends JumpPlausibilityFilter {
 	
-	private SubSectStiffnessCalculator subSectCalc;
+	private SubSectStiffnessCalculator stiffnessCalc;
 	private StiffnessAggregationMethod aggMethod;
 	private float threshold;
 
 	public ClusterCoulombCompatibilityFilter(SubSectStiffnessCalculator subSectCalc,
 			StiffnessAggregationMethod aggMethod, float threshold) {
-		this.subSectCalc = subSectCalc;
+		this.stiffnessCalc = subSectCalc;
 		this.aggMethod = aggMethod;
 		this.threshold = threshold;
 	}
 
 	@Override
 	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
-		StiffnessResult[] stiffness = subSectCalc.calcAggRupToClusterStiffness(rupture, newJump.toCluster);
-		double val = subSectCalc.getValue(stiffness, StiffnessType.CFF, aggMethod);
+		StiffnessResult[] stiffness = stiffnessCalc.calcAggRupToClusterStiffness(rupture, newJump.toCluster);
+		double val = stiffnessCalc.getValue(stiffness, StiffnessType.CFF, aggMethod);
 		PlausibilityResult result =
 				(float)val >= threshold ? PlausibilityResult.PASS : PlausibilityResult.FAIL_HARD_STOP;
 		if (verbose)
@@ -55,102 +45,12 @@ public class ClusterCoulombCompatibilityFilter extends JumpPlausibilityFilter {
 
 	@Override
 	public String getShortName() {
-		return "JumpClusterCoulomb";
+		return "JumpClusterCoulomb≥"+(float)threshold;
 	}
 
 	@Override
 	public String getName() {
-		return "Jump Cluster Coulomb Compatbility";
-	}
-
-	@Override
-	public TypeAdapter<PlausibilityFilter> getTypeAdapter() {
-		return new Adapter();
-	}
-	
-	public static class Adapter extends PlausibilityFilterTypeAdapter {
-
-		private ClusterConnectionStrategy connStrategy;
-
-		@Override
-		public void init(ClusterConnectionStrategy connStrategy, SectionDistanceAzimuthCalculator distAzCalc) {
-			this.connStrategy = connStrategy;
-		}
-
-		@Override
-		public void write(JsonWriter out, PlausibilityFilter filter) throws IOException {
-			Preconditions.checkState(filter instanceof ClusterCoulombCompatibilityFilter);
-			ClusterCoulombCompatibilityFilter cFilter = (ClusterCoulombCompatibilityFilter)filter;
-			out.beginObject();
-			
-			// serialize stiffness calculator
-			out.name("stiffnessCalc").beginObject();
-			out.name("gridSpacing").value(cFilter.subSectCalc.getGridSpacing());
-			out.name("lameLambda").value(cFilter.subSectCalc.getLameLambda());
-			out.name("lameMu").value(cFilter.subSectCalc.getLameMu());
-			out.name("coeffOfFriction").value(cFilter.subSectCalc.getCoeffOfFriction());
-			out.endObject();
-			
-			out.name("aggMethod").value(cFilter.aggMethod.name());
-			out.name("threshold").value(cFilter.threshold);
-			
-			out.endObject();
-		}
-
-		@Override
-		public PlausibilityFilter read(JsonReader in) throws IOException {
-			Preconditions.checkNotNull(connStrategy, "Never initialized");
-			SubSectStiffnessCalculator stiffnessCalc = null;
-			StiffnessAggregationMethod aggMethod = null;
-			Double threshold = null;
-			
-			in.beginObject();
-			while (in.hasNext()) {
-				switch (in.nextName()) {
-				case "stiffnessCalc":
-					in.beginObject();
-					Double mu = null;
-					Double lambda = null;
-					Double coeffOfFriction = null;
-					Double gridSpacing = null;
-					while (in.hasNext()) {
-						switch (in.nextName()) {
-						case "lameMu":
-							mu = in.nextDouble();
-							break;
-						case "lameLambda":
-							lambda = in.nextDouble();
-							break;
-						case "coeffOfFriction":
-							coeffOfFriction = in.nextDouble();
-							break;
-						case "gridSpacing":
-							gridSpacing = in.nextDouble();
-							break;
-
-						default:
-							break;
-						}
-					}
-					in.endObject();
-					stiffnessCalc = new SubSectStiffnessCalculator(connStrategy.getSubSections(),
-							gridSpacing, lambda, mu, coeffOfFriction);
-					break;
-				case "aggMethod":
-					aggMethod = StiffnessAggregationMethod.valueOf(in.nextString());
-					break;
-				case "threshold":
-					threshold = in.nextDouble();
-					break;
-
-				default:
-					break;
-				}
-			}
-			in.endObject();
-			return new ClusterCoulombCompatibilityFilter(stiffnessCalc, aggMethod, threshold.floatValue());
-		}
-		
+		return "Jump Cluster Coulomb  ≥ "+(float)threshold;
 	}
 
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/ClusterCoulombCompatibilityFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/ClusterCoulombCompatibilityFilter.java
@@ -1,0 +1,156 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl;
+
+import java.io.IOException;
+
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.JumpPlausibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterConnectionStrategy;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessAggregationMethod;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessResult;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessType;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
+
+/**
+ * This filter tests the Coulomb compatibility of each added cluster as a rupture is built. It ensures
+ * that, conditioned on unit slip of the existing rupture, each new cluster has a net Coulomb compatibility
+ * at or above the given threshold. For example, to ensure that each added cluster is net postitive, set
+ * the threshold to 0.
+ * 
+ * @author kevin
+ *
+ */
+public class ClusterCoulombCompatibilityFilter extends JumpPlausibilityFilter {
+	
+	private SubSectStiffnessCalculator subSectCalc;
+	private StiffnessAggregationMethod aggMethod;
+	private float threshold;
+
+	public ClusterCoulombCompatibilityFilter(SubSectStiffnessCalculator subSectCalc,
+			StiffnessAggregationMethod aggMethod, float threshold) {
+		this.subSectCalc = subSectCalc;
+		this.aggMethod = aggMethod;
+		this.threshold = threshold;
+	}
+
+	@Override
+	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
+		StiffnessResult[] stiffness = subSectCalc.calcAggRupToClusterStiffness(rupture, newJump.toCluster);
+		double val = subSectCalc.getValue(stiffness, StiffnessType.CFF, aggMethod);
+		PlausibilityResult result =
+				(float)val >= threshold ? PlausibilityResult.PASS : PlausibilityResult.FAIL_HARD_STOP;
+		if (verbose)
+			System.out.println(getShortName()+": val="+val+"\tresult="+result.name());
+		return result;
+	}
+
+	@Override
+	public String getShortName() {
+		return "JumpClusterCoulomb";
+	}
+
+	@Override
+	public String getName() {
+		return "Jump Cluster Coulomb Compatbility";
+	}
+
+	@Override
+	public TypeAdapter<PlausibilityFilter> getTypeAdapter() {
+		return new Adapter();
+	}
+	
+	public static class Adapter extends PlausibilityFilterTypeAdapter {
+
+		private ClusterConnectionStrategy connStrategy;
+
+		@Override
+		public void init(ClusterConnectionStrategy connStrategy, SectionDistanceAzimuthCalculator distAzCalc) {
+			this.connStrategy = connStrategy;
+		}
+
+		@Override
+		public void write(JsonWriter out, PlausibilityFilter filter) throws IOException {
+			Preconditions.checkState(filter instanceof ClusterCoulombCompatibilityFilter);
+			ClusterCoulombCompatibilityFilter cFilter = (ClusterCoulombCompatibilityFilter)filter;
+			out.beginObject();
+			
+			// serialize stiffness calculator
+			out.name("stiffnessCalc").beginObject();
+			out.name("gridSpacing").value(cFilter.subSectCalc.getGridSpacing());
+			out.name("lameLambda").value(cFilter.subSectCalc.getLameLambda());
+			out.name("lameMu").value(cFilter.subSectCalc.getLameMu());
+			out.name("coeffOfFriction").value(cFilter.subSectCalc.getCoeffOfFriction());
+			out.endObject();
+			
+			out.name("aggMethod").value(cFilter.aggMethod.name());
+			out.name("threshold").value(cFilter.threshold);
+			
+			out.endObject();
+		}
+
+		@Override
+		public PlausibilityFilter read(JsonReader in) throws IOException {
+			Preconditions.checkNotNull(connStrategy, "Never initialized");
+			SubSectStiffnessCalculator stiffnessCalc = null;
+			StiffnessAggregationMethod aggMethod = null;
+			Double threshold = null;
+			
+			in.beginObject();
+			while (in.hasNext()) {
+				switch (in.nextName()) {
+				case "stiffnessCalc":
+					in.beginObject();
+					Double mu = null;
+					Double lambda = null;
+					Double coeffOfFriction = null;
+					Double gridSpacing = null;
+					while (in.hasNext()) {
+						switch (in.nextName()) {
+						case "lameMu":
+							mu = in.nextDouble();
+							break;
+						case "lameLambda":
+							lambda = in.nextDouble();
+							break;
+						case "coeffOfFriction":
+							coeffOfFriction = in.nextDouble();
+							break;
+						case "gridSpacing":
+							gridSpacing = in.nextDouble();
+							break;
+
+						default:
+							break;
+						}
+					}
+					in.endObject();
+					stiffnessCalc = new SubSectStiffnessCalculator(connStrategy.getSubSections(),
+							gridSpacing, lambda, mu, coeffOfFriction);
+					break;
+				case "aggMethod":
+					aggMethod = StiffnessAggregationMethod.valueOf(in.nextString());
+					break;
+				case "threshold":
+					threshold = in.nextDouble();
+					break;
+
+				default:
+					break;
+				}
+			}
+			in.endObject();
+			return new ClusterCoulombCompatibilityFilter(stiffnessCalc, aggMethod, threshold.floatValue());
+		}
+		
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/ClusterPathCoulombCompatibilityFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/ClusterPathCoulombCompatibilityFilter.java
@@ -1,0 +1,219 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.JumpPlausibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterConnectionStrategy;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessAggregationMethod;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessResult;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessType;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
+
+/**
+ * This filter tests the Coulomb compatibility of each possible path through the given rupture. It tries each
+ * cluster as the nucleation point, and builds outwards to each rupture endpoint. Ruptures pass if at least
+ * one nucleation point is viable.
+ * 
+ * @author kevin
+ *
+ */
+public class ClusterPathCoulombCompatibilityFilter implements PlausibilityFilter {
+	
+	private SubSectStiffnessCalculator subSectCalc;
+	private StiffnessAggregationMethod aggMethod;
+	private float threshold;
+
+	public ClusterPathCoulombCompatibilityFilter(SubSectStiffnessCalculator subSectCalc,
+			StiffnessAggregationMethod aggMethod, float threshold) {
+		this.subSectCalc = subSectCalc;
+		this.aggMethod = aggMethod;
+		this.threshold = threshold;
+	}
+
+	@Override
+	public PlausibilityResult apply(ClusterRupture rupture, boolean verbose) {
+		if (rupture.getTotalNumJumps()  == 0)
+			return PlausibilityResult.PASS;
+		for (FaultSubsectionCluster nucleationCluster : rupture.getClustersIterable()) {
+			boolean valid = testNucleationPoint(rupture, nucleationCluster);
+			if (verbose)
+				System.out.println(getShortName()+": Nucleation point "+nucleationCluster+", result: "+valid);
+			if (valid)
+				// passes if *any* nucleation point works
+				return PlausibilityResult.PASS;
+		}
+		return PlausibilityResult.FAIL_FUTURE_POSSIBLE;
+	}
+
+	@Override
+	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
+		return apply(rupture.take(newJump), verbose);
+	}
+	
+	private boolean testNucleationPoint(ClusterRupture rup, FaultSubsectionCluster nucleationCluster) {
+		FaultSubsectionCluster predecessor = rup.clusterPredecessorsMap.get(nucleationCluster);
+		if (predecessor != null)
+			if (!testStrand(rup, new HashSet<>(), predecessor))
+				return false;
+		
+		for (FaultSubsectionCluster descendant : rup.clusterDescendantsMap.get(nucleationCluster)) {
+			if (!testStrand(rup, new HashSet<>(), descendant))
+				return false;
+		}
+		
+		// passed all
+		return true;
+	}
+	
+	private boolean testStrand(ClusterRupture rup, HashSet<FaultSubsectionCluster> strandClusters,
+			FaultSubsectionCluster addition) {
+		if (!strandClusters.isEmpty()) {
+			StiffnessResult[] stiffness = subSectCalc.calcAggClustersToClusterStiffness(
+					strandClusters, addition);
+			double val = subSectCalc.getValue(stiffness, StiffnessType.CFF, aggMethod);
+			if ((float)val < threshold)
+				return false;
+		}
+		
+		// this additon passed, continue downstream
+		HashSet<FaultSubsectionCluster> newStrandClusters = new HashSet<>(strandClusters);
+		newStrandClusters.add(addition);
+		
+		// check predecessor of this strand
+		FaultSubsectionCluster predecessor = rup.clusterPredecessorsMap.get(addition);
+		if (predecessor != null && !strandClusters.contains(predecessor)) {
+			// go down that path
+			
+			if (!testStrand(rup, newStrandClusters, predecessor))
+				return false;
+		}
+		
+		// check descendants of this strand
+		for (FaultSubsectionCluster descendant : rup.clusterDescendantsMap.get(addition)) {
+			if (strandClusters.contains(descendant))
+				continue;
+			// go down that path
+
+			if (!testStrand(rup, newStrandClusters, descendant))
+				return false;
+		}
+		
+		// if we made it here, this either the end of the line or all downstream strand extensions pass
+		return true;
+	}
+
+	@Override
+	public String getShortName() {
+		return "JumpClusterCoulomb";
+	}
+
+	@Override
+	public String getName() {
+		return "Jump Cluster Coulomb Compatbility";
+	}
+
+	@Override
+	public TypeAdapter<PlausibilityFilter> getTypeAdapter() {
+		return new Adapter();
+	}
+	
+	public static class Adapter extends PlausibilityFilterTypeAdapter {
+
+		private ClusterConnectionStrategy connStrategy;
+
+		@Override
+		public void init(ClusterConnectionStrategy connStrategy, SectionDistanceAzimuthCalculator distAzCalc) {
+			this.connStrategy = connStrategy;
+		}
+
+		@Override
+		public void write(JsonWriter out, PlausibilityFilter filter) throws IOException {
+			Preconditions.checkState(filter instanceof ClusterPathCoulombCompatibilityFilter);
+			ClusterPathCoulombCompatibilityFilter cFilter = (ClusterPathCoulombCompatibilityFilter)filter;
+			out.beginObject();
+			
+			// serialize stiffness calculator
+			out.name("stiffnessCalc").beginObject();
+			out.name("gridSpacing").value(cFilter.subSectCalc.getGridSpacing());
+			out.name("lameLambda").value(cFilter.subSectCalc.getLameLambda());
+			out.name("lameMu").value(cFilter.subSectCalc.getLameMu());
+			out.name("coeffOfFriction").value(cFilter.subSectCalc.getCoeffOfFriction());
+			out.endObject();
+			
+			out.name("aggMethod").value(cFilter.aggMethod.name());
+			out.name("threshold").value(cFilter.threshold);
+			
+			out.endObject();
+		}
+
+		@Override
+		public PlausibilityFilter read(JsonReader in) throws IOException {
+			Preconditions.checkNotNull(connStrategy, "Never initialized");
+			SubSectStiffnessCalculator stiffnessCalc = null;
+			StiffnessAggregationMethod aggMethod = null;
+			Double threshold = null;
+			
+			in.beginObject();
+			while (in.hasNext()) {
+				switch (in.nextName()) {
+				case "stiffnessCalc":
+					in.beginObject();
+					Double mu = null;
+					Double lambda = null;
+					Double coeffOfFriction = null;
+					Double gridSpacing = null;
+					while (in.hasNext()) {
+						switch (in.nextName()) {
+						case "lameMu":
+							mu = in.nextDouble();
+							break;
+						case "lameLambda":
+							lambda = in.nextDouble();
+							break;
+						case "coeffOfFriction":
+							coeffOfFriction = in.nextDouble();
+							break;
+						case "gridSpacing":
+							gridSpacing = in.nextDouble();
+							break;
+
+						default:
+							break;
+						}
+					}
+					in.endObject();
+					stiffnessCalc = new SubSectStiffnessCalculator(connStrategy.getSubSections(),
+							gridSpacing, lambda, mu, coeffOfFriction);
+					break;
+				case "aggMethod":
+					aggMethod = StiffnessAggregationMethod.valueOf(in.nextString());
+					break;
+				case "threshold":
+					threshold = in.nextDouble();
+					break;
+
+				default:
+					break;
+				}
+			}
+			in.endObject();
+			return new ClusterPathCoulombCompatibilityFilter(stiffnessCalc, aggMethod, threshold.floatValue());
+		}
+		
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/CumulativeAzimuthChangeFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/CumulativeAzimuthChangeFilter.java
@@ -8,6 +8,7 @@ import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionClust
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.JumpAzimuthChangeFilter.AzimuthCalc;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.RuptureTreeNavigator;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
 import org.opensha.sha.faultSurface.FaultSection;
 
@@ -32,7 +33,8 @@ public class CumulativeAzimuthChangeFilter implements PlausibilityFilter {
 				System.out.println(getShortName()+": passing with <3 sects");
 			return PlausibilityResult.PASS;
 		}
-		double tot = calc(rupture, rupture.clusters[0].startSect, null, null, verbose);
+		RuptureTreeNavigator navigator = rupture.getTreeNavigator();
+		double tot = calc(navigator, rupture.clusters[0].startSect, null, null, verbose);
 		if ((float)tot <= threshold) {
 			if (verbose)
 				System.out.println(getShortName()+": passing with tot="+tot);
@@ -51,10 +53,11 @@ public class CumulativeAzimuthChangeFilter implements PlausibilityFilter {
 				System.out.println(getShortName()+": failing with <2 sects on first cluster");
 			return PlausibilityResult.FAIL_HARD_STOP;
 		}
-		double tot = calc(rupture, rupture.clusters[0].startSect, null, null, verbose);
+		RuptureTreeNavigator navigator = rupture.getTreeNavigator();
+		double tot = calc(navigator, rupture.clusters[0].startSect, null, null, verbose);
 		if ((float)tot < threshold || verbose) {
 			List<FaultSection> subSects = new ArrayList<>(newJump.toCluster.subSects.size()+2);
-			subSects.add(rupture.sectPredecessorsMap.get(newJump.fromSection));
+			subSects.add(navigator.getPredecessor(newJump.fromSection));
 			subSects.add(newJump.fromSection);
 			subSects.addAll(newJump.toCluster.subSects);
 			for (int i=0; i<subSects.size()-2; i++) {
@@ -73,20 +76,20 @@ public class CumulativeAzimuthChangeFilter implements PlausibilityFilter {
 		return PlausibilityResult.FAIL_HARD_STOP;
 	}
 	
-	private double calc(ClusterRupture rupture, FaultSection sect1, FaultSection sect2,
+	private double calc(RuptureTreeNavigator navigator, FaultSection sect1, FaultSection sect2,
 			FaultSection sect3, boolean verbose) {
 		Preconditions.checkNotNull(sect1);
 		if (sect2 == null) {
 			double tot = 0d;
-			for (FaultSection descendent : rupture.sectDescendantsMap.get(sect1)) {
-				tot += calc(rupture, sect1, descendent, null, verbose);
+			for (FaultSection descendant : navigator.getDescendants(sect1)) {
+				tot += calc(navigator, sect1, descendant, null, verbose);
 			}
 			return tot;
 		}
 		if (sect3 == null) {
 			double tot = 0d;
-			for (FaultSection descendent : rupture.sectDescendantsMap.get(sect2)) {
-				tot += calc(rupture, sect1, sect2, descendent, verbose);
+			for (FaultSection descendant : navigator.getDescendants(sect2)) {
+				tot += calc(navigator, sect1, sect2, descendant, verbose);
 				if ((float)tot > threshold && !verbose)
 					return tot;
 			}
@@ -95,8 +98,8 @@ public class CumulativeAzimuthChangeFilter implements PlausibilityFilter {
 		double tot = doCalc(sect1, sect2, sect3);
 		if ((float)tot > threshold)
 			return tot;
-		for (FaultSection descendent : rupture.sectDescendantsMap.get(sect3)) {
-			tot += calc(rupture, sect2, sect3, descendent, verbose);
+		for (FaultSection descendant : navigator.getDescendants(sect3)) {
+			tot += calc(navigator, sect2, sect3, descendant, verbose);
 			if ((float)tot > threshold && !verbose)
 				return tot;
 		}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/CumulativeAzimuthChangeFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/CumulativeAzimuthChangeFilter.java
@@ -17,11 +17,11 @@ import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
 
 public class CumulativeAzimuthChangeFilter implements PlausibilityFilter {
 	
-	private AzimuthCalc calc;
+	private AzimuthCalc azCalc;
 	private float threshold;
 
 	public CumulativeAzimuthChangeFilter(AzimuthCalc calc, float threshold) {
-		this.calc = calc;
+		this.azCalc = calc;
 		this.threshold = threshold;
 	}
 
@@ -104,8 +104,8 @@ public class CumulativeAzimuthChangeFilter implements PlausibilityFilter {
 	}
 	
 	private double doCalc(FaultSection sect1, FaultSection sect2, FaultSection sect3) {
-		double beforeAz = calc.calcAzimuth(sect1, sect2);
-		double afterAz = calc.calcAzimuth(sect2, sect3);
+		double beforeAz = azCalc.calcAzimuth(sect1, sect2);
+		double afterAz = azCalc.calcAzimuth(sect2, sect3);
 		
 		return Math.abs(JumpAzimuthChangeFilter.getAzimuthDifference(beforeAz, afterAz));
 	}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/GapWithinSectFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/GapWithinSectFilter.java
@@ -1,0 +1,33 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl;
+
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.JumpPlausibilityFilter;
+
+import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
+
+/**
+ * This ensures that clusters never jump to themselves (which would skip a section)
+ * @author kevin
+ *
+ */
+public class GapWithinSectFilter extends JumpPlausibilityFilter {
+
+	@Override
+	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
+		if (newJump.fromCluster.parentSectionID == newJump.toCluster.parentSectionID)
+			return PlausibilityResult.FAIL_HARD_STOP;
+		return PlausibilityResult.PASS;
+	}
+
+	@Override
+	public String getShortName() {
+		return "GapWithinSect";
+	}
+
+	@Override
+	public String getName() {
+		return "Gap Within Fault Section";
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/JumpAzimuthChangeFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/JumpAzimuthChangeFilter.java
@@ -8,6 +8,7 @@ import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.JumpPlausibilityFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.JumpAzimuthChangeFilter.HardCodedLeftLateralFlipAzimuthCalc;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.RuptureTreeNavigator;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
 import org.opensha.sha.faultSurface.FaultSection;
 
@@ -33,7 +34,8 @@ public class JumpAzimuthChangeFilter extends JumpPlausibilityFilter {
 
 	@Override
 	public PlausibilityResult testJump(ClusterRupture rupture, Jump jump, boolean verbose) {
-		FaultSection before1 = rupture.sectPredecessorsMap.get(jump.fromSection);
+		RuptureTreeNavigator navigator = rupture.getTreeNavigator();
+		FaultSection before1 = navigator.getPredecessor(jump.fromSection);
 		if (before1 == null) {
 			// fewer than 2 sections before the first jump, will never work
 			if (verbose)
@@ -48,7 +50,7 @@ public class JumpAzimuthChangeFilter extends JumpPlausibilityFilter {
 		if (rupture.contains(after1)) {
 			// this is a preexisting jump and can be a fork with multiple second sections after the jump
 			// we will pass only if they all pass
-			after2s = rupture.sectDescendantsMap.get(after1);
+			after2s = navigator.getDescendants(after1);
 		} else {
 			// we're testing a new possible jump
 			if (jump.toCluster.subSects.size() < 2) {

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/JumpDistFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/JumpDistFilter.java
@@ -3,6 +3,9 @@ package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.JumpPlausibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.ScalarValuePlausibiltyFilter;
+
+import com.google.common.collect.Range;
 
 import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
 
@@ -12,7 +15,7 @@ import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
  * @author kevin
  *
  */
-public class JumpDistFilter extends JumpPlausibilityFilter {
+public class JumpDistFilter extends JumpPlausibilityFilter implements ScalarValuePlausibiltyFilter<Float> {
 	
 	private double maxDist;
 	
@@ -37,6 +40,24 @@ public class JumpDistFilter extends JumpPlausibilityFilter {
 	@Override
 	public String getName() {
 		return "Maximum Jump Dist";
+	}
+
+	@Override
+	public Float getValue(ClusterRupture rupture) {
+		float max = 0f;
+		for (Jump jump : rupture.getJumpsIterable())
+			max = Float.max(max, (float)jump.distance);
+		return max;
+	}
+
+	@Override
+	public Float getValue(ClusterRupture rupture, Jump newJump) {
+		return (float)newJump.distance;
+	}
+
+	@Override
+	public Range<Float> getAcceptableRange() {
+		return Range.atMost((float)maxDist);
 	}
 
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/MinSectsPerParentFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/MinSectsPerParentFilter.java
@@ -12,6 +12,7 @@ import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterCo
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
 import org.opensha.sha.faultSurface.FaultSection;
 
+import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
@@ -152,7 +153,8 @@ public class MinSectsPerParentFilter implements PlausibilityFilter {
 		private ClusterConnectionStrategy connStrategy;
 
 		@Override
-		public void init(ClusterConnectionStrategy connStrategy, SectionDistanceAzimuthCalculator distAzCalc) {
+		public void init(ClusterConnectionStrategy connStrategy,
+				SectionDistanceAzimuthCalculator distAzCalc, Gson gson) {
 			this.connStrategy = connStrategy;
 		}
 

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/MultiDirectionalPlausibilityFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/MultiDirectionalPlausibilityFilter.java
@@ -1,0 +1,57 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl;
+
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.RuptureConnectionSearch;
+
+import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
+
+/**
+ * Some plausibility filters are directional, e.g., a rupture will pass if built in one direction (from A->B)
+ * but fail in another (from B->A). The rupture building algorithm generally gets around this by trying every
+ * possible starting point, but if you are doing filter tests against an already build rupture set you can
+ * wrap a plausibility filter with this in order to test all directions. 
+ * @author kevin
+ *
+ */
+public class MultiDirectionalPlausibilityFilter implements PlausibilityFilter {
+	
+	private PlausibilityFilter filter;
+	private RuptureConnectionSearch connSearch;
+
+	public MultiDirectionalPlausibilityFilter(PlausibilityFilter filter, RuptureConnectionSearch connSearch) {
+		this.filter = filter;
+		this.connSearch = connSearch;
+	}
+
+	@Override
+	public String getShortName() {
+		return filter.getShortName();
+	}
+
+	@Override
+	public String getName() {
+		return filter.getName();
+	}
+
+	@Override
+	public PlausibilityResult apply(ClusterRupture rupture, boolean verbose) {
+		PlausibilityResult result = filter.apply(rupture, verbose);
+		if (result.isPass())
+			return result;
+		// try other paths through the rupture
+		for (ClusterRupture altRupture : rupture.getInversions(connSearch)) {
+			result = filter.apply(altRupture, verbose);
+			if (result.isPass())
+				return result;
+		}
+		return result;
+	}
+
+	@Override
+	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
+		return apply(rupture.take(newJump), verbose);
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/NumClustersFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/NumClustersFilter.java
@@ -1,0 +1,41 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl;
+
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
+
+import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
+
+public class NumClustersFilter implements PlausibilityFilter {
+	
+	private int maxNumClusters;
+
+	public NumClustersFilter(int maxNumClusters) {
+		this.maxNumClusters = maxNumClusters;
+	}
+
+	@Override
+	public String getShortName() {
+		return "Max"+maxNumClusters+"Clusters";
+	}
+
+	@Override
+	public String getName() {
+		return "Max "+maxNumClusters+" Clusters";
+	}
+
+	@Override
+	public PlausibilityResult apply(ClusterRupture rupture, boolean verbose) {
+		if (rupture.getTotalNumClusters() > maxNumClusters)
+			return PlausibilityResult.FAIL_HARD_STOP;
+		return PlausibilityResult.PASS;
+	}
+
+	@Override
+	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
+		if (rupture.getTotalNumClusters() > maxNumClusters-1)
+			return PlausibilityResult.FAIL_HARD_STOP;
+		return PlausibilityResult.PASS;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/NumClustersFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/NumClustersFilter.java
@@ -2,11 +2,20 @@ package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl;
 
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
-import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.ScalarValuePlausibiltyFilter;
+
+import com.google.common.collect.Range;
 
 import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
 
-public class NumClustersFilter implements PlausibilityFilter {
+/**
+ * Maximum number of allowed clusters in a rupture. This will mostly be useful for creating
+ * rupture sets to test connection points, without worrying about big ruptures
+ * 
+ * @author kevin
+ *
+ */
+public class NumClustersFilter implements ScalarValuePlausibiltyFilter<Integer> {
 	
 	private int maxNumClusters;
 
@@ -36,6 +45,21 @@ public class NumClustersFilter implements PlausibilityFilter {
 		if (rupture.getTotalNumClusters() > maxNumClusters-1)
 			return PlausibilityResult.FAIL_HARD_STOP;
 		return PlausibilityResult.PASS;
+	}
+
+	@Override
+	public Integer getValue(ClusterRupture rupture) {
+		return rupture.getTotalNumClusters();
+	}
+
+	@Override
+	public Integer getValue(ClusterRupture rupture, Jump newJump) {
+		return rupture.getTotalNumClusters()+1;
+	}
+
+	@Override
+	public Range<Integer> getAcceptableRange() {
+		return Range.atMost(maxNumClusters);
 	}
 
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/ParentCoulombCompatibilityFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/ParentCoulombCompatibilityFilter.java
@@ -5,17 +5,20 @@ import java.util.Map;
 
 import org.opensha.commons.util.IDPairing;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
-import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.JumpPlausibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.ScalarValuePlausibiltyFilter;
 import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator;
 import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessAggregationMethod;
 import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessResult;
 import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessType;
 
+import com.google.common.collect.Range;
+
 import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
 
-public class ParentCoulombCompatibilityFilter extends JumpPlausibilityFilter {
+public class ParentCoulombCompatibilityFilter extends JumpPlausibilityFilter
+implements ScalarValuePlausibiltyFilter<Float> {
 	
 	private SubSectStiffnessCalculator stiffnessCalc;
 	private StiffnessAggregationMethod aggMethod;
@@ -30,9 +33,9 @@ public class ParentCoulombCompatibilityFilter extends JumpPlausibilityFilter {
 		SUM
 	}
 
-	public ParentCoulombCompatibilityFilter(SubSectStiffnessCalculator subSectCalc,
+	public ParentCoulombCompatibilityFilter(SubSectStiffnessCalculator stiffnessCalc,
 			StiffnessAggregationMethod aggMethod, float threshold, Directionality directionality) {
-		this.stiffnessCalc = subSectCalc;
+		this.stiffnessCalc = stiffnessCalc;
 		this.aggMethod = aggMethod;
 		this.threshold = threshold;
 		this.directionality = directionality;
@@ -58,14 +61,21 @@ public class ParentCoulombCompatibilityFilter extends JumpPlausibilityFilter {
 			return PlausibilityResult.PASS;
 		IDPairing pair = new IDPairing(id1, id2);
 		Boolean result = passCache.get(pair);
-		if (result == null) {
+		if (result == null || verbose) {
 			// need to calculate it
-			double forward = calc(newJump.fromCluster, newJump.toCluster);
-			if (directionality == Directionality.EITHER && (float)forward >= threshold) {
+			
+			// swap out with full parent section clusters
+			int fromID = newJump.fromCluster.parentSectionID;
+			int toID = newJump.toCluster.parentSectionID;
+			
+			double forward = calc(fromID, toID);
+			if (verbose) System.out.println(getShortName()+": forward, "+fromID+"=>"+toID+" = "+forward);
+			if (directionality == Directionality.EITHER && (float)forward >= threshold && !verbose) {
 				// short circuit
 				result = true;
 			} else {
-				double reversed = calc(newJump.toCluster, newJump.fromCluster);
+				double reversed = calc(toID, fromID);
+				if (verbose) System.out.println(getShortName()+": reversed, "+toID+"=>"+fromID+" = "+reversed);
 				switch (directionality) {
 				case BOTH:
 					result = (float)reversed >= threshold && (float)forward >= threshold;
@@ -86,8 +96,8 @@ public class ParentCoulombCompatibilityFilter extends JumpPlausibilityFilter {
 		return result ? PlausibilityResult.PASS : PlausibilityResult.FAIL_HARD_STOP;
 	}
 	
-	private double calc(FaultSubsectionCluster source, FaultSubsectionCluster receiver) {
-		StiffnessResult[] stiffness = stiffnessCalc.calcClusterStiffness(source, receiver);
+	private double calc(int sourceID, int receiverID) {
+		StiffnessResult[] stiffness = stiffnessCalc.calcParentStiffness(sourceID, receiverID);
 		return stiffnessCalc.getValue(stiffness, StiffnessType.CFF, aggMethod);
 	}
 
@@ -99,6 +109,40 @@ public class ParentCoulombCompatibilityFilter extends JumpPlausibilityFilter {
 	@Override
 	public String getName() {
 		return "Parent Section Coulomb ≥ "+(float)threshold;
+	}
+
+	@Override
+	public Float getValue(ClusterRupture rupture) {
+		float min = Float.POSITIVE_INFINITY;
+		for (Jump jump : rupture.getJumpsIterable())
+			min = Float.min(min, getValue(rupture, jump));
+		return min;
+	}
+
+	@Override
+	public Float getValue(ClusterRupture rupture, Jump newJump) {
+		// swap out with full parent section clusters
+		int fromID = newJump.fromCluster.parentSectionID;
+		int toID = newJump.toCluster.parentSectionID;
+
+		double forward = calc(fromID, toID);
+		double reversed = calc(toID, fromID);
+		switch (directionality) {
+		case BOTH:
+			return Float.min((float)forward, (float)reversed);
+		case EITHER:
+			return Float.max((float)forward, (float)reversed);
+		case SUM:
+			return (float)(forward + reversed);
+
+		default:
+			throw new IllegalStateException();
+		}
+	}
+
+	@Override
+	public Range<Float> getAcceptableRange() {
+		return Range.atLeast(threshold);
 	}
 
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/ParentCoulombCompatibilityFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/ParentCoulombCompatibilityFilter.java
@@ -1,0 +1,104 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.opensha.commons.util.IDPairing;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.JumpPlausibilityFilter;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessAggregationMethod;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessResult;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessType;
+
+import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
+
+public class ParentCoulombCompatibilityFilter extends JumpPlausibilityFilter {
+	
+	private SubSectStiffnessCalculator stiffnessCalc;
+	private StiffnessAggregationMethod aggMethod;
+	private float threshold;
+	private Directionality directionality;
+	
+	private transient Map<IDPairing, Boolean> passCache;
+	
+	public enum Directionality {
+		EITHER,
+		BOTH,
+		SUM
+	}
+
+	public ParentCoulombCompatibilityFilter(SubSectStiffnessCalculator subSectCalc,
+			StiffnessAggregationMethod aggMethod, float threshold, Directionality directionality) {
+		this.stiffnessCalc = subSectCalc;
+		this.aggMethod = aggMethod;
+		this.threshold = threshold;
+		this.directionality = directionality;
+	}
+
+	@Override
+	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
+		if (passCache == null) {
+			synchronized (this) {
+				if (passCache == null)
+					passCache = new HashMap<>();
+			}
+		}
+		int id1, id2;
+		if (newJump.fromCluster.parentSectionID < newJump.toCluster.parentSectionID) {
+			id1 = newJump.fromCluster.parentSectionID;
+			id2 = newJump.toCluster.parentSectionID;
+		} else {
+			id2 = newJump.fromCluster.parentSectionID;
+			id1 = newJump.toCluster.parentSectionID;
+		}
+		if (id1 == id2)
+			return PlausibilityResult.PASS;
+		IDPairing pair = new IDPairing(id1, id2);
+		Boolean result = passCache.get(pair);
+		if (result == null) {
+			// need to calculate it
+			double forward = calc(newJump.fromCluster, newJump.toCluster);
+			if (directionality == Directionality.EITHER && (float)forward >= threshold) {
+				// short circuit
+				result = true;
+			} else {
+				double reversed = calc(newJump.toCluster, newJump.fromCluster);
+				switch (directionality) {
+				case BOTH:
+					result = (float)reversed >= threshold && (float)forward >= threshold;
+					break;
+				case EITHER:
+					result = (float)reversed >= threshold || (float)forward >= threshold;
+					break;
+				case SUM:
+					result = (float)(reversed+forward) >= threshold;
+					break;
+
+				default:
+					throw new IllegalStateException();
+				}
+			}
+			passCache.put(pair, result);
+		}
+		return result ? PlausibilityResult.PASS : PlausibilityResult.FAIL_HARD_STOP;
+	}
+	
+	private double calc(FaultSubsectionCluster source, FaultSubsectionCluster receiver) {
+		StiffnessResult[] stiffness = stiffnessCalc.calcClusterStiffness(source, receiver);
+		return stiffnessCalc.getValue(stiffness, StiffnessType.CFF, aggMethod);
+	}
+
+	@Override
+	public String getShortName() {
+		return "ParentCoulomb≥"+(float)threshold;
+	}
+
+	@Override
+	public String getName() {
+		return "Parent Section Coulomb ≥ "+(float)threshold;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/SingleClusterPerParentFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/SingleClusterPerParentFilter.java
@@ -1,6 +1,8 @@
 package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
@@ -9,31 +11,37 @@ import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.Plausib
 
 import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
 
+/**
+ * This filter dictates that a single parent fault section can only exist once within
+ * a rupture. Otherwise, a rupture could start on sect A, jump to sect B, then jump back
+ * to another part of sect A. This was not used in UCERF3.
+ * 
+ * @author kevin
+ *
+ */
 public class SingleClusterPerParentFilter implements PlausibilityFilter {
 
 	@Override
 	public String getShortName() {
-		return "GapWithinSect";
+		return "1ClusterPerParent";
 	}
 
 	@Override
 	public String getName() {
-		return "Gap Within Fault Section";
+		return "Single Cluster Per Parent";
 	}
 	
-	private void count(ClusterRupture rup, HashSet<Integer> parents, HashSet<FaultSubsectionCluster> clusters) {
-		for (FaultSubsectionCluster cluster : rup.clusters) {
+	private void count(ClusterRupture rup, HashSet<Integer> parents, List<FaultSubsectionCluster> clusters) {
+		for (FaultSubsectionCluster cluster : rup.getClustersIterable()) {
 			parents.add(cluster.parentSectionID);
 			clusters.add(cluster);
 		}
-		for (ClusterRupture splay : rup.splays.values())
-			count(splay, parents, clusters);
 	}
 
 	@Override
 	public PlausibilityResult apply(ClusterRupture rupture, boolean verbose) {
 		HashSet<Integer> parents = new HashSet<>();
-		HashSet<FaultSubsectionCluster> clusters = new HashSet<>();
+		List<FaultSubsectionCluster> clusters = new ArrayList<>();
 		count(rupture, parents, clusters);
 		if (parents.size() != clusters.size()) {
 			if (verbose) System.out.println(getShortName()+": have "+parents.size()
@@ -46,7 +54,7 @@ public class SingleClusterPerParentFilter implements PlausibilityFilter {
 	@Override
 	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
 		HashSet<Integer> parents = new HashSet<>();
-		HashSet<FaultSubsectionCluster> clusters = new HashSet<>();
+		List<FaultSubsectionCluster> clusters = new ArrayList<>();
 		count(rupture, parents, clusters);
 		parents.add(newJump.toCluster.parentSectionID);
 		clusters.add(newJump.toCluster);

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/SplayCountFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/SplayCountFilter.java
@@ -2,7 +2,9 @@ package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl;
 
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
-import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.ScalarValuePlausibiltyFilter;
+
+import com.google.common.collect.Range;
 
 import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
 
@@ -13,7 +15,7 @@ import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
  * @author kevin
  *
  */
-public class SplayCountFilter implements PlausibilityFilter {
+public class SplayCountFilter implements ScalarValuePlausibiltyFilter<Integer> {
 	
 	private int maxSplays;
 
@@ -79,6 +81,21 @@ public class SplayCountFilter implements PlausibilityFilter {
 		if (count > maxSplays)
 			return PlausibilityResult.FAIL_HARD_STOP;
 		return PlausibilityResult.PASS;
+	}
+
+	@Override
+	public Integer getValue(ClusterRupture rupture) {
+		return countSplays(rupture);
+	}
+
+	@Override
+	public Integer getValue(ClusterRupture rupture, Jump newJump) {
+		return getValue(rupture.take(newJump));
+	}
+
+	@Override
+	public Range<Integer> getAcceptableRange() {
+		return Range.atMost(maxSplays);
 	}
 
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/TotalAzimuthChangeFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/TotalAzimuthChangeFilter.java
@@ -14,14 +14,14 @@ import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
 
 public class TotalAzimuthChangeFilter implements PlausibilityFilter {
 	
-	private AzimuthCalc calc;
+	private AzimuthCalc azCalc;
 	private float threshold;
 	private boolean multiFaultOnly;
 	private boolean testFullEnd;
 
 	public TotalAzimuthChangeFilter(AzimuthCalc calc, float threshold, boolean multiFaultOnly,
 			boolean testFullEnd) {
-		this.calc = calc;
+		this.azCalc = calc;
 		this.threshold = threshold;
 		this.multiFaultOnly = multiFaultOnly;
 		this.testFullEnd = testFullEnd;
@@ -60,14 +60,14 @@ public class TotalAzimuthChangeFilter implements PlausibilityFilter {
 			return PlausibilityResult.FAIL_FUTURE_POSSIBLE;
 		FaultSection before1 = startCluster.startSect;
 		FaultSection before2 = startCluster.subSects.get(1);
-		double beforeAz = calc.calcAzimuth(before1, before2);
+		double beforeAz = azCalc.calcAzimuth(before1, before2);
 		
 		int startIndex = testFullEnd ? 0 : endCluster.subSects.size()-2;
 		double maxDiff = 0d;
 		for (int i=startIndex; i<endCluster.subSects.size()-1; i++) {
 			FaultSection after1 = endCluster.subSects.get(i);
 			FaultSection after2 = endCluster.subSects.get(i+1);
-			double afterAz = calc.calcAzimuth(after1, after2);
+			double afterAz = azCalc.calcAzimuth(after1, after2);
 			
 			double diff = JumpAzimuthChangeFilter.getAzimuthDifference(beforeAz, afterAz);
 //			System.out.println(beforeAz+" => "+afterAz+" = "+diff);

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/U3CompatibleCumulativeRakeChangeFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/U3CompatibleCumulativeRakeChangeFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.RuptureTreeNavigator;
 import org.opensha.sha.faultSurface.FaultSection;
 
 import com.google.common.base.Preconditions;
@@ -41,7 +42,7 @@ public class U3CompatibleCumulativeRakeChangeFilter implements PlausibilityFilte
 			return PlausibilityResult.PASS;
 		}
 		FaultSection stopAt = rupture.clusters[rupture.clusters.length-1].startSect;
-		double tot = calc(rupture, rupture.clusters[0].startSect, stopAt, 0d, verbose);
+		double tot = calc(rupture.getTreeNavigator(), rupture.clusters[0].startSect, stopAt, 0d, verbose);
 		if (tot <= threshold) {
 			if (verbose)
 				System.out.println(getShortName()+": passing with tot="+tot);
@@ -57,10 +58,10 @@ public class U3CompatibleCumulativeRakeChangeFilter implements PlausibilityFilte
 		return apply(rupture.take(newJump), verbose);
 	}
 	
-	private double calc(ClusterRupture rupture, FaultSection sect1, FaultSection stopAt,
+	private double calc(RuptureTreeNavigator navigator, FaultSection sect1, FaultSection stopAt,
 			double tot, boolean verbose) {
 		double rake1 = sect1.getAveRake();
-		for (FaultSection sect2 : rupture.sectDescendantsMap.get(sect1)) {
+		for (FaultSection sect2 : navigator.getDescendants(sect1)) {
 			double rake2 = sect2.getAveRake();
 			double diff = rakeDiff(rake1, rake2);
 			tot += diff;
@@ -72,7 +73,7 @@ public class U3CompatibleCumulativeRakeChangeFilter implements PlausibilityFilte
 			if (sect2 == stopAt)
 				// UCERF3 compatibility: don't check the full last section
 				break;
-			tot = calc(rupture, sect2, stopAt, tot, verbose);
+			tot = calc(navigator, sect2, stopAt, tot, verbose);
 		}
 		return tot;
 	}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/U3CompatibleCumulativeRakeChangeFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/U3CompatibleCumulativeRakeChangeFilter.java
@@ -1,15 +1,13 @@
 package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
-import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.ScalarValuePlausibiltyFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.RuptureTreeNavigator;
 import org.opensha.sha.faultSurface.FaultSection;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Range;
 
 import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
 
@@ -26,7 +24,7 @@ import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
  * @author kevin
  *
  */
-public class U3CompatibleCumulativeRakeChangeFilter implements PlausibilityFilter {
+public class U3CompatibleCumulativeRakeChangeFilter implements ScalarValuePlausibiltyFilter<Double> {
 	
 	private double threshold;
 
@@ -42,7 +40,8 @@ public class U3CompatibleCumulativeRakeChangeFilter implements PlausibilityFilte
 			return PlausibilityResult.PASS;
 		}
 		FaultSection stopAt = rupture.clusters[rupture.clusters.length-1].startSect;
-		double tot = calc(rupture.getTreeNavigator(), rupture.clusters[0].startSect, stopAt, 0d, verbose);
+		double tot = calc(rupture.getTreeNavigator(), rupture.clusters[0].startSect,
+				stopAt, 0d, verbose, !verbose);
 		if (tot <= threshold) {
 			if (verbose)
 				System.out.println(getShortName()+": passing with tot="+tot);
@@ -59,7 +58,7 @@ public class U3CompatibleCumulativeRakeChangeFilter implements PlausibilityFilte
 	}
 	
 	private double calc(RuptureTreeNavigator navigator, FaultSection sect1, FaultSection stopAt,
-			double tot, boolean verbose) {
+			double tot, boolean verbose, boolean shortCircuit) {
 		double rake1 = sect1.getAveRake();
 		for (FaultSection sect2 : navigator.getDescendants(sect1)) {
 			double rake2 = sect2.getAveRake();
@@ -68,12 +67,12 @@ public class U3CompatibleCumulativeRakeChangeFilter implements PlausibilityFilte
 			if (verbose && diff != 0d)
 				System.out.println(getShortName()+": "+sect1.getSectionId()+"="+(float)rake1+" => "
 							+sect2.getSectionId()+"="+(float)rake2+" = "+diff);
-			if (tot > threshold && !verbose)
+			if (tot > threshold && shortCircuit)
 				return tot;
 			if (sect2 == stopAt)
 				// UCERF3 compatibility: don't check the full last section
 				break;
-			tot = calc(navigator, sect2, stopAt, tot, verbose);
+			tot = calc(navigator, sect2, stopAt, tot, verbose, shortCircuit);
 		}
 		return tot;
 	}
@@ -94,6 +93,25 @@ public class U3CompatibleCumulativeRakeChangeFilter implements PlausibilityFilte
 	@Override
 	public String getName() {
 		return "UCERF3 Cumulative Rake Filter";
+	}
+
+	@Override
+	public Double getValue(ClusterRupture rupture) {
+		if (rupture.getTotalNumSects() < 2) {
+			return 0d;
+		}
+		FaultSection stopAt = rupture.clusters[rupture.clusters.length-1].startSect;
+		return calc(rupture.getTreeNavigator(), rupture.clusters[0].startSect, stopAt, 0d, false, false);
+	}
+
+	@Override
+	public Double getValue(ClusterRupture rupture, Jump newJump) {
+		return getValue(rupture.take(newJump));
+	}
+
+	@Override
+	public Range<Double> getAcceptableRange() {
+		return Range.atMost(threshold);
 	}
 
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/U3CoulombJunctionFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/U3CoulombJunctionFilter.java
@@ -19,12 +19,12 @@ import scratch.UCERF3.inversion.coulomb.CoulombRatesRecord;
 import scratch.UCERF3.inversion.coulomb.CoulombRatesTester;
 import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
 
-public class CoulombJunctionFilter implements PlausibilityFilter {
+public class U3CoulombJunctionFilter implements PlausibilityFilter {
 	
 	private CoulombRatesTester tester;
 	private CoulombRates coulombRates;
 
-	public CoulombJunctionFilter(CoulombRatesTester tester, CoulombRates coulombRates) {
+	public U3CoulombJunctionFilter(CoulombRatesTester tester, CoulombRates coulombRates) {
 		this.tester = tester;
 		this.coulombRates = coulombRates;
 	}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/ClusterConnectionStrategy.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/ClusterConnectionStrategy.java
@@ -1,27 +1,434 @@
 package org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
+import org.opensha.commons.data.Named;
+import org.opensha.commons.util.IDPairing;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
+import org.opensha.sha.faultSurface.FaultSection;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import scratch.UCERF3.enumTreeBranches.DeformationModels;
+import scratch.UCERF3.enumTreeBranches.FaultModels;
+import scratch.UCERF3.utils.DeformationModelFetcher;
 
 /**
- * This interface defines cluster connections. The addConnections method will be called in order to 
- * populate the connections of each cluster
+ * This abstract class defines cluster connections. The getClusters() method will add all
+ * connections the first time that it is called.
  * 
  * @author kevin
  *
  */
-public interface ClusterConnectionStrategy {
+public abstract class ClusterConnectionStrategy implements Named {
+
+	private List<? extends FaultSection> subSections;
+	private List<FaultSubsectionCluster> clusters;
+	
+	protected transient HashSet<IDPairing> connectedParents;
+	protected transient boolean connectionsAdded = false;
+	
+	public ClusterConnectionStrategy(List<? extends FaultSection> subSections) {
+		this(subSections, buildClusters(subSections));
+	}
+	
+	public ClusterConnectionStrategy(List<? extends FaultSection> subSections,
+			List<FaultSubsectionCluster> clusters) {
+		this.subSections = ImmutableList.copyOf(subSections);
+		this.clusters = ImmutableList.copyOf(clusters);
+	}
 	
 	/**
-	 * Add all possible connections between the given clusters (via the
-	 * FaultSubsectionCluster.addConnection(Jump) method)
+	 * Builds clusters from the given sub-sections (without adding any connections)
+	 * @param subSections
+	 * @return
+	 */
+	public static List<FaultSubsectionCluster> buildClusters(List<? extends FaultSection> subSections) {
+		List<FaultSubsectionCluster> clusters = new ArrayList<>();
+		
+		List<FaultSection> curClusterSects = null;
+		int curParentID = -1;
+		
+		for (FaultSection subSect : subSections) {
+			int parentID = subSect.getParentSectionId();
+			Preconditions.checkState(parentID >= 0,
+					"Subsections are required, but this section doesn't have a parent ID set: %s. %s",
+					subSect.getSectionId(), subSect.getSectionName());
+			if (parentID != curParentID) {
+				if (curClusterSects != null)
+					clusters.add(new FaultSubsectionCluster(curClusterSects));
+				curParentID = parentID;
+				curClusterSects = new ArrayList<>();
+			}
+			curClusterSects.add(subSect);
+		}
+		clusters.add(new FaultSubsectionCluster(curClusterSects));
+		
+		return clusters;
+	}
+	
+	/**
+	 * @return list of sub sections
+	 */
+	public synchronized List<? extends FaultSection> getSubSections() {
+		return subSections;
+	}
+	
+	/**
+	 * @return list of full clusters, after adding all connections
+	 */
+	public synchronized List<FaultSubsectionCluster> getClusters() {
+		if (!connectionsAdded) {
+			System.out.println("Building connections between "+clusters.size()+" clusters");
+			int count = buildConnections();
+			System.out.println("Found "+count+" possible section connections");
+		}
+		return clusters;
+	}
+
+	/**
+	 * Populates all possible connections between the given clusters (via the
+	 * FaultSubsectionCluster.addConnection(Jump) method).
 	 * 
-	 * @param clusters
-	 * @param distCalc
+	 * If this method is overridden, you must also override the areParentSectsConnected method.
+	 * 
 	 * @return the number of connections added
 	 */
-	public int addConnections(List<FaultSubsectionCluster> clusters, SectionDistanceAzimuthCalculator distCalc);
+	private int buildConnections() {
+		int count = 0;
+		connectedParents = new HashSet<>();
+		for (int c1=0; c1<clusters.size(); c1++) {
+			FaultSubsectionCluster cluster1 = clusters.get(c1);
+			for (int c2=c1+1; c2<clusters.size(); c2++) {
+				FaultSubsectionCluster cluster2 = clusters.get(c2);
+				List<Jump> jumps = buildPossibleConnections(cluster1, cluster2);
+				if (jumps != null) {
+					for (Jump jump : jumps) {
+						connectedParents.add(new IDPairing(cluster1.parentSectionID, cluster2.parentSectionID));
+						connectedParents.add(new IDPairing(cluster2.parentSectionID, cluster1.parentSectionID));
+						cluster1.addConnection(jump);
+						cluster2.addConnection(jump.reverse());
+						count++;
+					}
+				}
+			}
+		}
+		connectionsAdded = true;
+		return count;
+	}
+	
+	/**
+	 * Builds a list of all possible jumps between all full clusters
+	 * 
+	 * @param clusters
+	 * @return
+	 */
+	public List<Jump> getAllPossibleJumps() {
+		// force it to populate connections if not yet populated
+		getClusters();
+		
+		List<Jump> jumps = new ArrayList<>();
+		for (int c1=0; c1<clusters.size(); c1++) {
+			FaultSubsectionCluster cluster1 = clusters.get(c1);
+			jumps.addAll(cluster1.getConnections());
+		}
+		return jumps;
+	}
+	
+	/**
+	 * Returns a list of any possible connection(s) between the given clusters
+	 * 
+	 * @param from
+	 * @param to
+	 * @return List of allowed jumps, can be empty or null if no connections possible
+	 */
+	protected abstract List<Jump> buildPossibleConnections(FaultSubsectionCluster from, FaultSubsectionCluster to);
+	
+	/**
+	 * 
+	 * @param parentID1
+	 * @param parentID2
+	 * @return true if there is any allowed direct connection between the given parent section IDs
+	 */
+	public boolean areParentSectsConnected(int parentID1, int parentID2) {
+		// force it to populate connections if not yet populated
+		getClusters();
+		return connectedParents.contains(new IDPairing(parentID1, parentID2));
+	}
+	
+	public static class ConnStratTypeAdapter extends TypeAdapter<ClusterConnectionStrategy> {
+
+		private List<? extends FaultSection> subSects;
+
+		public ConnStratTypeAdapter(List<? extends FaultSection> subSects) {
+			this.subSects = subSects;
+		}
+
+		@Override
+		public void write(JsonWriter out, ClusterConnectionStrategy value) throws IOException {
+			// serialize based on clusters list
+			out.beginObject();
+			out.name("name").value(value.getName());
+			out.name("clusters").beginArray();
+			for (FaultSubsectionCluster cluster : value.getClusters()) {
+				out.beginObject();
+				out.name("parentID").value(cluster.parentSectionID);
+				out.name("subSectIDs").beginArray();
+				for (FaultSection sect : cluster.subSects)
+					out.value(sect.getSectionId());
+				out.endArray();
+				out.name("endSectIDs").beginArray();
+				for (FaultSection sect : cluster.endSects)
+					out.value(sect.getSectionId());
+				out.endArray();
+				List<Jump> connections = cluster.getConnections();
+				if (connections != null) {
+					out.name("connections").beginArray();
+					for (Jump jump : connections) {
+						out.beginObject();
+						out.name("fromSectID").value(jump.fromSection.getSectionId());
+						out.name("toParentID").value(jump.toSection.getParentSectionId());
+						out.name("toSectID").value(jump.toSection.getSectionId());
+						out.name("distance").value(jump.distance);
+						out.endObject();
+					}
+					out.endArray();
+				}
+				out.endObject();
+			}
+			out.endArray();
+			out.endObject();
+		}
+
+		@Override
+		public ClusterConnectionStrategy read(JsonReader in) throws IOException {
+			in.beginObject();
+			String name = null;
+			List<FaultSubsectionCluster> clusters = null;
+			
+			while (in.hasNext()) {
+				String jsonName = in.nextName();
+				switch (jsonName) {
+				case "name":
+					name = in.nextString();
+					break;
+				case "clusters":
+					clusters = loadClusters(in);
+					break;
+				default:
+					throw new IllegalStateException("Unexpected JSON with name="+jsonName);
+				}
+			}
+			in.endObject();
+			Preconditions.checkNotNull(clusters);
+			return new PrecomputedClusterConnectionStrategy(name, subSects, clusters);
+		}
+		
+		private FaultSection getSect(int sectID) {
+			Preconditions.checkState(sectID >= 0 && sectID < subSects.size(),
+					"sectID=%s outside valid range: [0,%s]", sectID, subSects.size()-1);
+			FaultSection sect = subSects.get(sectID);;
+			Preconditions.checkState(sect.getSectionId() == sectID,
+					"Subsection indexing mismatch. Section at index %s has sectID=%s",
+					sectID, sect.getSectionId());
+			return sect;
+		}
+		
+		private List<FaultSubsectionCluster> loadClusters(JsonReader in) throws IOException {
+			List<FaultSubsectionCluster> clusters = new ArrayList<>();
+			in.beginArray();
+			
+			Map<Integer, FaultSubsectionCluster> parentsToClusters = new HashMap<>();
+			// can't fill in jumps until all clusters have been loaded
+			Map<FaultSubsectionCluster, List<JumpStub>> clusterJumps = new HashMap<>();
+			
+			while (in.hasNext()) {
+				in.beginObject();
+				
+				Integer parentID = null;
+				List<FaultSection> subSects = null;
+				List<FaultSection> endSects = null;
+				List<JumpStub> jumps = null;
+				
+				while (in.hasNext()) {
+					switch (in.nextName()) {
+					case "parentID":
+						parentID = in.nextInt();
+						break;
+					case "subSectIDs":
+						in.beginArray();
+						subSects = new ArrayList<>();
+						while (in.hasNext())
+							subSects.add(getSect(in.nextInt()));
+						in.endArray();
+						break;
+					case "endSectIDs":
+						in.beginArray();
+						endSects = new ArrayList<>();
+						while (in.hasNext())
+							endSects.add(getSect(in.nextInt()));
+						in.endArray();
+						break;
+					case "connections":
+						in.beginArray();
+						jumps = new ArrayList<>();
+						while (in.hasNext()) {
+							in.beginObject();
+							FaultSection fromSect = null;
+							FaultSection toSect = null;
+							Double distance = null;
+							Integer toParentID = null;
+							while (in.hasNext()) {
+								switch (in.nextName()) {
+								case "fromSectID":
+									fromSect = getSect(in.nextInt());
+									break;
+								case "toSectID":
+									toSect = getSect(in.nextInt());
+									break;
+								case "toParentID":
+									toParentID = in.nextInt();
+									break;
+								case "distance":
+									distance = in.nextDouble();
+									break;
+
+								default:
+									break;
+								}
+							}
+							Preconditions.checkNotNull(fromSect, "Jump fromSectID not specified");
+							Preconditions.checkNotNull(toSect, "Jump toSectID not specified");
+							Preconditions.checkNotNull(toParentID, "Jump toParentSectID not specified");
+							Preconditions.checkState(toParentID.intValue() == toSect.getParentSectionId(),
+									"toParentID=%s but toSect.getParentSectionId()=%s",
+									toParentID, toSect.getParentSectionId());
+							Preconditions.checkNotNull(distance, "Jump distance not specified");
+							jumps.add(new JumpStub(fromSect, toSect, distance));
+						
+							in.endObject();
+						}
+						in.endArray();
+						break;
+
+					default:
+						break;
+					}
+				}
+				Preconditions.checkNotNull(parentID, "Cluster parentID not specified");
+				Preconditions.checkNotNull(subSects, "Cluster subSects not specified");
+				FaultSubsectionCluster cluster;
+				if (endSects != null)
+					cluster = new FaultSubsectionCluster(subSects, endSects);
+				else
+					cluster = new FaultSubsectionCluster(subSects);
+				clusters.add(cluster);
+				parentsToClusters.put(parentID, cluster);
+				if (jumps != null)
+					clusterJumps.put(cluster, jumps);
+				
+				in.endObject();
+			}
+			
+			in.endArray();
+			
+			// now finalize jumps
+			for (FaultSubsectionCluster cluster : clusterJumps.keySet()) {
+				List<JumpStub> stubs = clusterJumps.get(cluster);
+				for (JumpStub stub : stubs) {
+					int toParent = stub.toSection.getParentSectionId();
+					FaultSubsectionCluster toCluster = parentsToClusters.get(toParent);
+					Preconditions.checkNotNull(toCluster,
+							"Jump to a non-existent cluster with parentID=%s", toParent);
+					Preconditions.checkState(stub.fromSection.getParentSectionId() == cluster.parentSectionID,
+							"Jump fromSect is from an unexpected parent section");
+					cluster.addConnection(new Jump(stub.fromSection, cluster,
+							stub.toSection, toCluster, stub.distance));
+				}
+			}
+			return clusters;
+		}
+		
+	}
+	
+	private static class JumpStub {
+		final FaultSection fromSection;
+		final FaultSection toSection;
+		final double distance;
+		public JumpStub(FaultSection fromSection, FaultSection toSection, double distance) {
+			super();
+			this.fromSection = fromSection;
+			this.toSection = toSection;
+			this.distance = distance;
+		}
+	}
+	
+	public static void main(String[] args) throws IOException {
+		FaultModels fm = FaultModels.FM3_1;
+		DeformationModels dm = fm.getFilterBasis();
+		
+		DeformationModelFetcher dmFetch = new DeformationModelFetcher(fm, dm,
+				null, 0.1);
+		
+		List<FaultSection> parentSects = fm.fetchFaultSections();
+		List<? extends FaultSection> subSects = dmFetch.getSubSectionList();
+		
+		SectionDistanceAzimuthCalculator distAzCalc = new SectionDistanceAzimuthCalculator(subSects);
+		File cacheFile = new File("/tmp/dist_az_cache_"+fm.encodeChoiceString()+"_"+subSects.size()
+			+"_sects_"+parentSects.size()+"_parents.csv");
+		if (cacheFile.exists()) {
+			System.out.println("Loading dist/az cache from "+cacheFile.getAbsolutePath());
+			distAzCalc.loadCacheFile(cacheFile);
+		}
+		
+		DistCutoffClosestSectClusterConnectionStrategy connStrat =
+				new DistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, 5d);
+		
+		GsonBuilder builder = new GsonBuilder();
+		builder.setPrettyPrinting();
+		builder.registerTypeHierarchyAdapter(ClusterConnectionStrategy.class,
+				new ConnStratTypeAdapter(subSects));
+		
+		Gson gson = builder.create();
+		
+		String json = gson.toJson(connStrat);
+		System.out.println(json);
+		System.out.println("Loading...");
+		ClusterConnectionStrategy loaded = gson.fromJson(json, ClusterConnectionStrategy.class);
+		System.out.println("Validating...");
+		List<FaultSubsectionCluster> clusters1 = connStrat.getClusters();
+		List<FaultSubsectionCluster> clusters2 = loaded.getClusters();
+		Preconditions.checkState(clusters1.size() == clusters2.size());
+		for (int i=0; i<clusters1.size(); i++) {
+			FaultSubsectionCluster c1 = clusters1.get(i);
+			FaultSubsectionCluster c2 = clusters2.get(i);
+			Preconditions.checkState(c1.equals(c2),
+					"Cluster mismatch at %s:\n\tOrig: %s\n\tLoaded", i, c1, c2);
+			List<Jump> jumps1 = c1.getConnections();
+			List<Jump> jumps2 = c2.getConnections();
+			if (jumps1 == null) {
+				Preconditions.checkState(jumps2 == null);
+			} else {
+				Preconditions.checkState(jumps1.size() == jumps2.size());
+				for (int j=0; j<jumps1.size(); j++)
+					Preconditions.checkState(jumps1.get(j).equals(jumps2.get(j)));
+			}
+		}
+		System.out.println("DONE");
+	}
 
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/ClusterPermutationStrategy.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/ClusterPermutationStrategy.java
@@ -2,6 +2,7 @@ package org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies;
 
 import java.util.List;
 
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
 import org.opensha.sha.faultSurface.FaultSection;
 
@@ -24,4 +25,21 @@ public interface ClusterPermutationStrategy {
 	 */
 	public List<FaultSubsectionCluster> getPermutations(FaultSubsectionCluster fullCluster,
 			FaultSection firstSection);
+	
+	/**
+	 * Builds a list of all viable subsection permutations of the given cluster which start with
+	 * the given section. Any viable connections to other sections must be added to each permutation.
+	 * 
+	 * This method gives a rupture to which this cluster may be added, allowing for the permutation
+	 * strategy to change as ruptures grow. The default implementation defers to that without a rupture.
+	 * 
+	 * @param currentRupture the current rupture to which this cluster may be added
+	 * @param fullCluster the full cluster
+	 * @param firstSection the starting section from which all permutations should be built
+	 * @return list of viable permutations
+	 */
+	public default List<FaultSubsectionCluster> getPermutations(ClusterRupture currentRupture,
+			FaultSubsectionCluster fullCluster, FaultSection firstSection) {
+		return getPermutations(fullCluster, firstSection);
+	}
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/ConnectionPointsPermutationStrategy.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/ConnectionPointsPermutationStrategy.java
@@ -2,6 +2,7 @@ package org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
@@ -10,13 +11,13 @@ import org.opensha.sha.faultSurface.FaultSection;
 import com.google.common.base.Preconditions;
 
 /**
- * This just returns full clusters from the given start section to either end of the cluster
+ * This just returns full clusters from the given start section to either end of the cluster or exit points
  * (no permutations in-between);
  * 
  * @author kevin
  *
  */
-public class FullClusterPermutationStrategy implements ClusterPermutationStrategy {
+public class ConnectionPointsPermutationStrategy implements ClusterPermutationStrategy {
 
 	@Override
 	public List<FaultSubsectionCluster> getPermutations(FaultSubsectionCluster fullCluster,
@@ -27,6 +28,8 @@ public class FullClusterPermutationStrategy implements ClusterPermutationStrateg
 		List<FaultSection> newSects = new ArrayList<>();
 		newSects.add(firstSection);
 		
+		Set<FaultSection> exitPoints = fullCluster.getExitPoints();
+		
 		List<FaultSubsectionCluster> permuations = new ArrayList<>();
 		
 		// build toward the smallest ID
@@ -34,8 +37,9 @@ public class FullClusterPermutationStrategy implements ClusterPermutationStrateg
 			for (int i=myInd; --i>=0;) {
 				FaultSection nextSection = clusterSects.get(i);
 				newSects.add(nextSection);
+				if (exitPoints.contains(nextSection) || i == 0)
+					permuations.add(buildCopyJumps(fullCluster, newSects));
 			}
-			permuations.add(buildCopyJumps(fullCluster, newSects));
 		}
 		
 		if (myInd < clusterSects.size()-1) {
@@ -45,8 +49,9 @@ public class FullClusterPermutationStrategy implements ClusterPermutationStrateg
 			for (int i=myInd+1; i<clusterSects.size(); i++) {
 				FaultSection nextSection = clusterSects.get(i);
 				newSects.add(nextSection);
+				if (exitPoints.contains(nextSection) || i == clusterSects.size()-1)
+					permuations.add(buildCopyJumps(fullCluster, newSects));
 			}
-			permuations.add(buildCopyJumps(fullCluster, newSects));
 		}
 		return permuations;
 	}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/DistCutoffClosestSectClusterConnectionStrategy.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/DistCutoffClosestSectClusterConnectionStrategy.java
@@ -51,4 +51,9 @@ public class DistCutoffClosestSectClusterConnectionStrategy extends ClusterConne
 		return "ClosestSectPair: maxDist="+(float)maxJumpDist+" km";
 	}
 
+	@Override
+	public double getMaxJumpDist() {
+		return maxJumpDist;
+	}
+
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/FullClusterPermutationStrategy.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/FullClusterPermutationStrategy.java
@@ -1,0 +1,64 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.faultSurface.FaultSection;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * This just returns full clusters from the given start section to either end of the cluster
+ * (no permutations in-between);
+ * 
+ * @author kevin
+ *
+ */
+public class FullClusterPermutationStrategy implements ClusterPermutationStrategy {
+
+	@Override
+	public List<FaultSubsectionCluster> getPermutations(FaultSubsectionCluster fullCluster,
+			FaultSection firstSection) {
+		List<FaultSection> clusterSects = fullCluster.subSects;
+		int myInd = fullCluster.subSects.indexOf(firstSection);
+		Preconditions.checkState(myInd >= 0, "first section not found in cluster");
+		List<FaultSection> newSects = new ArrayList<>();
+		newSects.add(firstSection);
+		
+		List<FaultSubsectionCluster> permuations = new ArrayList<>();
+		
+		// build toward the smallest ID
+		if (myInd > 0) {
+			for (int i=myInd; --i>=0;) {
+				FaultSection nextSection = clusterSects.get(i);
+				newSects.add(nextSection);
+			}
+			permuations.add(buildCopyJumps(fullCluster, newSects));
+		}
+		
+		if (myInd < clusterSects.size()-1) {
+			newSects = new ArrayList<>();
+			newSects.add(firstSection);
+			// build toward the largest ID
+			for (int i=myInd+1; i<clusterSects.size(); i++) {
+				FaultSection nextSection = clusterSects.get(i);
+				newSects.add(nextSection);
+			}
+			permuations.add(buildCopyJumps(fullCluster, newSects));
+		}
+		return permuations;
+	}
+	
+	private static FaultSubsectionCluster buildCopyJumps(FaultSubsectionCluster fullCluster,
+			List<FaultSection> subsetSects) {
+		FaultSubsectionCluster permutation = new FaultSubsectionCluster(new ArrayList<>(subsetSects));
+		for (FaultSection sect : subsetSects)
+			for (Jump jump : fullCluster.getConnections(sect))
+				permutation.addConnection(new Jump(sect, permutation,
+						jump.toSection, jump.toCluster, jump.distance));
+		return permutation;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/PrecomputedClusterConnectionStrategy.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/PrecomputedClusterConnectionStrategy.java
@@ -1,0 +1,38 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies;
+
+import java.util.HashSet;
+import java.util.List;
+
+import org.opensha.commons.util.IDPairing;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.faultSurface.FaultSection;
+
+class PrecomputedClusterConnectionStrategy extends ClusterConnectionStrategy {
+
+	private String name;
+
+	PrecomputedClusterConnectionStrategy(String name, List<? extends FaultSection> subSections,
+			List<FaultSubsectionCluster> clusters) {
+		super(subSections, clusters);
+		this.name = name;
+		this.connectionsAdded = true;
+		connectedParents = new HashSet<>();
+		for (FaultSubsectionCluster cluster : clusters)
+			for (Jump jump : cluster.getConnections())
+				connectedParents.add(new IDPairing(cluster.parentSectionID, jump.toCluster.parentSectionID));
+		if (connectedParents.isEmpty())
+			System.err.println("WARNING: no connections detected");
+	}
+
+	@Override
+	protected List<Jump> buildPossibleConnections(FaultSubsectionCluster from, FaultSubsectionCluster to) {
+		throw new IllegalStateException("Already built when pre-computed");
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/PrecomputedClusterConnectionStrategy.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/PrecomputedClusterConnectionStrategy.java
@@ -11,11 +11,13 @@ import org.opensha.sha.faultSurface.FaultSection;
 class PrecomputedClusterConnectionStrategy extends ClusterConnectionStrategy {
 
 	private String name;
+	private double maxJumpDist;
 
 	PrecomputedClusterConnectionStrategy(String name, List<? extends FaultSection> subSections,
-			List<FaultSubsectionCluster> clusters) {
+			List<FaultSubsectionCluster> clusters, double maxJumpDist) {
 		super(subSections, clusters);
 		this.name = name;
+		this.maxJumpDist = maxJumpDist;
 		this.connectionsAdded = true;
 		connectedParents = new HashSet<>();
 		for (FaultSubsectionCluster cluster : clusters)
@@ -33,6 +35,11 @@ class PrecomputedClusterConnectionStrategy extends ClusterConnectionStrategy {
 	@Override
 	public String getName() {
 		return name;
+	}
+
+	@Override
+	public double getMaxJumpDist() {
+		return maxJumpDist;
 	}
 
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/UCERF3ClusterConnectionStrategy.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/UCERF3ClusterConnectionStrategy.java
@@ -8,71 +8,73 @@ import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
 import org.opensha.sha.faultSurface.FaultSection;
 
+import com.google.common.collect.Lists;
+
 import scratch.UCERF3.inversion.coulomb.CoulombRates;
 
-public class UCERF3ClusterConnectionStrategy implements ClusterConnectionStrategy {
+public class UCERF3ClusterConnectionStrategy extends ClusterConnectionStrategy {
 	
+	private SectionDistanceAzimuthCalculator distCalc;
 	private double maxJumpDist;
 	private CoulombRates coulombRates;
 
-	public UCERF3ClusterConnectionStrategy(double maxJumpDist, CoulombRates coulombRates) {
+	public UCERF3ClusterConnectionStrategy(List<? extends FaultSection> subSects,
+			SectionDistanceAzimuthCalculator distCalc, double maxJumpDist, CoulombRates coulombRates) {
+		super(subSects);
+		this.distCalc = distCalc;
 		this.maxJumpDist = maxJumpDist;
 		this.coulombRates = coulombRates;
 	}
 
 	@Override
-	public int addConnections(List<FaultSubsectionCluster> clusters, SectionDistanceAzimuthCalculator distCalc) {
-		// TODO Auto-generated method stub
-		
-		int count = 0;
-		for (int c1=0; c1<clusters.size(); c1++) {
-			FaultSubsectionCluster cluster1 = clusters.get(c1);
-			for (int c2=c1+1; c2<clusters.size(); c2++) {
-				FaultSubsectionCluster cluster2 = clusters.get(c2);
-				Jump jump = null;
-				for (FaultSection s1 : cluster1.subSects) {
-					for (FaultSection s2 : cluster2.subSects) {
-						double dist = distCalc.getDistance(s1, s2);
-						// do everything to float precision to avoid system/OS dependent results
-						if ((float)dist <= (float)maxJumpDist && (jump == null || (float)dist <= (float)jump.distance)) {
-							if (jump != null && (float)dist == (float)jump.distance) {
-								// this 2nd check in floating point precision gets around an issue where the distance is identical
-								// within floating point precision for 2 sub sections on the same section. if we don't do this check
-								// than the actual "closer" section could vary depending on the machine/os used. in this case, just
-								// use the one that's in coulomb. If neither are in coulomb, then keep the first occurrence (lower ID)
-								
-								boolean prevValCoulomb = false;
-								boolean curValCoulomb = false;
-								if (coulombRates != null) {
-									prevValCoulomb = coulombRates.containsKey(new IDPairing(
-											jump.fromSection.getSectionId(), jump.toSection.getSectionId()));
-									curValCoulomb = coulombRates.containsKey(new IDPairing(
-											s1.getSectionId(), s2.getSectionId()));
-								}
-//								System.out.println("IT HAPPENED!!!!!! "+subSectIndex1+"=>"+subSectIndex2+" vs "
-//												+data1.getSectionId()+"=>"+data2.getSectionId());
-//								System.out.println("prevValCoulomb="+prevValCoulomb+"\tcurValCoulomb="+curValCoulomb);
-								if (prevValCoulomb)
-									// this means that the previous value is in coulomb, use that!
-									continue;
-								if (!curValCoulomb) {
-									// this means that either no coulomb values were supplied, or neither choice is in coulomb. lets use
-									// the first one for consistency
-									continue;
-								}
-							}
-							jump = new Jump(s1, cluster1, s2, cluster2, dist);
+	protected List<Jump> buildPossibleConnections(FaultSubsectionCluster from, FaultSubsectionCluster to) {
+		Jump jump = null;
+		for (FaultSection s1 : from.subSects) {
+			for (FaultSection s2 : to.subSects) {
+				double dist = distCalc.getDistance(s1, s2);
+				// do everything to float precision to avoid system/OS dependent results
+				if ((float)dist <= (float)maxJumpDist && (jump == null || (float)dist <= (float)jump.distance)) {
+					if (jump != null && (float)dist == (float)jump.distance) {
+						// this 2nd check in floating point precision gets around an issue where the distance is identical
+						// within floating point precision for 2 sub sections on the same section. if we don't do this check
+						// than the actual "closer" section could vary depending on the machine/os used. in this case, just
+						// use the one that's in coulomb. If neither are in coulomb, then keep the first occurrence (lower ID)
+						
+						boolean prevValCoulomb = false;
+						boolean curValCoulomb = false;
+						if (coulombRates != null) {
+							prevValCoulomb = coulombRates.containsKey(new IDPairing(
+									jump.fromSection.getSectionId(), jump.toSection.getSectionId()));
+							curValCoulomb = coulombRates.containsKey(new IDPairing(
+									s1.getSectionId(), s2.getSectionId()));
+						}
+//						System.out.println("IT HAPPENED!!!!!! "+subSectIndex1+"=>"+subSectIndex2+" vs "
+//										+data1.getSectionId()+"=>"+data2.getSectionId());
+//						System.out.println("prevValCoulomb="+prevValCoulomb+"\tcurValCoulomb="+curValCoulomb);
+						if (prevValCoulomb)
+							// this means that the previous value is in coulomb, use that!
+							continue;
+						if (!curValCoulomb) {
+							// this means that either no coulomb values were supplied, or neither choice is in coulomb. lets use
+							// the first one for consistency
+							continue;
 						}
 					}
-				}
-				if (jump != null) {
-					cluster1.addConnection(jump);
-					cluster2.addConnection(jump.reverse());
-					count++;
+					jump = new Jump(s1, from, s2, to, dist);
 				}
 			}
 		}
-		return count;
+		if (jump == null)
+			return null;
+		return Lists.newArrayList(jump);
+	}
+
+	@Override
+	public String getName() {
+		String name = "UCERF3: maxDist="+(float)maxJumpDist+" km";
+		if (coulombRates != null)
+			name += ", precomputed Coulomb pairings";
+		return name;
 	}
 
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/UCERF3ClusterConnectionStrategy.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/UCERF3ClusterConnectionStrategy.java
@@ -77,4 +77,9 @@ public class UCERF3ClusterConnectionStrategy extends ClusterConnectionStrategy {
 		return name;
 	}
 
+	@Override
+	public double getMaxJumpDist() {
+		return maxJumpDist;
+	}
+
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/CompareClusterRuptureBuild.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/CompareClusterRuptureBuild.java
@@ -45,13 +45,13 @@ import scratch.UCERF3.utils.FaultSystemIO;
 public class CompareClusterRuptureBuild {
 
 	public static void main(String[] args) throws ZipException, IOException, DocumentException {
-//		FaultSystemRupSet compRupSet = FaultSystemIO.loadRupSet(new File(
-//				"/home/kevin/workspace/OpenSHA/dev/scratch/UCERF3/data/scratch/InversionSolutions/"
-//				+ "2013_05_10-ucerf3p3-production-10runs_COMPOUND_SOL_FM3_1_MEAN_BRANCH_AVG_SOL.zip"));
-//		boolean isCompUCERF3 = true;
 		FaultSystemRupSet compRupSet = FaultSystemIO.loadRupSet(new File(
-				"/home/kevin/OpenSHA/UCERF4/rup_sets/fm3_1_cmlAz_cmlRake_cffClusterPositive.zip"));
-		boolean isCompUCERF3 = false;
+				"/home/kevin/workspace/OpenSHA/dev/scratch/UCERF3/data/scratch/InversionSolutions/"
+				+ "2013_05_10-ucerf3p3-production-10runs_COMPOUND_SOL_FM3_1_MEAN_BRANCH_AVG_SOL.zip"));
+		boolean isCompUCERF3 = true;
+//		FaultSystemRupSet compRupSet = FaultSystemIO.loadRupSet(new File(
+//				"/home/kevin/OpenSHA/UCERF4/rup_sets/fm3_1_cmlAz_cmlRake_cffClusterPositive.zip"));
+//		boolean isCompUCERF3 = false;
 		
 		System.out.println("compRupSet has "+compRupSet.getNumRuptures()+" ruptures");
 		
@@ -83,6 +83,23 @@ public class CompareClusterRuptureBuild {
 					compRupSet.getFaultSectionData(i).getSectionName()));
 		}
 		System.out.println("passed all section consistency tests");
+		
+		System.out.println("Looking for duplicates");
+		Map<HashSet<Integer>, Integer> prevRups = new HashMap<>();
+		for (int i=0; i<clusterRupSet.getNumRuptures(); i++) {
+			HashSet<Integer> idsSet = new HashSet<>(clusterRupSet.getSectionsIndicesForRup(i));
+//			Preconditions.checkState(!prevRups.containsKey(idsSet));
+			if (prevRups.containsKey(idsSet)) {
+				int prevID = prevRups.get(idsSet);
+				System.out.println("DUPLICATE FOUND");
+				System.out.println("\t"+prevID+": "+Joiner.on(",").join(
+						clusterRupSet.getSectionsIndicesForRup(prevID)));
+				System.out.println("\t"+i+": "+Joiner.on(",").join(
+						clusterRupSet.getSectionsIndicesForRup(i)));
+			}
+			prevRups.put(idsSet, i);
+		}
+		System.exit(0);
 		
 		List<PlausibilityFilter> filters;
 		List<AbstractPlausibilityFilter> u3Filters = null;

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/DepthAwareJsonReader.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/DepthAwareJsonReader.java
@@ -1,0 +1,40 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.util;
+
+import java.io.IOException;
+import java.io.Reader;
+
+import com.google.gson.stream.JsonReader;
+
+public class DepthAwareJsonReader extends JsonReader {
+	
+	private int curDepth = 0;
+
+	public DepthAwareJsonReader(Reader in) {
+		super(in);
+	}
+
+	@Override
+	public void beginArray() throws IOException {
+		// TODO Auto-generated method stub
+		super.beginArray();
+	}
+
+	@Override
+	public void endArray() throws IOException {
+		// TODO Auto-generated method stub
+		super.endArray();
+	}
+
+	@Override
+	public void beginObject() throws IOException {
+		// TODO Auto-generated method stub
+		super.beginObject();
+	}
+
+	@Override
+	public void endObject() throws IOException {
+		// TODO Auto-generated method stub
+		super.endObject();
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RupCartoonGenerator.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RupCartoonGenerator.java
@@ -281,10 +281,11 @@ public class RupCartoonGenerator {
 		}
 		
 		private void addAzimuths(ClusterRupture rup, Jump jump) {
-			FaultSection before = rup.sectPredecessorsMap.get(jump.fromSection);
+			RuptureTreeNavigator navigator = rup.getTreeNavigator();
+			FaultSection before = navigator.getPredecessor(jump.fromSection);
 			if (before != null)
 				addAzimuth(before, jump.fromSection);
-			for (FaultSection after : rup.sectDescendantsMap.get(jump.toSection))
+			for (FaultSection after : navigator.getDescendants(jump.toSection))
 				addAzimuth(jump.toSection, after);
 		}
 		

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RupCartoonGenerator.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RupCartoonGenerator.java
@@ -548,7 +548,7 @@ public class RupCartoonGenerator {
 		
 		SectionDistanceAzimuthCalculator distCalc = new SectionDistanceAzimuthCalculator(rupBuild.subSectsList);
 //		List<FaultSubsectionCluster> clusters = connStrat.getClusters();
-		RupSetConnectionSearch search = new RupSetConnectionSearch(null, distCalc, Double.POSITIVE_INFINITY, false);
+		RuptureConnectionSearch search = new RuptureConnectionSearch(null, distCalc, Double.POSITIVE_INFINITY, false);
 		List<FaultSubsectionCluster> clusters = search.calcClusters(rupBuild.subSectsList, false);
 		
 		List<Jump> rupJumps = search.calcRuptureJumps(clusters, true);
@@ -579,7 +579,7 @@ public class RupCartoonGenerator {
 				fullClusters.add(new FaultSubsectionCluster(fullSects));
 			}
 		}
-		RupSetConnectionSearch search = new RupSetConnectionSearch(null, distCalc, Double.POSITIVE_INFINITY, false);
+		RuptureConnectionSearch search = new RuptureConnectionSearch(null, distCalc, Double.POSITIVE_INFINITY, false);
 		
 		List<Jump> rupJumps = search.calcRuptureJumps(fullClusters, true);
 		return search.buildClusterRupture(fullClusters, rupJumps, true, fullClusters.get(0));

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RupCartoonGenerator.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RupCartoonGenerator.java
@@ -38,6 +38,7 @@ import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.JumpAzimuthChangeFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.MinSectsPerParentFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterConnectionStrategy;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.DistCutoffClosestSectClusterConnectionStrategy;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.UCERF3ClusterPermuationStrategy;
 import org.opensha.sha.faultSurface.FaultSection;
@@ -318,7 +319,7 @@ public class RupCartoonGenerator {
 		
 		private double fractDDW;
 		private List<FaultSection> subSectsList;
-		private List<FaultSubsectionCluster> allClusters;
+//		private List<FaultSubsectionCluster> allClusters;
 		
 		private List<ClusterRupture> allRups;
 		private ClusterRupture biggestRup;
@@ -326,38 +327,40 @@ public class RupCartoonGenerator {
 		public RuptureBuilder(double fractDDW) {
 			this.fractDDW = fractDDW;
 			this.subSectsList = new ArrayList<>();
-			allClusters = new ArrayList<>();
+//			allClusters = new ArrayList<>();
 		}
 		
 		public void addFault(FaultSection parent) {
 			// first build subsections
 			double width = parent.getOrigDownDipWidth();
-			FaultSubsectionCluster cluster = new FaultSubsectionCluster(
-					parent.getSubSectionsList(fractDDW*width, subSectsList.size(), 2));
-			subSectsList.addAll(cluster.subSects);
-			allClusters.add(cluster);
+//			FaultSubsectionCluster cluster = new FaultSubsectionCluster(
+//					parent.getSubSectionsList(fractDDW*width, subSectsList.size(), 2));
+//			subSectsList.addAll(cluster.subSects);
+			subSectsList.addAll(parent.getSubSectionsList(fractDDW*width, subSectsList.size(), 2));
+//			allClusters.add(cluster);
 		}
 		
-		public void buildRuptures() {
-			DistCutoffClosestSectClusterConnectionStrategy connStrat =
-					new DistCutoffClosestSectClusterConnectionStrategy(Double.POSITIVE_INFINITY);
-			connStrat.addConnections(allClusters, new SectionDistanceAzimuthCalculator(subSectsList));
-			
-			ClusterRuptureBuilder builder = new ClusterRuptureBuilder(
-					allClusters, new ArrayList<>(), Integer.MAX_VALUE);
-			allRups = builder.build(new UCERF3ClusterPermuationStrategy());
-			System.out.println("Built "+allRups.size()+" rups");
-			for (ClusterRupture rup : allRups) {
-				if (biggestRup == null)
-					biggestRup = rup;
-				else if (rup.unique.size() > biggestRup.unique.size())
-					biggestRup = rup;
-				else if (rup.unique.size() == biggestRup.unique.size()
-						&& rup.clusters.length > biggestRup.clusters.length)
-					biggestRup = rup;
-			}
-			System.out.println("Biggest has "+biggestRup.unique.size()+" sections");
-		}
+//		public void buildRuptures() {
+//			DistCutoffClosestSectClusterConnectionStrategy connStrat =
+//					new DistCutoffClosestSectClusterConnectionStrategy(subSectsList,
+//							new SectionDistanceAzimuthCalculator(subSectsList), Double.POSITIVE_INFINITY);
+//			connStrat.addConnections(allClusters);
+//			
+//			ClusterRuptureBuilder builder = new ClusterRuptureBuilder(
+//					allClusters, new ArrayList<>(), Integer.MAX_VALUE);
+//			allRups = builder.build(new UCERF3ClusterPermuationStrategy());
+//			System.out.println("Built "+allRups.size()+" rups");
+//			for (ClusterRupture rup : allRups) {
+//				if (biggestRup == null)
+//					biggestRup = rup;
+//				else if (rup.unique.size() > biggestRup.unique.size())
+//					biggestRup = rup;
+//				else if (rup.unique.size() == biggestRup.unique.size()
+//						&& rup.clusters.length > biggestRup.clusters.length)
+//					biggestRup = rup;
+//			}
+//			System.out.println("Biggest has "+biggestRup.unique.size()+" sections");
+//		}
 		
 	}
 	
@@ -367,17 +370,13 @@ public class RupCartoonGenerator {
 	}
 	
 	private static void animateRuptureBuilding(File outputDir, String prefix, RuptureBuilder rupBuild,
-			List<PlausibilityFilter> filters, SectionDistanceAzimuthCalculator distAzCalc,
-			double maxDist, int maxNumSplays, boolean includeDuplicates, boolean plotAzimuths,
+			List<PlausibilityFilter> filters, ClusterConnectionStrategy connStrat,
+			int maxNumSplays, boolean includeDuplicates, boolean plotAzimuths,
 			boolean axisLabels, double fps) throws IOException {
 		TrackAllDebugCriteria tracker = new TrackAllDebugCriteria();
 		
-		DistCutoffClosestSectClusterConnectionStrategy connStrat =
-				new DistCutoffClosestSectClusterConnectionStrategy(maxDist);
-		connStrat.addConnections(rupBuild.allClusters, distAzCalc);
-		
 		ClusterRuptureBuilder builder = new ClusterRuptureBuilder(
-				rupBuild.allClusters, filters, maxNumSplays);
+				connStrat.getClusters(), filters, maxNumSplays);
 		builder.setDebugCriteria(tracker, false);
 		List<ClusterRupture> finalRups = builder.build(new UCERF3ClusterPermuationStrategy());
 		
@@ -548,11 +547,9 @@ public class RupCartoonGenerator {
 			rupBuild.addFault(parent);
 		
 		SectionDistanceAzimuthCalculator distCalc = new SectionDistanceAzimuthCalculator(rupBuild.subSectsList);
-		DistCutoffClosestSectClusterConnectionStrategy connStrat =
-				new DistCutoffClosestSectClusterConnectionStrategy(Double.POSITIVE_INFINITY);
-		List<FaultSubsectionCluster> clusters = rupBuild.allClusters;
-		connStrat.addConnections(clusters, distCalc);
-		RupSetConnectionSearch search = new RupSetConnectionSearch(null, distCalc, connStrat, false);
+//		List<FaultSubsectionCluster> clusters = connStrat.getClusters();
+		RupSetConnectionSearch search = new RupSetConnectionSearch(null, distCalc, Double.POSITIVE_INFINITY, false);
+		List<FaultSubsectionCluster> clusters = search.calcClusters(rupBuild.subSectsList, false);
 		
 		List<Jump> rupJumps = search.calcRuptureJumps(clusters, true);
 		ClusterRupture fullRup = search.buildClusterRupture(clusters, rupJumps, true, clusters.get(0));
@@ -582,11 +579,7 @@ public class RupCartoonGenerator {
 				fullClusters.add(new FaultSubsectionCluster(fullSects));
 			}
 		}
-		
-		DistCutoffClosestSectClusterConnectionStrategy connStrat =
-				new DistCutoffClosestSectClusterConnectionStrategy(Double.POSITIVE_INFINITY);
-		connStrat.addConnections(fullClusters, distCalc);
-		RupSetConnectionSearch search = new RupSetConnectionSearch(null, distCalc, connStrat, false);
+		RupSetConnectionSearch search = new RupSetConnectionSearch(null, distCalc, Double.POSITIVE_INFINITY, false);
 		
 		List<Jump> rupJumps = search.calcRuptureJumps(fullClusters, true);
 		return search.buildClusterRupture(fullClusters, rupJumps, true, fullClusters.get(0));
@@ -706,11 +699,13 @@ public class RupCartoonGenerator {
 		List<PlausibilityFilter> filters = new ArrayList<>();
 		SectionDistanceAzimuthCalculator animDistAzCalc = new SectionDistanceAzimuthCalculator(
 				rupBuild.subSectsList);
-		filters.add(new MinSectsPerParentFilter(2, false, rupBuild.allClusters));
+		ClusterConnectionStrategy connStrat = new DistCutoffClosestSectClusterConnectionStrategy(
+				rupBuild.subSectsList, animDistAzCalc, Double.POSITIVE_INFINITY);
+		filters.add(new MinSectsPerParentFilter(2, false, connStrat));
 		filters.add(new JumpAzimuthChangeFilter(
 				new JumpAzimuthChangeFilter.SimpleAzimuthCalc(animDistAzCalc), 60f));
 		animateRuptureBuilding(outputDir, "system_build_anim", rupBuild,
-				filters, animDistAzCalc, Double.POSITIVE_INFINITY, 0, true, false, false, 1d);
+				filters, connStrat, 0, true, false, false, 1d);
 	}
 
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RupSetConnectionSearch.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RupSetConnectionSearch.java
@@ -62,29 +62,22 @@ public class RupSetConnectionSearch {
 	private SectionDistanceAzimuthCalculator distCalc;
 	
 	public static final double MAX_POSSIBLE_JUMP_DEFAULT = 100d;
-	private ClusterConnectionStrategy clusterConnStrategy;
+	private double maxJumpDist;
 	
 	public static final boolean CUMULATIVE_JUMPS_DEFAULT = false;
 	// if true, find connections via the smallest cumulative jump distance
 	// if false, find connections via the smallest individual jump (possibly across multiple clusters)
 	private boolean cumulativeJumps;
-
-	public RupSetConnectionSearch(FaultSystemRupSet rupSet) {
-		this(rupSet, new SectionDistanceAzimuthCalculator(rupSet.getFaultSectionDataList()));
-	}
 	
 	public RupSetConnectionSearch(FaultSystemRupSet rupSet, SectionDistanceAzimuthCalculator distCalc) {
-		this(rupSet, distCalc, new DistCutoffClosestSectClusterConnectionStrategy(MAX_POSSIBLE_JUMP_DEFAULT),
-				CUMULATIVE_JUMPS_DEFAULT);
+		this(rupSet, distCalc, MAX_POSSIBLE_JUMP_DEFAULT, CUMULATIVE_JUMPS_DEFAULT);
 	}
 	
 	public RupSetConnectionSearch(FaultSystemRupSet rupSet, SectionDistanceAzimuthCalculator distCalc,
-			ClusterConnectionStrategy clusterConnStrategy, boolean cumulativeJumps) {
+			double maxJumpDist, boolean cumulativeJumps) {
 		this.rupSet = rupSet;
-		if (distCalc == null)
-			distCalc = new SectionDistanceAzimuthCalculator(rupSet.getFaultSectionDataList());
 		this.distCalc = distCalc;
-		this.clusterConnStrategy = clusterConnStrategy; 
+		this.maxJumpDist = maxJumpDist; 
 		this.cumulativeJumps = cumulativeJumps;
 	}
 	
@@ -124,10 +117,10 @@ public class RupSetConnectionSearch {
 			clusters.add(new FaultSubsectionCluster(curSects));
 		}
 		
-		// calculate connections
-		clusterConnStrategy.addConnections(clusters, distCalc);
+		ClusterConnectionStrategy connStrat = new DistCutoffClosestSectClusterConnectionStrategy(
+				sects, clusters, distCalc, maxJumpDist);
 		
-		return clusters;
+		return connStrat.getClusters();
 	}
 	
 	private static final Comparator<FaultSection> sectIDcomp = new Comparator<FaultSection>() {
@@ -460,6 +453,7 @@ public class RupSetConnectionSearch {
 		Multimap<FaultSubsectionCluster, Jump> jumpsFromMap = HashMultimap.create();
 		if (debug) {
 			Collections.sort(jumps, Jump.id_comparator);
+			rupClusters = new ArrayList<>(rupClusters);
 			Collections.sort(rupClusters);
 		}
 		for (Jump jump : jumps) {
@@ -892,11 +886,10 @@ public class RupSetConnectionSearch {
 		
 		FaultSystemRupSet rupSet = FaultSystemIO.loadRupSet(fssFile);
 		
-		SectionDistanceAzimuthCalculator distCalc = new SectionDistanceAzimuthCalculator(rupSet.getFaultSectionDataList());
-		
-		ClusterConnectionStrategy connStrategy = new DistCutoffClosestSectClusterConnectionStrategy(maxPossibleJumpDist);
+		SectionDistanceAzimuthCalculator distCalc =
+				new SectionDistanceAzimuthCalculator(rupSet.getFaultSectionDataList());
 		RupSetConnectionSearch search = new RupSetConnectionSearch(rupSet, distCalc,
-				connStrategy, CUMULATIVE_JUMPS_DEFAULT);
+				maxPossibleJumpDist, CUMULATIVE_JUMPS_DEFAULT);
 		
 		Preconditions.checkState(outputDir.exists() || outputDir.mkdir());
 		

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RupSetDiagnosticsPageGen.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RupSetDiagnosticsPageGen.java
@@ -1,0 +1,10 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.util;
+
+public class RupSetDiagnosticsPageGen {
+
+	public static void main(String[] args) {
+		// TODO Auto-generated method stub
+
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RupSetDiagnosticsPageGen.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RupSetDiagnosticsPageGen.java
@@ -1,10 +1,1887 @@
 package org.opensha.sha.earthquake.faultSysSolution.ruptures.util;
 
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Stroke;
+import java.awt.geom.Point2D;
+import java.io.File;
+import java.io.IOException;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.dom4j.DocumentException;
+import org.jfree.chart.annotations.XYAnnotation;
+import org.jfree.chart.annotations.XYBoxAnnotation;
+import org.jfree.chart.annotations.XYPolygonAnnotation;
+import org.jfree.chart.annotations.XYTextAnnotation;
+import org.jfree.chart.axis.NumberTickUnit;
+import org.jfree.chart.axis.TickUnit;
+import org.jfree.chart.axis.TickUnits;
+import org.jfree.chart.title.PaintScaleLegend;
+import org.jfree.data.Range;
+import org.jfree.ui.RectangleEdge;
+import org.jfree.ui.TextAnchor;
+import org.opensha.commons.data.function.DefaultXY_DataSet;
+import org.opensha.commons.data.function.DiscretizedFunc;
+import org.opensha.commons.data.function.EvenlyDiscretizedFunc;
+import org.opensha.commons.data.function.HistogramFunction;
+import org.opensha.commons.data.function.XY_DataSet;
+import org.opensha.commons.data.region.CaliforniaRegions.RELM_TESTING;
+import org.opensha.commons.geo.Location;
+import org.opensha.commons.geo.LocationList;
+import org.opensha.commons.geo.Region;
+import org.opensha.commons.gui.plot.HeadlessGraphPanel;
+import org.opensha.commons.gui.plot.PlotCurveCharacterstics;
+import org.opensha.commons.gui.plot.PlotElement;
+import org.opensha.commons.gui.plot.PlotLineType;
+import org.opensha.commons.gui.plot.PlotSpec;
+import org.opensha.commons.gui.plot.jfreechart.xyzPlot.XYZGraphPanel;
+import org.opensha.commons.mapping.PoliticalBoundariesData;
+import org.opensha.commons.mapping.gmt.elements.GMT_CPT_Files;
+import org.opensha.commons.util.DataUtils.MinMaxAveTracker;
+import org.opensha.commons.util.ExceptionUtils;
+import org.opensha.commons.util.MarkdownUtils;
+import org.opensha.commons.util.MarkdownUtils.TableBuilder;
+import org.opensha.commons.util.cpt.CPT;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityConfiguration;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.JumpAzimuthChangeFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.JumpDistFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.SingleClusterPerParentFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.SplayCountFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.JumpAzimuthChangeFilter.AzimuthCalc;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterConnectionStrategy;
+import org.opensha.sha.faultSurface.FaultSection;
+import org.opensha.sha.faultSurface.RuptureSurface;
+import org.opensha.sha.faultSurface.utils.GriddedSurfaceUtils;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+
+import scratch.UCERF3.FaultSystemRupSet;
+import scratch.UCERF3.FaultSystemSolution;
+import scratch.UCERF3.enumTreeBranches.FaultModels;
+import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
+import scratch.UCERF3.utils.FaultSystemIO;
+
 public class RupSetDiagnosticsPageGen {
 
-	public static void main(String[] args) {
-		// TODO Auto-generated method stub
+	public static void main(String[] args) throws IOException, DocumentException {
+		File rupSetsDir = new File("/home/kevin/OpenSHA/UCERF4/rup_sets");
+		
+		File mainOutputDir = new File("/home/kevin/markdown/rupture-sets");
 
+		String inputName = "FM3.1, No Az, CFF Parent & Cluster Positive";
+		File inputFile = new File(rupSetsDir, "fm3_1_noAz_noRake_parentPositive_cffClusterPositive.zip");
+//		String inputName = "FM3.1, No Az, CFF Cluster PathPositive";
+//		File inputFile = new File(rupSetsDir, "fm3_1_noAz_cffClusterPathPositive.zip");
+		String compName = "FM3.1, UCERF3";
+		File compareFile = new File(rupSetsDir, "fm3_1_ucerf3.zip");
+		Region region = new RELM_TESTING();
+		
+		File outputDir = new File(mainOutputDir, inputFile.getName().replaceAll(".zip", ""));
+		Preconditions.checkState(outputDir.exists() || outputDir.mkdir());
+		
+		if (compareFile == null)
+			outputDir = new File(outputDir, "standalone");
+		else
+			outputDir = new File(outputDir, "comp_"+compareFile.getName().replaceAll(".zip", ""));
+		Preconditions.checkState(outputDir.exists() || outputDir.mkdir());
+		
+		File resourcesDir = new File(outputDir, "resources");
+		Preconditions.checkState(resourcesDir.exists() || resourcesDir.mkdir());
+		
+		FaultSystemRupSet inputRupSet;
+		FaultSystemSolution inputSol = null;
+		PlausibilityConfiguration inputConfig = null;
+		
+		FaultSystemRupSet compRupSet = null;
+		FaultSystemSolution compSol = null;
+		PlausibilityConfiguration compConfig = null;
+		
+		System.out.println("Loading input");
+		if (FaultSystemIO.isSolution(inputFile)) {
+			System.out.println("Input is a solution");
+			inputSol = FaultSystemIO.loadSol(inputFile);
+			inputRupSet = inputSol.getRupSet();
+		} else {
+			inputRupSet = FaultSystemIO.loadRupSet(inputFile);
+		}
+		inputConfig = inputRupSet.getPlausibilityConfiguration();
+		List<? extends FaultSection> subSects = inputRupSet.getFaultSectionDataList();
+		SectionDistanceAzimuthCalculator distAzCalc = new SectionDistanceAzimuthCalculator(subSects);
+		if (inputConfig == null) {
+			// see if it's UCERF3
+			FaultModels fm = getUCERF3FM(inputRupSet);
+			if (fm != null) {
+				inputConfig = PlausibilityConfiguration.getUCERF3(subSects, distAzCalc, fm);
+				inputRupSet.setPlausibilityConfiguration(inputConfig);
+			}
+		}
+		RuptureConnectionSearch inputSearch = new RuptureConnectionSearch(
+				inputRupSet, distAzCalc, getSearchMaxJumpDist(inputConfig), false);
+		System.out.println("Building input cluster ruptures");
+		List<ClusterRupture> inputRups = buildClusterRups(inputRupSet, inputSearch);
+		HashSet<UniqueRupture> inputUniques = new HashSet<>();
+		for (ClusterRupture rup : inputRups)
+			inputUniques.add(rup.unique);
+
+		List<ClusterRupture> compRups = null;
+		RuptureConnectionSearch compSearch = null;
+		HashSet<UniqueRupture> compUniques = null;
+		if (compareFile != null) {
+			System.out.println("Loading comparison");
+			if (FaultSystemIO.isSolution(compareFile)) {
+				System.out.println("comp is a solution");
+				compSol = FaultSystemIO.loadSol(compareFile);
+				compRupSet = compSol.getRupSet();
+			} else {
+				compRupSet = FaultSystemIO.loadRupSet(compareFile);
+			}
+			Preconditions.checkState(compRupSet.getNumSections() == subSects.size(),
+					"comp has different sub sect count");
+			compConfig = compRupSet.getPlausibilityConfiguration();
+			if (compConfig == null) {
+				// see if it's UCERF3
+				FaultModels fm = getUCERF3FM(compRupSet);
+				if (fm != null) {
+					compConfig = PlausibilityConfiguration.getUCERF3(subSects, distAzCalc, fm);
+					compRupSet.setPlausibilityConfiguration(compConfig);
+				}
+			}
+			compSearch = new RuptureConnectionSearch(
+					compRupSet, distAzCalc, getSearchMaxJumpDist(compConfig), false);
+			compRups = buildClusterRups(compRupSet, compSearch);
+			compUniques = new HashSet<>();
+			for (ClusterRupture rup : compRups)
+				compUniques.add(rup.unique);
+		}
+		
+		List<String> lines = new ArrayList<>();
+		lines.add("# Rupture Set Diagnostics: "+inputName);
+		lines.add("");
+		lines.addAll(getBasicLines(inputRupSet));
+		lines.add("");
+		if (inputConfig != null) {
+			lines.add("## Plausibility Configuration:");
+			lines.add("");
+			lines.addAll(getPlausibilityLines(inputConfig));
+			lines.add("");
+		}
+		
+		if (compRupSet != null) {
+			lines.add("## Comparison Rup Set");
+			lines.add("");
+			lines.add("Will include comparisons against: "+compName);
+			lines.add("");
+			lines.addAll(getBasicLines(compRupSet));
+			lines.add("");
+			if (inputConfig != null) {
+				lines.add("### Comp Plausibility Configuration:");
+				lines.add("");
+				lines.addAll(getPlausibilityLines(compConfig));
+				lines.add("");
+			}
+		}
+		
+		// length and magnitude distributions
+		int tocIndex = lines.size();
+		String topLink = "*[(top)](#table-of-contents)*";
+		
+		lines.add("## Rupture Size Histograms");
+		lines.add(topLink); lines.add("");
+		
+		TableBuilder table = MarkdownUtils.tableBuilder();
+		if (compRupSet != null)
+			table.addLine(inputName, compName);
+		
+		plotRuptureHistograms(resourcesDir, "len_hist", table, inputRupSet, inputSol,
+				inputUniques, compRupSet, compSol, compUniques, true);
+		plotRuptureHistograms(resourcesDir, "mag_hist", table, inputRupSet, inputSol,
+				inputUniques, compRupSet, compSol, compUniques, false);
+		
+		lines.addAll(table.build());
+		lines.add("");
+		
+		if (compRups != null && (inputConfig != null || compConfig != null)) {
+			// plausibility comparisons
+			
+			lines.add("Plausibility Comparisons");
+			lines.add(topLink); lines.add("");
+			
+			if (compConfig != null) {
+				lines.add("## "+inputName+" Comparisons with "+compName+" Filters");
+				lines.add(topLink); lines.add("");
+				
+				List<PlausibilityFilter> filters = new ArrayList<>();
+				// add implicit filters
+				double jumpDist = compConfig.getConnectionStrategy().getMaxJumpDist();
+				if (Double.isFinite(jumpDist))
+					filters.add(new JumpDistFilter(jumpDist));
+				filters.add(new SplayCountFilter(compConfig.getMaxNumSplays()));
+				filters.add(new SingleClusterPerParentFilter());
+				RupSetPlausibilityResult result = testRupSetPlausibility(inputRups, filters);
+				File plot = plotRupSetPlausibility(result, resourcesDir, "comp_filter_compare",
+						"Comparison with "+compName+" Filters");
+				lines.add("![plot](resources/"+plot.getName()+")");
+				lines.add("");
+				lines.addAll(getRupSetPlausibilityTable(result).build());
+				lines.add("");
+			}
+			
+			if (compRups != null && inputConfig != null) {
+				lines.add("## "+compName+" Comparisons with "+inputName+" Filters");
+				lines.add(topLink); lines.add("");
+				
+				List<PlausibilityFilter> filters = new ArrayList<>();
+				// add implicit filters
+				double jumpDist = inputConfig.getConnectionStrategy().getMaxJumpDist();
+				if (Double.isFinite(jumpDist))
+					filters.add(new JumpDistFilter(jumpDist));
+				filters.add(new SplayCountFilter(inputConfig.getMaxNumSplays()));
+				filters.add(new SingleClusterPerParentFilter());
+				RupSetPlausibilityResult result = testRupSetPlausibility(compRups, filters);
+				File plot = plotRupSetPlausibility(result, resourcesDir, "main_filter_compare",
+						"Comparison with "+inputName+" Filters");
+				lines.add("![plot](resources/"+plot.getName()+")");
+				lines.add("");
+				lines.addAll(getRupSetPlausibilityTable(result).build());
+				lines.add("");
+			}
+		}
+		
+		// connections plots
+		Map<Jump, List<Integer>> inputJumpsToRupsMap = new HashMap<>();
+		Map<Jump, Double> inputJumps = getJumps(inputSol, inputRups, inputJumpsToRupsMap);
+		
+		System.out.println("Plotting section connections");
+		plotConnectivityLines(inputRupSet, resourcesDir, "sect_connectivity",
+				inputName+" Connectivity", inputJumps.keySet(), MAIN_COLOR, region, 800);
+		plotConnectivityLines(inputRupSet, resourcesDir, "sect_connectivity_hires",
+				inputName+" Connectivity", inputJumps.keySet(), MAIN_COLOR, region, 3000);
+		Map<Jump, List<Integer>> compJumpsToRupsMap = null;
+		Map<Jump, Double> compJumps = null;
+		Map<Jump, Double> inputUniqueJumps = null;
+		Set<Jump> commonJumps = null;
+		Map<Jump, Double> compUniqueJumps = null;
+		if (compRups != null) {
+			compJumpsToRupsMap = new HashMap<>();
+			compJumps = getJumps(compSol, compRups, compJumpsToRupsMap);
+			plotConnectivityLines(compRupSet, resourcesDir, "sect_connectivity_comp",
+					compName+" Connectivity", compJumps.keySet(), COMP_COLOR, region, 800);
+			plotConnectivityLines(compRupSet, resourcesDir, "sect_connectivity_comp_hires",
+					compName+" Connectivity", compJumps.keySet(), COMP_COLOR, region, 3000);
+			inputUniqueJumps = new HashMap<>(inputJumps);
+			commonJumps = new HashSet<>();
+			for (Jump jump : compJumps.keySet()) {
+				if (inputUniqueJumps.containsKey(jump)) {
+					inputUniqueJumps.remove(jump);
+					commonJumps.add(jump);
+				}
+			}
+			plotConnectivityLines(inputRupSet, resourcesDir, "sect_connectivity_unique",
+					inputName+" Unique Connectivity", inputUniqueJumps.keySet(), MAIN_COLOR, region, 800);
+			plotConnectivityLines(inputRupSet, resourcesDir, "sect_connectivity_unique_hires",
+					inputName+" Unique Connectivity", inputUniqueJumps.keySet(), MAIN_COLOR, region, 3000);
+			compUniqueJumps = new HashMap<>(compJumps);
+			for (Jump jump : inputJumps.keySet())
+				if (compUniqueJumps.containsKey(jump))
+					compUniqueJumps.remove(jump);
+			plotConnectivityLines(compRupSet, resourcesDir, "sect_connectivity_unique_ucerf3",
+					compName+" Unique Connectivity", compUniqueJumps.keySet(), COMP_COLOR, region, 800);
+			plotConnectivityLines(compRupSet, resourcesDir, "sect_connectivity_unique_ucerf3_hires",
+					compName+" Unique Connectivity", compUniqueJumps.keySet(), COMP_COLOR, region, 3000);
+		}
+		
+		double maxConnDist = 0d;
+		for (Jump jump : inputJumps.keySet())
+			maxConnDist = Math.max(maxConnDist, jump.distance);
+		for (Jump jump : compJumps.keySet())
+			maxConnDist = Math.max(maxConnDist, jump.distance);
+		plotConnectivityHistogram(resourcesDir, "sect_connectivity_hist",
+				inputName+" Connectivity", inputJumps, inputUniqueJumps, maxConnDist,
+				MAIN_COLOR, false, false);
+		if (inputSol != null) {
+			plotConnectivityHistogram(resourcesDir, "sect_connectivity_hist_rates",
+					inputName+" Connectivity", inputJumps, inputUniqueJumps, maxConnDist,
+					MAIN_COLOR, true, false);
+			plotConnectivityHistogram(resourcesDir, "sect_connectivity_hist_rates_log",
+					inputName+" Connectivity", inputJumps, inputUniqueJumps, maxConnDist,
+					MAIN_COLOR, true, true);
+		}
+		if (compRups != null) {
+			plotConnectivityHistogram(resourcesDir, "sect_connectivity_hist_comp",
+					compName+" Connectivity", compJumps, compUniqueJumps, maxConnDist,
+					COMP_COLOR, false, false);
+			if (compSol != null) {
+				plotConnectivityHistogram(resourcesDir, "sect_connectivity_hist_rates_comp",
+						compName+" Connectivity", compJumps, compUniqueJumps, maxConnDist,
+						COMP_COLOR, true, false);
+				plotConnectivityHistogram(resourcesDir, "sect_connectivity_hist_rates_comp_log",
+						compName+" Connectivity", compJumps, compUniqueJumps, maxConnDist,
+						COMP_COLOR, true, true);
+			}
+		}
+		
+		lines.add("## Fault Section Connections");
+		lines.add(topLink); lines.add("");
+		
+		if (compRups != null) {
+			List<Set<Jump>> connectionsList = new ArrayList<>();
+			List<Color> connectedColors = new ArrayList<>();
+			List<String> connNames = new ArrayList<>();
+			
+			connectionsList.add(inputUniqueJumps.keySet());
+			connectedColors.add(MAIN_COLOR);
+			connNames.add(inputName+" Only");
+			
+			connectionsList.add(compUniqueJumps.keySet());
+			connectedColors.add(COMP_COLOR);
+			connNames.add(compName+" Only");
+			
+			connectionsList.add(commonJumps);
+			connectedColors.add(COMMON_COLOR);
+			connNames.add("Common Connections");
+			
+			String combConnPrefix = "sect_connectivity_combined";
+			plotConnectivityLines(inputRupSet, resourcesDir, combConnPrefix, "Combined Connectivity",
+					connectionsList, connectedColors, connNames, region, 800);
+			plotConnectivityLines(inputRupSet, resourcesDir, combConnPrefix+"_hires", "Combined Connectivity",
+					connectionsList, connectedColors, connNames, region, 3000);
+			lines.add("![Combined]("+resourcesDir.getName()+"/"+combConnPrefix+".png)");
+			lines.add("");
+			lines.add("[View high resolution]("+resourcesDir.getName()+"/"+combConnPrefix+"_hires.png)");
+			lines.add("");
+		}
+		
+		table = MarkdownUtils.tableBuilder();
+		if (compRups != null)
+			table.addLine(inputName, compName);
+		File mainPlot = new File(resourcesDir, "sect_connectivity.png");
+		File compPlot = new File(resourcesDir, "sect_connectivity_comp.png");
+		addTablePlots(table, mainPlot, compPlot, compRups != null);
+		if (compRups != null) {
+			mainPlot = new File(resourcesDir, "sect_connectivity_unique.png");
+			compPlot = new File(resourcesDir, "sect_connectivity_unique_comp.png");
+			Preconditions.checkState(compPlot.exists());
+			addTablePlots(table, mainPlot, compPlot, compRups != null);
+		}
+		mainPlot = new File(resourcesDir, "sect_connectivity_hist.png");
+		compPlot = new File(resourcesDir, "sect_connectivity_hist_comp.png");
+		addTablePlots(table, mainPlot, compPlot, compRups != null);
+		if (inputSol != null || compSol != null) {
+			mainPlot = new File(resourcesDir, "sect_connectivity_hist_rates.png");
+			compPlot = new File(resourcesDir, "sect_connectivity_hist_rates_comp.png");
+			addTablePlots(table, mainPlot, compPlot, compRups != null);
+			mainPlot = new File(resourcesDir, "sect_connectivity_hist_rates_log.png");
+			compPlot = new File(resourcesDir, "sect_connectivity_hist_rates_comp_log.png");
+			addTablePlots(table, mainPlot, compPlot, compRups != null);
+		}
+		lines.addAll(table.build());
+		lines.add("");
+		
+		if (compRups!= null) {
+			System.out.println("Plotting connection examples");
+			lines.add("### Unique Connection Example Ruptures");
+			lines.add(topLink); lines.add("");
+			
+			lines.add("**"+inputName+" Ruptures with Unique Connections**");
+			int maxRups = 20;
+			int maxCols = 5;
+			table = plotConnRupExamples(inputSearch, inputUniqueJumps.keySet(),
+					inputJumpsToRupsMap, maxRups, maxCols, resourcesDir, "conn_example");
+			lines.add("");
+			if (table == null)
+				lines.add("*N/A*");
+			else
+				lines.addAll(table.build());
+			lines.add("");
+			lines.add("**"+compName+" Ruptures with Unique Connections**");
+			table = plotConnRupExamples(compSearch, compUniqueJumps.keySet(),
+					compJumpsToRupsMap, maxRups, maxCols, resourcesDir, "comp_conn_example");
+			lines.add("");
+			if (table == null)
+				lines.add("*N/A*");
+			else
+				lines.addAll(table.build());
+			lines.add("");
+		}
+		
+		// now jumps
+		
+		float[] maxJumpDists = { 0.1f, 1f, 3f };
+		boolean hasSols = compSol != null || inputSol != null;
+		
+		lines.add("## Jump Counts Over Distance");
+		lines.add(topLink); lines.add("");
+		table = MarkdownUtils.tableBuilder();
+		if (hasSols)
+			table.addLine("As Discretized", "Rate Weighted");
+		for (float jumpDist : maxJumpDists) {
+			lines.add("");
+			System.out.println("Plotting num jumps");
+			table.initNewLine();
+			File plotFile = plotFixedJumpDist(inputRupSet, null, inputRups, inputName,
+					compRupSet, null, compRups, compName, distAzCalc, 0d, jumpDist, resourcesDir);
+			table.addColumn("![Plausibility Filter]("+resourcesDir.getName()+"/"+plotFile.getName()+")");
+			if (hasSols) {
+				plotFile = plotFixedJumpDist(
+						inputSol == null ? null : inputRupSet, inputSol, inputRups, inputName,
+						compSol == null ? null : compRupSet, compSol, compRups, compName,
+						distAzCalc, 0d, jumpDist, resourcesDir);
+				table.addColumn("![Plausibility Filter]("+resourcesDir.getName()+"/"+plotFile.getName()+")");
+			}
+		}
+		lines.add("");
+		
+		// now azimuths
+		List<RakeType> rakeTypes = new ArrayList<>();
+		rakeTypes.add(null);
+		for (RakeType type : RakeType.values())
+			rakeTypes.add(type);
+		lines.add("## Jump Azimuths");
+		lines.add(topLink); lines.add("");
+		
+		Table<RakeType, RakeType, List<Double>> inputRakeAzTable = calcJumpAzimuths(inputRups, distAzCalc);
+		Table<RakeType, RakeType, List<Double>> compRakeAzTable = null;
+		if (compRups != null)
+			compRakeAzTable = calcJumpAzimuths(compRups, distAzCalc);
+		
+		for (RakeType sourceType : rakeTypes) {
+			String prefix, title;
+			if (sourceType == null) {
+				prefix = "jump_az_any";
+				title = "Jumps from Any";
+				lines.add("### Jump Azimuths From Any");
+			} else {
+				prefix = "jump_az_"+sourceType.prefix;
+				title = "Jumps from "+sourceType.name;
+				lines.add("### Jump Azimuths From "+sourceType.name);
+			}
+			
+			System.out.println("Plotting "+title);
+
+			lines.add(topLink); lines.add("");
+			
+			table = MarkdownUtils.tableBuilder();
+			if (compRups != null)
+				table.addLine(inputName, compName);
+			
+			table.initNewLine();
+			File plotFile = plotJumpAzimuths(sourceType, rakeTypes, inputRakeAzTable,
+					resourcesDir, prefix, title);
+			table.addColumn("!["+title+"](resources/"+plotFile.getName()+")");
+			if (compRups != null) {
+				plotFile = plotJumpAzimuths(sourceType, rakeTypes, compRakeAzTable,
+						resourcesDir, prefix+"_comp", title);
+				table.addColumn("!["+title+"](resources/"+plotFile.getName()+")");
+			}
+			table.finalizeLine();
+			lines.addAll(table.build());
+			lines.add("");
+			
+			table = MarkdownUtils.tableBuilder();
+			table.initNewLine();
+			
+			for (RakeType destType : rakeTypes) {
+				String myPrefix = prefix+"_";
+				String myTitle = title+" to ";
+				if (destType == null) {
+					myPrefix += "any";
+					myTitle += "Any";
+				} else {
+					myPrefix += destType.prefix;
+					myTitle += destType.name;
+				}
+				
+				plotFile = plotJumpAzimuthsRadial(sourceType, destType, inputRakeAzTable,
+						resourcesDir, myPrefix, myTitle);
+				table.addColumn("!["+title+"](resources/"+plotFile.getName()+")");
+			}
+			table.finalizeLine();
+			lines.addAll(table.wrap(3, 0).build());
+			lines.add("");
+		}
+		
+		// add TOC
+		lines.addAll(tocIndex, MarkdownUtils.buildTOC(lines, 2));
+		lines.add(tocIndex, "## Table Of Contents");
+		
+		// write markdown
+		MarkdownUtils.writeReadmeAndHTML(lines, outputDir);
+	}
+	
+	private static void addTablePlots(TableBuilder table, File mainPlot, File compPlot,
+			boolean hasComp) {
+		table.initNewLine();
+		if (mainPlot.exists())	
+			table.addColumn("![plot]("+mainPlot.getParentFile().getName()
+					+"/"+mainPlot.getName()+")");
+		else
+			table.addColumn("*N/A*");
+		if (hasComp) {
+			if (compPlot.exists())
+				table.addColumn("![plot]("+compPlot.getParentFile().getName()
+						+"/"+compPlot.getName()+")");
+			else
+				table.addColumn("*N/A*");
+		}
+		table.finalizeLine();
+	}
+	
+	private static final Color MAIN_COLOR = Color.RED;
+	private static final Color COMP_COLOR = Color.BLUE;
+	private static final Color COMMON_COLOR = Color.GREEN;
+
+	private static DecimalFormat twoDigits = new DecimalFormat("0.00");
+	private static DecimalFormat thousands = new DecimalFormat("0");
+	static {
+		thousands.getDecimalFormatSymbols().setGroupingSeparator(',');
+	}
+	
+	private static double getLength(FaultSystemRupSet rupSet, int r) {
+		double[] lengths = rupSet.getLengthForAllRups();
+		if (lengths == null) {
+			// calculate it
+			double len = 0d;
+			for (FaultSection sect : rupSet.getFaultSectionDataForRupture(r))
+				len += sect.getTraceLength();
+			return len;
+		}
+		return lengths[r]*1e-3; // m => km
+	}
+	
+	private static List<String> getBasicLines(FaultSystemRupSet rupSet) {
+		List<String> lines = new ArrayList<>();
+		MinMaxAveTracker magTrack = new MinMaxAveTracker();
+		MinMaxAveTracker lenTrack = new MinMaxAveTracker();
+		MinMaxAveTracker sectsTrack = new MinMaxAveTracker();
+		for (int r=0; r<rupSet.getNumRuptures(); r++) {
+			magTrack.addValue(rupSet.getMagForRup(r));
+			lenTrack.addValue(getLength(rupSet, r));
+			sectsTrack.addValue(rupSet.getSectionsIndicesForRup(r).size());
+		}
+		lines.add("* Num ruptures: "+thousands.format(rupSet.getNumRuptures()));
+		lines.add("* Rupture mag range: ["+twoDigits.format(magTrack.getMin())
+		+","+twoDigits.format(magTrack.getMax())+"]");
+		lines.add("* Rupture length range: ["+twoDigits.format(lenTrack.getMin())
+		+","+twoDigits.format(lenTrack.getMax())+"] km");
+		lines.add("* Rupture sect count range: ["+(int)sectsTrack.getMin()
+			+","+(int)sectsTrack.getMax()+"]");
+		return lines;
+	}
+	
+	private static List<String> getPlausibilityLines(PlausibilityConfiguration config) {
+		List<String> lines = new ArrayList<>();
+		
+		ClusterConnectionStrategy connStrat = config.getConnectionStrategy();
+		MinMaxAveTracker parentConnTrack = new MinMaxAveTracker();
+		HashSet<Integer> parentIDs = new HashSet<>();
+		for (FaultSection sect : connStrat.getSubSections())
+			parentIDs.add(sect.getParentSectionId());
+		int totNumConnections = 0;
+		for (int parentID1 : parentIDs) {
+			int myConnections = 0;
+			for (int parentID2 : parentIDs) {
+				if (parentID1 == parentID2)
+					continue;
+				if (connStrat.areParentSectsConnected(parentID1, parentID2))
+					myConnections++;
+			}
+			parentConnTrack.addValue(myConnections);
+			totNumConnections += myConnections;
+		}
+		int minConns = (int)parentConnTrack.getMin();
+		int maxConns = (int)parentConnTrack.getMax();
+		String avgConns = twoDigits.format(parentConnTrack.getAverage());
+		totNumConnections /= 2; // remove duplicates
+		lines.add("* Connection strategy: ");
+		lines.add(" * Max jump dist: "+(float)connStrat.getMaxJumpDist()+" km");
+		lines.add(" * Allowed parent-section connections:");
+		lines.add("  * Total: "+totNumConnections);
+		lines.add("  * Each: avg="+avgConns+", range=["+minConns+","+maxConns+"]");
+		lines.add("* Max num splays: "+config.getMaxNumSplays());
+		lines.add("* Filters:");
+		for (PlausibilityFilter filter : config.getFilters())
+			lines.add(" * "+filter.getName());
+		
+		return lines;
+	}
+	
+	private static FaultModels getUCERF3FM(FaultSystemRupSet rupSet) {
+		if (rupSet.getNumRuptures() == 253706)
+			return FaultModels.FM3_1;
+		if (rupSet.getNumRuptures() == 305709)
+			return FaultModels.FM3_2;
+		return null;
+	}
+	
+	/*
+	 * Conversion from subsection list to cluster ruptures
+	 */
+	
+	public static List<ClusterRupture> buildClusterRups(FaultSystemRupSet rupSet,
+			RuptureConnectionSearch search) {
+		PlausibilityConfiguration config = rupSet.getPlausibilityConfiguration();
+		System.out.println("Config null ? "+(config == null));
+		if (config != null && config.getMaxNumSplays() == 0) {
+			// if splays aren't allowed and we have a plausibility configuration, then simple strand ruptures
+			System.out.println("Assuming simple single strand ruptures");
+			List<ClusterRupture> rups = new ArrayList<>();
+			
+			for (int r=0; r<rupSet.getNumRuptures(); r++) {
+				List<FaultSection> rupSects = rupSet.getFaultSectionDataForRupture(r);
+//				System.out.println("rupture "+r);
+				rups.add(ClusterRupture.forOrderedSingleStrandRupture(rupSects, search.getDistAzCalc()));
+			}
+			
+			return rups;
+		}
+		ExecutorService exec = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+		
+		List<Future<ClusterRupture>> futures = new ArrayList<>();
+		for (int r=0; r<rupSet.getNumRuptures(); r++)
+			futures.add(exec.submit(new ClusterRupCalc(search, r)));
+		
+		List<ClusterRupture> ruptures = new ArrayList<>();
+		
+		for (int r=0; r<futures.size(); r++) {
+			if (r % 1000 == 0)
+				System.out.println("Calculating for rupture "+r+"/"+rupSet.getNumRuptures());
+			Future<ClusterRupture> future = futures.get(r);
+			try {
+				ruptures.add(future.get());
+			} catch (InterruptedException | ExecutionException e) {
+				exec.shutdown();
+				throw ExceptionUtils.asRuntimeException(e);
+			}
+		}
+		
+		System.out.println("Built "+ruptures.size()+" ruptures");
+		
+		exec.shutdown();
+		Preconditions.checkState(ruptures.size() == rupSet.getNumRuptures());
+		
+		return ruptures;
+	}
+	
+	private static class ClusterRupCalc implements Callable<ClusterRupture> {
+		
+		private RuptureConnectionSearch search;
+		private int rupIndex;
+
+		public ClusterRupCalc(RuptureConnectionSearch search, int rupIndex) {
+			this.search = search;
+			this.rupIndex = rupIndex;
+		}
+
+		@Override
+		public ClusterRupture call() throws Exception {
+			return search.buildClusterRupture(rupIndex, false);
+		}
+		
+	}
+	
+	private static double getSearchMaxJumpDist(PlausibilityConfiguration config) {
+		if (config == null)
+			return 100d;
+		ClusterConnectionStrategy connStrat = config.getConnectionStrategy();
+		double maxDist = connStrat.getMaxJumpDist();
+		if (Double.isFinite(maxDist))
+			return maxDist;
+		return 100d;
+	}
+	
+	public static void plotRuptureHistograms(File outputDir, String prefix, TableBuilder table,
+			FaultSystemRupSet inputRupSet, FaultSystemSolution inputSol,
+			HashSet<UniqueRupture> inputUniques, FaultSystemRupSet compRupSet,
+			FaultSystemSolution compSol, HashSet<UniqueRupture> compUniques, boolean length)
+			throws IOException {
+		File main = plotRuptureHistogram(outputDir, prefix, inputRupSet, null,
+				compUniques, MAIN_COLOR, length);
+		table.initNewLine();
+		table.addColumn("![hist]("+outputDir.getName()+"/"+main.getName()+")");
+		if (compRupSet != null) {
+			File comp = plotRuptureHistogram(outputDir, prefix+"_comp", compRupSet, null,
+					inputUniques, COMP_COLOR, length);
+			table.addColumn("![hist]("+outputDir.getName()+"/"+comp.getName()+")");
+		}
+		table.finalizeLine();
+		if (inputSol != null || compSol != null) {
+			table.initNewLine();
+			
+			if (inputSol != null) {
+				main = plotRuptureHistogram(outputDir, prefix+"_rates", inputRupSet, inputSol,
+						compUniques, MAIN_COLOR, length);
+				table.addColumn("![hist]("+outputDir.getName()+"/"+main.getName()+")");
+			} else {
+				table.addColumn("*N/A*");
+			}
+			if (compSol != null) {
+				File comp = plotRuptureHistogram(outputDir, prefix+"_comp_rates", compRupSet,
+						compSol, inputUniques, COMP_COLOR, length);
+				table.addColumn("![hist]("+outputDir.getName()+"/"+comp.getName()+")");
+			} else {
+				table.addColumn("*N/A*");
+			}
+			
+			table.finalizeLine();
+		}
+	}
+	
+	public static File plotRuptureHistogram(File outputDir, String prefix,
+			FaultSystemRupSet rupSet, FaultSystemSolution sol, HashSet<UniqueRupture> compRups,
+			Color color, boolean length) throws IOException {
+		List<Double> scalars = new ArrayList<>();
+		MinMaxAveTracker track = new MinMaxAveTracker();
+		for (int r=0; r<rupSet.getNumRuptures(); r++) {
+			double scalar;
+			if (length)
+				scalar = getLength(rupSet, r);
+			else
+				scalar = rupSet.getMagForRup(r);
+			scalars.add(scalar);
+			track.addValue(scalar);
+		}
+		HistogramFunction hist;
+		if (length)
+			hist = HistogramFunction.getEncompassingHistogram(0d, track.getMax(), 50d);
+		else
+			hist = HistogramFunction.getEncompassingHistogram(Math.floor(track.getMin()),
+					Math.ceil(track.getMax()), 0.1d);
+		HistogramFunction commonHist = null;
+		if (compRups != null)
+			commonHist = new HistogramFunction(hist.getMinX(), hist.getMaxX(), hist.size());
+		
+		for (int r=0; r<rupSet.getNumRuptures(); r++) {
+			double scalar = scalars.get(r);
+			double y = sol == null ? 1 : sol.getRateForRup(r);
+			hist.add(hist.getClosestXIndex(scalar), y);
+			if (compRups != null && compRups.contains(
+					new UniqueRupture(rupSet.getSectionsIndicesForRup(r)))) {
+				commonHist.add(hist.getClosestXIndex(scalar), y);
+			}
+		}
+		
+		List<DiscretizedFunc> funcs = new ArrayList<>();
+		List<PlotCurveCharacterstics> chars = new ArrayList<>();
+		
+		hist.setName("All Ruptures");
+		funcs.add(hist);
+		chars.add(new PlotCurveCharacterstics(PlotLineType.HISTOGRAM, 1f, color));
+		
+		if (commonHist != null) {
+			commonHist.setName("Common To Both");
+			funcs.add(commonHist);
+			chars.add(new PlotCurveCharacterstics(PlotLineType.HISTOGRAM, 1f, COMMON_COLOR));
+		}
+		
+		String title;
+		String xAxisLabel;
+		if (length) {
+			title = "Rupture Length Histogram";
+			xAxisLabel = "Length (km)";
+		} else {
+			title = "Rupture Magnitude Histogram";
+			xAxisLabel = "Magnitude";
+		}
+		String yAxisLabel = sol == null ? "Count" : "Annual Rate";
+		
+		PlotSpec spec = new PlotSpec(funcs, chars, title, xAxisLabel, yAxisLabel);
+		spec.setLegendVisible(compRups != null);
+		
+		Range xRange = new Range(hist.getMinX() - 0.5*hist.getDelta(),
+				hist.getMaxX() + 0.5*hist.getDelta());
+		
+		HeadlessGraphPanel gp = new HeadlessGraphPanel();
+		gp.setBackgroundColor(Color.WHITE);
+		gp.setTickLabelFontSize(18);
+		gp.setAxisLabelFontSize(20);
+		gp.setPlotLabelFontSize(21);
+		gp.setLegendFontSize(22);
+		
+		gp.drawGraphPanel(spec, false, false, xRange, null);
+		gp.getChartPanel().setSize(800, 600);
+		File pngFile = new File(outputDir, prefix+".png");
+		File pdfFile = new File(outputDir, prefix+".pdf");
+		gp.saveAsPNG(pngFile.getAbsolutePath());
+		gp.saveAsPDF(pdfFile.getAbsolutePath());
+		return pngFile;
+	}
+	
+	/*
+	 * rupture plausibility testing
+	 */
+	
+	public static RupSetPlausibilityResult testRupSetPlausibility(List<ClusterRupture> rups,
+			List<PlausibilityFilter> filters) {
+		int allPassCount = 0;
+		int[] failCounts = new int[filters.size()];
+		int[] failCanContinueCounts = new int[filters.size()];
+		int[] onlyFailCounts = new int[filters.size()];
+		int[] erredCounts = new int[filters.size()];
+		
+		for (ClusterRupture rupture : rups) {
+			boolean allPass = true;
+			int onlyFailureIndex = -1;
+			for (int t=0; t<filters.size(); t++) {
+				PlausibilityFilter test = filters.get(t);
+				PlausibilityResult result;
+				boolean subPass;
+				try {
+					result = test.apply(rupture, false);
+					if (result == PlausibilityResult.FAIL_FUTURE_POSSIBLE)
+						failCanContinueCounts[t]++;
+					subPass = result.isPass();
+				} catch (Exception e) {
+					if (erredCounts[t] == 0) {
+						System.err.println("First exception for "+test.getName()+":");
+						e.printStackTrace();
+					}
+					erredCounts[t] ++;
+					subPass = true; // do not fail on error
+				}
+				if (!subPass && allPass) {
+					// this is the first failure
+					onlyFailureIndex = t;
+				} else if (!subPass) {
+					// failed more than 1
+					onlyFailureIndex = -1;
+				}
+				allPass = subPass && allPass;
+				if (!subPass)
+					failCounts[t] ++;
+			}
+			if (allPass)
+				allPassCount ++;
+			if (onlyFailureIndex >= 0)
+				onlyFailCounts[onlyFailureIndex] ++;
+		}
+		
+		return new RupSetPlausibilityResult(filters, rups.size(), allPassCount, failCounts,
+				failCanContinueCounts, onlyFailCounts, erredCounts);
+	}
+	
+	public static class RupSetPlausibilityResult {
+		public final List<PlausibilityFilter> filters;
+		public final int numRuptures;
+		public final int allPassCount;
+		public final int[] failCounts;
+		public final int[] failCanContinueCounts;
+		public final int[] onlyFailCounts;
+		public final int[] erredCounts;
+		
+		public RupSetPlausibilityResult(List<PlausibilityFilter> filters, int numRuptures, int allPassCount,
+				int[] failCounts, int[] failCanContinueCounts, int[] onlyFailCounts, int[] erredCounts) {
+			super();
+			this.filters = filters;
+			this.numRuptures = numRuptures;
+			this.allPassCount = allPassCount;
+			this.failCounts = failCounts;
+			this.failCanContinueCounts = failCanContinueCounts;
+			this.onlyFailCounts = onlyFailCounts;
+			this.erredCounts = erredCounts;
+		}
+	}
+	
+	private static Color[] FILTER_COLORS = { Color.DARK_GRAY, new Color(102, 51, 0), Color.RED, Color.BLUE,
+			Color.GREEN.darker(), Color.CYAN, Color.PINK, Color.ORANGE.darker(), Color.MAGENTA };
+	
+	public static File plotRupSetPlausibility(RupSetPlausibilityResult result, File outputDir,
+			String prefix, String title) throws IOException {
+		double dx = 1d;
+		double buffer = 0.2*dx;
+		double deltaEachSide = (dx - buffer)/2d;
+		double maxY = 50;
+
+		Font font = new Font(Font.SANS_SERIF, Font.BOLD, 22);
+		Font allFont = new Font(Font.SANS_SERIF, Font.BOLD, 26);
+		
+		List<PlotElement> funcs = new ArrayList<>();
+		List<PlotCurveCharacterstics> chars = new ArrayList<>();
+		
+		funcs.add(new DefaultXY_DataSet(new double[] {0d, 1d}, new double[] {0d, 0d}));
+		chars.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 0f, Color.WHITE));
+		
+		List<XYAnnotation> anns = new ArrayList<>();
+		
+		double topRowY = maxY*0.95;
+		double secondRowY = maxY*0.91;
+		double thirdRowY = maxY*0.85;
+		
+		for (int i=0; i<result.filters.size(); i++) {
+			double x = i*dx + 0.5*dx;
+			double percentFailed = 100d*result.failCounts[i]/result.numRuptures;
+			double percentOnly = 100d*result.onlyFailCounts[i]/result.numRuptures;
+			double percentErred = 100d*result.erredCounts[i]/result.numRuptures;
+			
+			Color c = FILTER_COLORS[i % FILTER_COLORS.length];
+			
+			String name = result.filters.get(i).getShortName();
+			
+			if (percentErred > 0) {
+//				funcs.add(vertLine(x, percentFailed, percentFailed + percentErred));
+//				chars.add(new PlotCurveCharacterstics(PlotLineType.SOLID, thickness, Color.LIGHT_GRAY));
+				anns.add(emptyBox(x-deltaEachSide, 0d, x+deltaEachSide, percentFailed + percentErred,
+						PlotLineType.DASHED, Color.LIGHT_GRAY, 2f));
+				name += "*";
+			}
+			
+//			funcs.add(vertLine(x, 0, percentFailed));
+//			chars.add(new PlotCurveCharacterstics(PlotLineType.SOLID, thickness, c));
+			anns.add(filledBox(x-deltaEachSide, 0, x+deltaEachSide, percentFailed, c));
+			
+			if (percentOnly > 0) {
+//				funcs.add(vertLine(x, 0, percentOnly));
+//				chars.add(new PlotCurveCharacterstics(PlotLineType.SOLID, thickness, darker(c)));
+				anns.add(filledBox(x-deltaEachSide, 0, x+deltaEachSide, percentOnly, darker(c)));
+			}
+			
+			XYTextAnnotation ann = new XYTextAnnotation(name, x, i % 2 == 0 ? secondRowY : thirdRowY);
+			ann.setTextAnchor(TextAnchor.TOP_CENTER);
+			ann.setPaint(c);
+			ann.setFont(font);
+			
+			anns.add(ann);
+			
+			ann = new XYTextAnnotation(percentDF.format(percentFailed/100d), x, percentFailed+0.6);
+			ann.setTextAnchor(TextAnchor.BOTTOM_CENTER);
+			ann.setPaint(Color.BLACK);
+			ann.setFont(font);
+			
+			anns.add(ann);
+		}
+		
+		Range xRange = new Range(-0.15*dx, (result.filters.size()+0.15)*dx);
+		
+		XYTextAnnotation ann = new XYTextAnnotation(
+				percentDF.format((double)result.allPassCount/result.numRuptures)+" passed all",
+				xRange.getCentralValue(), topRowY);
+		ann.setTextAnchor(TextAnchor.CENTER);
+		ann.setPaint(Color.BLACK);
+		ann.setFont(allFont);
+		
+		anns.add(ann);
+		
+		PlotSpec spec = new PlotSpec(funcs, chars, title, " ", "Percent Failed");
+		spec.setPlotAnnotations(anns);
+		
+		HeadlessGraphPanel gp = new HeadlessGraphPanel();
+		gp.setBackgroundColor(Color.WHITE);
+		gp.setTickLabelFontSize(18);
+		gp.setAxisLabelFontSize(20);
+		gp.setPlotLabelFontSize(21);
+		
+		gp.drawGraphPanel(spec, false, false, xRange, new Range(0, maxY));
+		gp.getXAxis().setTickLabelsVisible(false);
+//		gp.getXAxis().setvisi
+		gp.getChartPanel().setSize(1200, 600);
+		File pngFile = new File(outputDir, prefix+".png");
+		File pdfFile = new File(outputDir, prefix+".pdf");
+		gp.saveAsPNG(pngFile.getAbsolutePath());
+		gp.saveAsPDF(pdfFile.getAbsolutePath());
+		return pngFile;
+	}
+	
+	private static Color darker(Color c) {
+		int r = c.getRed();
+		int g = c.getGreen();
+		int b = c.getBlue();
+//		r += (255-r)/2;
+//		g += (255-g)/2;
+//		b += (255-b)/2;
+		r /= 2;
+		g /= 2;
+		b /= 2;
+		return new Color(r, g, b);
+	}
+	
+	private static DefaultXY_DataSet vertLine(double x, double y0, double y1) {
+		DefaultXY_DataSet line = new DefaultXY_DataSet();
+		line.set(x, y0);
+		line.set(x, y1);
+		return line;
+	}
+	
+	private static XYBoxAnnotation filledBox(double x0, double y0, double x1, double y1, Color c) {
+		XYBoxAnnotation ann = new XYBoxAnnotation(x0, y0, x1, y1, null, null, c);
+		return ann;
+	}
+	
+	private static XYBoxAnnotation emptyBox(double x0, double y0, double x1, double y1,
+			PlotLineType lineType, Color c, float thickness) {
+		Stroke stroke = lineType.buildStroke(thickness);
+		XYBoxAnnotation ann = new XYBoxAnnotation(x0, y0, x1, y1, stroke, c, null);
+		return ann;
+	}
+	
+	public static TableBuilder getRupSetPlausibilityTable(RupSetPlausibilityResult result) {
+		TableBuilder table = MarkdownUtils.tableBuilder();
+		table.addLine("Filter", "Failed", "Only Failure", "Erred");
+		for (int t=0; t<result.filters.size(); t++) {
+			table.initNewLine();
+			table.addColumn("**"+result.filters.get(t).getName()+"**");
+			table.addColumn(countStats(result.failCounts[t], result.numRuptures));
+			table.addColumn(countStats(result.onlyFailCounts[t], result.numRuptures));
+			table.addColumn(countStats(result.erredCounts[t], result.numRuptures));
+			table.finalizeLine();
+		}
+		return table;
+	}
+	
+	private static final DecimalFormat percentDF = new DecimalFormat("0.00%");
+	private static String countStats(int count, int tot) {
+		return count+"/"+tot+" ("+percentDF.format((double)count/(double)tot)+")";
+	}
+	
+	/*
+	 * Rupture connections
+	 */
+	
+	static void plotConnectivityLines(FaultSystemRupSet rupSet, File outputDir, String prefix, String title,
+			Set<Jump> connections, Color connectedColor, Region reg, int width) throws IOException {
+		List<Set<Jump>> connectionsList = new ArrayList<>();
+		List<Color> connectedColors = new ArrayList<>();
+		List<String> connNames = new ArrayList<>();
+		
+		connectionsList.add(connections);
+		connectedColors.add(connectedColor);
+		connNames.add("Connections");
+		
+		plotConnectivityLines(rupSet, outputDir, prefix, title, connectionsList, connectedColors, connNames, reg, width);
+	}
+	
+	static void plotConnectivityLines(FaultSystemRupSet rupSet, File outputDir, String prefix, String title,
+			List<Set<Jump>> connectionsList, List<Color> connectedColors, List<String> connNames,
+			Region reg, int width) throws IOException {
+		Color faultColor = Color.DARK_GRAY;
+		Color faultOutlineColor = Color.LIGHT_GRAY;
+		
+		List<XY_DataSet> funcs = new ArrayList<>();
+		List<PlotCurveCharacterstics> chars = new ArrayList<>();
+		
+		if (reg instanceof RELM_TESTING) {
+			// add ca outlines
+			XY_DataSet[] outlines = PoliticalBoundariesData.loadCAOutlines();
+			PlotCurveCharacterstics outlineChar = new PlotCurveCharacterstics(PlotLineType.SOLID, (float)1d, Color.GRAY);
+			
+			for (XY_DataSet outline : outlines) {
+				funcs.add(outline);
+				chars.add(outlineChar);
+			}
+		}
+		
+		List<Location> middles = new ArrayList<>();
+		
+		for (int s=0; s<rupSet.getNumSections(); s++) {
+			FaultSection sect = rupSet.getFaultSectionData(s);
+			RuptureSurface surf = sect.getFaultSurface(1d);
+			
+			XY_DataSet trace = new DefaultXY_DataSet();
+			for (Location loc : surf.getEvenlyDiscritizedUpperEdge())
+				trace.set(loc.getLongitude(), loc.getLatitude());
+			
+			if (sect.getAveDip() != 90d) {
+				XY_DataSet outline = new DefaultXY_DataSet();
+				LocationList perimeter = surf.getPerimeter();
+				for (Location loc : perimeter)
+					outline.set(loc.getLongitude(), loc.getLatitude());
+				Location first = perimeter.first();
+				outline.set(first.getLongitude(), first.getLatitude());
+				
+				funcs.add(0, outline);
+				chars.add(0, new PlotCurveCharacterstics(PlotLineType.SOLID, 1f, faultOutlineColor));
+			}
+			
+			middles.add(GriddedSurfaceUtils.getSurfaceMiddleLoc(surf));
+			
+			if (s == 0)
+				trace.setName("Fault Sections");
+			
+			funcs.add(trace);
+			chars.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 1f, faultColor));
+		}
+		
+		for (int i=0; i<connectionsList.size(); i++) {
+			Set<Jump> connections = connectionsList.get(i);
+			Color connectedColor = connectedColors.get(i);
+			String connName = connNames.get(i);
+			
+			boolean first = true;
+			for (Jump connection : connections) {
+				DefaultXY_DataSet xy = new DefaultXY_DataSet();
+				
+				if (first) {
+					xy.setName(connName);
+					first = false;
+				}
+				
+				Location loc1 = middles.get(connection.fromSection.getSectionId());
+				Location loc2 = middles.get(connection.toSection.getSectionId());
+				
+				xy.set(loc1.getLongitude(), loc1.getLatitude());
+				xy.set(loc2.getLongitude(), loc2.getLatitude());
+				
+				funcs.add(xy);
+				chars.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 2f, connectedColor));
+			}
+		}
+		
+		PlotSpec spec = new PlotSpec(funcs, chars, title, "Longitude", "Latitude");
+		spec.setLegendVisible(true);
+		
+		HeadlessGraphPanel gp = new HeadlessGraphPanel();
+		gp.setTickLabelFontSize(18);
+		gp.setAxisLabelFontSize(24);
+		gp.setPlotLabelFontSize(24);
+		gp.setBackgroundColor(Color.WHITE);
+		
+		Range xRange = new Range(reg.getMinLon(), reg.getMaxLon());
+		Range yRange = new Range(reg.getMinLat(), reg.getMaxLat());
+		
+		gp.drawGraphPanel(spec, false, false, xRange, yRange);
+		double tick = 2d;
+		TickUnits tus = new TickUnits();
+		TickUnit tu = new NumberTickUnit(tick);
+		tus.add(tu);
+		gp.getXAxis().setStandardTickUnits(tus);
+		gp.getYAxis().setStandardTickUnits(tus);
+		
+		File file = new File(outputDir, prefix);
+		double aspectRatio = yRange.getLength() / xRange.getLength();
+		gp.getChartPanel().setSize(width, 200 + (int)((width-200d)*aspectRatio));
+		gp.saveAsPNG(file.getAbsolutePath()+".png");
+		gp.saveAsPDF(file.getAbsolutePath()+".pdf");
+	}
+	
+	static void plotConnectivityHistogram(File outputDir, String prefix, String title,
+			Map<Jump, Double> connections, Map<Jump, Double> uniqueConnections,
+			double maxDist, Color connectedColor, boolean rateWeighted, boolean yLog)
+					throws IOException {
+		double delta = 1d;
+//		if (maxDist > 90)
+//			delta = 5d;
+//		else if (maxDist > 40)
+//			delta = 2;
+//		else if (maxDist > 20)
+//			delta = 1d;
+//		else
+//			delta = 0.5d;
+		
+		HistogramFunction hist = HistogramFunction.getEncompassingHistogram(0d, maxDist, delta);
+		hist.setName("All Connections");
+		HistogramFunction uniqueHist = HistogramFunction.getEncompassingHistogram(0d, maxDist, delta);
+		uniqueHist.setName("Unique To Model");
+		
+		double myMax = 0d;
+		double mean = 0d;
+		double sumWeights = 0d;
+		double meanAbove = 0d;
+		double sumWeightsAbove = 0d;
+		
+		for (Jump pair : connections.keySet()) {
+			double dist = pair.distance;
+			double weight = rateWeighted ? connections.get(pair) : 1d;
+			
+			myMax = Math.max(myMax, dist);
+			mean += dist*weight;
+			sumWeights += weight;
+			if (dist >= 0.1) {
+				meanAbove += dist*weight;
+				sumWeightsAbove += weight;
+			}
+			
+			int xIndex = hist.getClosestXIndex(dist);
+			hist.add(xIndex, weight);
+			if (uniqueConnections.containsKey(pair))
+				uniqueHist.add(xIndex, weight);
+		}
+
+		mean /= sumWeights;
+		meanAbove /= sumWeightsAbove;
+		
+		List<XY_DataSet> funcs = new ArrayList<>();
+		List<PlotCurveCharacterstics> chars = new ArrayList<>();
+		
+		Color uniqueColor = new Color(connectedColor.getRed()/4,
+				connectedColor.getGreen()/4, connectedColor.getBlue()/4);
+		
+		funcs.add(hist);
+		chars.add(new PlotCurveCharacterstics(PlotLineType.HISTOGRAM, 1f, connectedColor));
+		
+		funcs.add(uniqueHist);
+		chars.add(new PlotCurveCharacterstics(PlotLineType.HISTOGRAM, 1f, uniqueColor));
+		
+		String yAxisLabel = rateWeighted ? "Annual Rate" : "Count";
+		
+		PlotSpec spec = new PlotSpec(funcs, chars, title, "Jump Distance (km)", yAxisLabel);
+		spec.setLegendVisible(true);
+		
+		Range xRange = new Range(0d, maxDist);
+		Range yRange;
+		if (yLog) {
+//			double minNonZero = Double.POSITIVE_INFINITY;
+//			for (Point2D pt : hist)
+//				if (pt.getY() > 0)
+//					minNonZero = Math.min(minNonZero, pt.getY());
+//			double minY = Math.pow(10, Math.floor(Math.log10(minNonZero)));
+//			if (!Double.isFinite(minY) || minY < 1e-8)
+//				minY = 1e-8;
+//			double maxY = Math.max(1e-1, Math.pow(10, Math.ceil(Math.log10(hist.getMaxY()))));
+//			yRange = new Range(minY, maxY);
+			yRange = new Range(1e-6, 1e1);
+		} else {
+			yRange = new Range(0d, 1.05*hist.getMaxY());
+		}
+		
+		DecimalFormat distDF = new DecimalFormat("0.0");
+		double annX = 0.975*maxDist;
+		Font annFont = new Font(Font.SANS_SERIF, Font.BOLD, 20);
+		
+		double annYScalar = 0.975;
+		double annYDelta = 0.05;
+		
+		double logMinY = Math.log10(yRange.getLowerBound());
+		double logMaxY = Math.log10(yRange.getUpperBound());
+		double logDeltaY = logMaxY - logMinY;
+		
+		double annY;
+		if (yLog)
+			annY = Math.pow(10, logMinY + logDeltaY*annYScalar);
+		else
+			annY = annYScalar*yRange.getUpperBound();
+		XYTextAnnotation maxAnn = new XYTextAnnotation(
+				"Max: "+distDF.format(myMax), annX, annY);
+		maxAnn.setFont(annFont);
+		maxAnn.setTextAnchor(TextAnchor.TOP_RIGHT);
+		spec.addPlotAnnotation(maxAnn);
+		
+		annYScalar -= annYDelta;
+		if (yLog)
+			annY = Math.pow(10, logMinY + logDeltaY*annYScalar);
+		else
+			annY = annYScalar*yRange.getUpperBound();
+		XYTextAnnotation meanAnn = new XYTextAnnotation(
+				"Mean: "+distDF.format(mean), annX, annY);
+		meanAnn.setFont(annFont);
+		meanAnn.setTextAnchor(TextAnchor.TOP_RIGHT);
+		spec.addPlotAnnotation(meanAnn);
+		
+		annYScalar -= annYDelta;
+		if (yLog)
+			annY = Math.pow(10, logMinY + logDeltaY*annYScalar);
+		else
+			annY = annYScalar*yRange.getUpperBound();
+		if (rateWeighted) {
+			XYTextAnnotation rateAnn = new XYTextAnnotation(
+					"Total Rate: "+distDF.format(sumWeights), annX, annY);
+			rateAnn.setFont(annFont);
+			rateAnn.setTextAnchor(TextAnchor.TOP_RIGHT);
+			spec.addPlotAnnotation(rateAnn);
+		} else {
+			XYTextAnnotation countAnn = new XYTextAnnotation(
+					"Total Count: "+(int)sumWeights, annX, annY);
+			countAnn.setFont(annFont);
+			countAnn.setTextAnchor(TextAnchor.TOP_RIGHT);
+			spec.addPlotAnnotation(countAnn);
+		}
+		
+		annYScalar -= annYDelta;
+		if (yLog)
+			annY = Math.pow(10, logMinY + logDeltaY*annYScalar);
+		else
+			annY = annYScalar*yRange.getUpperBound();
+		XYTextAnnotation meanAboveAnn = new XYTextAnnotation(
+				"Mean >0.1: "+distDF.format(meanAbove), annX, annY);
+		meanAboveAnn.setFont(annFont);
+		meanAboveAnn.setTextAnchor(TextAnchor.TOP_RIGHT);
+		spec.addPlotAnnotation(meanAboveAnn);
+		
+		annYScalar -= annYDelta;
+		if (yLog)
+			annY = Math.pow(10, logMinY + logDeltaY*annYScalar);
+		else
+			annY = annYScalar*yRange.getUpperBound();
+		if (rateWeighted) {
+			XYTextAnnotation rateAnn = new XYTextAnnotation(
+					"Total Rate >0.1: "+distDF.format(sumWeightsAbove), annX, annY);
+			rateAnn.setFont(annFont);
+			rateAnn.setTextAnchor(TextAnchor.TOP_RIGHT);
+			spec.addPlotAnnotation(rateAnn);
+		} else {
+			XYTextAnnotation countAnn = new XYTextAnnotation(
+					"Total Count >0.1: "+(int)sumWeightsAbove, annX, annY);
+			countAnn.setFont(annFont);
+			countAnn.setTextAnchor(TextAnchor.TOP_RIGHT);
+			spec.addPlotAnnotation(countAnn);
+		}
+		
+		HeadlessGraphPanel gp = new HeadlessGraphPanel();
+		gp.setTickLabelFontSize(18);
+		gp.setAxisLabelFontSize(24);
+		gp.setPlotLabelFontSize(24);
+		gp.setBackgroundColor(Color.WHITE);
+		
+		gp.drawGraphPanel(spec, false, yLog, xRange, yRange);
+		
+		File file = new File(outputDir, prefix);
+		gp.getChartPanel().setSize(800, 650);
+		gp.saveAsPDF(file.getAbsolutePath()+".pdf");
+		gp.saveAsPNG(file.getAbsolutePath()+".png");
+	}
+	
+	private static Map<Jump, Double> getJumps(FaultSystemSolution sol, List<ClusterRupture> ruptures,
+			Map<Jump, List<Integer>> jumpToRupsMap) {
+		Map<Jump, Double> jumpRateMap = new HashMap<>();
+		for (int r=0; r<ruptures.size(); r++) {
+			double rate = sol == null ? 1d : sol.getRateForRup(r);
+			ClusterRupture rupture = ruptures.get(r);
+			for (Jump jump : rupture.getJumpsIterable()) {
+				if (jump.fromSection.getSectionId() > jump.toSection.getSectionId())
+					jump = jump.reverse();
+				Double prevRate = jumpRateMap.get(jump);
+				if (prevRate == null)
+					prevRate = 0d;
+				jumpRateMap.put(jump, prevRate + rate);
+				if (jumpToRupsMap != null) {
+					List<Integer> prevRups = jumpToRupsMap.get(jump);
+					if (prevRups == null) {
+						prevRups = new ArrayList<>();
+						jumpToRupsMap.put(jump, prevRups);
+					}
+					prevRups.add(r);
+				}
+			}
+		}
+		return jumpRateMap;
+	}
+	
+	private static TableBuilder plotConnRupExamples(RuptureConnectionSearch search, Set<Jump> pairings,
+			Map<Jump, List<Integer>> pairRupsMap, int maxRups, int maxCols,
+			File resourcesDir, String prefix) throws IOException {
+		List<Jump> sortedPairings = new ArrayList<>(pairings);
+		Collections.sort(sortedPairings, Jump.id_comparator);
+		
+		Random r = new Random(sortedPairings.size()*maxRups);
+		Collections.shuffle(sortedPairings, r);
+		
+		int possibleRups = 0;
+		for (Jump pair : pairings)
+			possibleRups += pairRupsMap.get(pair).size();
+		if (possibleRups < maxRups)
+			maxRups = possibleRups;
+		if (maxRups == 0)
+			return null;
+		
+		int indInPairing = 0;
+		List<Integer> rupsToPlot = new ArrayList<>();
+		while (rupsToPlot.size() < maxRups) {
+			for (Jump pair : sortedPairings) {
+				List<Integer> rups = pairRupsMap.get(pair);
+				if (rups.size() > indInPairing) {
+					rupsToPlot.add(rups.get(indInPairing));
+					if (rupsToPlot.size() == maxRups)
+						break;
+				}
+			}
+			indInPairing++;
+		}
+		
+		System.out.println("Plotting "+rupsToPlot+" ruptures");
+		TableBuilder table = MarkdownUtils.tableBuilder();
+		table.initNewLine();
+		for (int rupIndex : rupsToPlot) {
+			String rupPrefix = prefix+"_"+rupIndex;
+			search.plotConnections(resourcesDir, rupPrefix, rupIndex, pairings, "Unique Connections");
+			table.addColumn("![Rupture "+rupIndex+"]("
+					+resourcesDir.getName()+"/"+rupPrefix+".png)");
+		}
+		table.finalizeLine();
+		return table.wrap(maxCols, 0);
+	}
+	
+	private static File plotFixedJumpDist(FaultSystemRupSet inputRupSet, FaultSystemSolution inputSol,
+			List<ClusterRupture> inputClusterRups, String inputName, FaultSystemRupSet compRupSet,
+			FaultSystemSolution compSol, List<ClusterRupture> compClusterRups, String compName,
+			SectionDistanceAzimuthCalculator distAzCalc, double minMag, float jumpDist, File outputDir)
+					throws IOException {
+		
+		List<DiscretizedFunc> funcs = new ArrayList<>();
+		List<PlotCurveCharacterstics> chars = new ArrayList<>();
+
+		if (inputRupSet != null) {
+			DiscretizedFunc func = calcJumpDistFunc(inputRupSet, inputSol, inputClusterRups, minMag, jumpDist);
+			func.scale(1d/func.calcSumOfY_Vals());
+			funcs.add(func);
+			
+			func.setName(inputName);
+			chars.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 3f, MAIN_COLOR));
+		}
+		
+		if (compSol != null) {
+			DiscretizedFunc compFunc = calcJumpDistFunc(compRupSet, compSol, compClusterRups, minMag, jumpDist);
+			compFunc.scale(1d/compFunc.calcSumOfY_Vals());
+			compFunc.setName(compName);
+			funcs.add(compFunc);
+			chars.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 3f, COMP_COLOR));
+		}
+		
+		String title;
+		String xAxisLabel = "Num Jumps ≥"+(float)jumpDist+" km";
+		String yAxisLabel;
+		if (minMag > 0d) {
+			title = "M≥"+(float)minMag+" "+(float)jumpDist+" km Jump Comparison";
+		} else {
+			title = (float)jumpDist+" km Jump Comparison";
+		}
+		Range yRange = null;
+		String prefixAdd;
+		if (inputSol != null || compSol != null) {
+			yAxisLabel = "Fraction (Rate-Weighted)";
+			yRange = new Range(0d, 1d);
+			prefixAdd = "_rates";
+		} else {
+			yAxisLabel = "Count";
+			prefixAdd = "_counts";
+		}
+		PlotSpec spec = new PlotSpec(funcs, chars, title, xAxisLabel, yAxisLabel);
+//				"Num Jumps ≥"+(float)jumpDist+"km", "Fraction (Rate-Weighted)");
+		spec.setLegendVisible(true);
+		
+		HeadlessGraphPanel gp = new HeadlessGraphPanel();
+		gp.setBackgroundColor(Color.WHITE);
+		gp.setTickLabelFontSize(18);
+		gp.setAxisLabelFontSize(20);
+		gp.setPlotLabelFontSize(21);
+		
+		String prefix = new File(outputDir, "jumps_"+(float)jumpDist+"km"+prefixAdd).getAbsolutePath();
+		
+		gp.drawGraphPanel(spec, false, false, null, yRange);
+		TickUnits tus = new TickUnits();
+		TickUnit tu = new NumberTickUnit(1d);
+		tus.add(tu);
+		gp.getXAxis().setStandardTickUnits(tus);
+		gp.getChartPanel().setSize(1000, 500);
+		gp.saveAsPNG(prefix+".png");
+		gp.saveAsPDF(prefix+".pdf");
+		gp.saveAsTXT(prefix+".txt");
+		return new File(prefix+".png");
+	}
+	
+	private static DiscretizedFunc calcJumpDistFunc(FaultSystemRupSet rupSet, FaultSystemSolution sol,
+			List<ClusterRupture> clusterRups, double minMag, float jumpDist) {
+		EvenlyDiscretizedFunc solFunc = new EvenlyDiscretizedFunc(0d, 5, 1d);
+
+		for (int r=0; r<rupSet.getNumRuptures(); r++) {
+			double mag = rupSet.getMagForRup(r);
+
+			if (mag < minMag)
+				continue;
+			
+			ClusterRupture rup = clusterRups.get(r);
+			int jumpsOverDist = 0;
+			for (Jump jump : rup.getJumpsIterable()) {
+				if ((float)jump.distance > jumpDist)
+					jumpsOverDist++;
+			}
+
+			double rate = sol == null ? 1d : sol.getRateForRup(r);
+			
+			// indexes are fine to use here since it starts at zero with a delta of one 
+			if (jumpsOverDist < solFunc.size())
+				solFunc.set(jumpsOverDist, solFunc.getY(jumpsOverDist) + rate);
+		}
+		
+		return solFunc;
+	}
+	
+	private enum RakeType {
+		RIGHT_LATERAL("Right-Lateral SS", "rl", Color.RED.darker()) {
+			@Override
+			public boolean isMatch(double rake) {
+				return (float)rake >= -180f && (float)rake <= -170f
+						|| (float)rake <= 180f && (float)rake >= 170f;
+			}
+		},
+		LEFT_LATERAL("Left-Lateral SS", "ll", Color.GREEN.darker()) {
+			@Override
+			public boolean isMatch(double rake) {
+				return (float)rake >= -10f && (float)rake <= 10f;
+			}
+		},
+		REVERSE("Reverse", "rev", Color.BLUE.darker()) {
+			@Override
+			public boolean isMatch(double rake) {
+				return (float)rake >= 80f && (float)rake <= 100f;
+			}
+		},
+		NORMAL("Normal", "norm", Color.YELLOW.darker()) {
+			@Override
+			public boolean isMatch(double rake) {
+				return (float)rake >= -100f && (float)rake <= -80f;
+			}
+		},
+		OBLIQUE("Oblique", "oblique", Color.MAGENTA.darker()) {
+			@Override
+			public boolean isMatch(double rake) {
+				for (RakeType type : values())
+					if (type != this && type.isMatch(rake))
+						return false;
+				return true;
+			}
+		};
+		
+		private String name;
+		private String prefix;
+		private Color color;
+
+		private RakeType(String name, String prefix, Color color) {
+			this.name = name;
+			this.prefix = prefix;
+			this.color = color;
+		}
+		
+		public abstract boolean isMatch(double rake);
+	}
+	
+	private static Table<RakeType, RakeType, List<Double>> calcJumpAzimuths(
+			List<ClusterRupture> rups, SectionDistanceAzimuthCalculator distAzCalc) {
+		AzimuthCalc azCalc = new JumpAzimuthChangeFilter.SimpleAzimuthCalc(distAzCalc);
+		Table<RakeType, RakeType, List<Double>> ret = HashBasedTable.create();
+		for (RakeType r1 : RakeType.values())
+			for (RakeType r2 : RakeType.values())
+				ret.put(r1, r2, new ArrayList<>());
+		for (ClusterRupture rup : rups) {
+			for (Jump jump : rup.getJumpsIterable()) {
+				RakeType sourceRake = null, destRake = null;
+				for (RakeType type : RakeType.values()) {
+					if (type.isMatch(jump.fromSection.getAveRake()))
+						sourceRake = type;
+					if (type.isMatch(jump.toSection.getAveRake()))
+						destRake = type;
+				}
+				Preconditions.checkNotNull(sourceRake);
+				Preconditions.checkNotNull(destRake);
+				FaultSection before1 = rup.sectPredecessorsMap.get(jump.fromSection);
+				if (before1 == null)
+					continue;
+				FaultSection before2 = jump.fromSection;
+				double beforeAz = azCalc.calcAzimuth(before1, before2);
+				FaultSection after1 = jump.toSection;
+				for (FaultSection after2 : rup.sectDescendantsMap.get(after1)) {
+					double afterAz = azCalc.calcAzimuth(after1, after2);
+					double rawDiff = JumpAzimuthChangeFilter.getAzimuthDifference(beforeAz, afterAz);
+					Preconditions.checkState(rawDiff >= -180 && rawDiff <= 180);
+					double[] azDiffs;
+					if ((float)before2.getAveDip() == 90f) {
+						// strike slip, include both directions
+						azDiffs = new double[] { rawDiff, -rawDiff };
+					} else {
+						// follow the aki & richards convention
+						double dipDir = before2.getDipDirection();
+						double dipDirDiff = JumpAzimuthChangeFilter.getAzimuthDifference(dipDir, beforeAz);
+						if (dipDirDiff < 0)
+							// this means that the fault dips to the right of beforeAz, we're good
+							azDiffs = new double[] { rawDiff };
+						else
+							// this means that the fault dips to the left of beforeAz, flip it
+							azDiffs = new double[] { -rawDiff };
+					}
+					for (double azDiff : azDiffs)
+						ret.get(sourceRake, destRake).add(azDiff);
+				}
+			}
+		}
+		return ret;
+	}
+	
+	private static Map<RakeType, List<Double>> getAzimuthsFrom (RakeType sourceRake,
+			Table<RakeType, RakeType, List<Double>> azTable) {
+		Map<RakeType, List<Double>> azMap;
+		if (sourceRake == null) {
+			azMap = new HashMap<>();
+			for (RakeType type : RakeType.values())
+				azMap.put(type, new ArrayList<>());
+			for (RakeType source : RakeType.values()) {
+				Map<RakeType, List<Double>> row = azTable.row(source);
+				for (RakeType dest : row.keySet()) 
+					azMap.get(dest).addAll(row.get(dest));
+			}
+		} else {
+			azMap = azTable.row(sourceRake);
+		}
+		return azMap;
+	}
+	
+	private static File plotJumpAzimuths(RakeType sourceRake, List<RakeType> destRakes,
+			Table<RakeType, RakeType, List<Double>> azTable,
+			File outputDir, String prefix, String title) throws IOException {
+		Map<RakeType, List<Double>> azMap = getAzimuthsFrom(sourceRake, azTable);
+		
+		Range xRange = new Range(-180d, 180d);
+		List<Range> xRanges = new ArrayList<>();
+		xRanges.add(xRange);
+		
+		List<Range> yRanges = new ArrayList<>();
+		List<PlotSpec> specs = new ArrayList<>();
+		
+		for (int i=0; i<destRakes.size(); i++) {
+			RakeType destRake = destRakes.get(i);
+			
+			HistogramFunction hist = HistogramFunction.getEncompassingHistogram(-179d, 179d, 15d);
+			for (RakeType oRake : azMap.keySet()) {
+				if (destRake != null && destRake != oRake)
+					continue;
+				for (double azDiff : azMap.get(oRake)) {
+					hist.add(hist.getClosestXIndex(azDiff), 1d);
+				}
+			}
+
+			Color color;
+			String label;
+			if (destRake == null) {
+				color = Color.DARK_GRAY;
+				label = "Any";
+			} else {
+				color = destRake.color;
+				label = destRake.name;
+			}
+			
+			List<XY_DataSet> funcs = new ArrayList<>();
+			List<PlotCurveCharacterstics> chars = new ArrayList<>();
+			
+			funcs.add(hist);
+			chars.add(new PlotCurveCharacterstics(PlotLineType.HISTOGRAM, 1f, color));
+			
+			double maxY = Math.max(1.1*hist.getMaxY(), 1d);
+			Range yRange = new Range(0d, maxY);
+			
+			PlotSpec spec = new PlotSpec(funcs, chars, title, "Azimuthal Difference", "Count");
+			
+			XYTextAnnotation ann = new XYTextAnnotation("To "+label, 175, maxY*0.975);
+			ann.setFont(new Font(Font.SANS_SERIF, Font.BOLD, 24));
+			ann.setTextAnchor(TextAnchor.TOP_RIGHT);
+			spec.addPlotAnnotation(ann);
+			
+			specs.add(spec);
+			yRanges.add(yRange);
+		}
+		
+		HeadlessGraphPanel gp = new HeadlessGraphPanel();
+		gp.setTickLabelFontSize(18);
+		gp.setAxisLabelFontSize(24);
+		gp.setPlotLabelFontSize(24);
+		gp.setBackgroundColor(Color.WHITE);
+		
+		gp.drawGraphPanel(specs, false, false, xRanges, yRanges);
+		
+		File file = new File(outputDir, prefix+".png");
+		gp.getChartPanel().setSize(700, 1000);
+		gp.saveAsPNG(file.getAbsolutePath());
+		return file;
+	}
+	
+	private static double azDiffDegreesToAngleRad(double azDiff) {
+		// we want zero to be up, 90 to be right, 180 to be down, -90 to be left
+		// sin/cos convention is zero at the right, 90 up, 180 left, -90 down
+		
+		Preconditions.checkState((float)azDiff >= (float)-180f && (float)azDiff <= 180f,
+				"Bad azDiff: %s", azDiff);
+		// first mirror it
+		azDiff *= -1;
+		// now rotate 90 degrees
+		azDiff += 90d;
+		
+		return Math.toRadians(azDiff);
+	}
+	
+	private static File plotJumpAzimuthsRadial(RakeType sourceRake, RakeType destRake,
+			Table<RakeType, RakeType, List<Double>> azTable,
+			File outputDir, String prefix, String title) throws IOException {
+		System.out.println("Plotting "+title);
+		Map<RakeType, List<Double>> azMap = getAzimuthsFrom(sourceRake, azTable);
+		
+		List<XY_DataSet> funcs = new ArrayList<>();
+		List<PlotCurveCharacterstics> chars = new ArrayList<>();
+		
+		Map<Float, List<Color>> azColorMap = new HashMap<>();
+		
+		HistogramFunction hist = HistogramFunction.getEncompassingHistogram(-179d, 179d, 15d);
+		long totCount = 0;
+		for (RakeType oRake : azMap.keySet()) {
+			if (destRake != null && destRake != oRake)
+				continue;
+			for (double azDiff : azMap.get(oRake)) {
+				hist.add(hist.getClosestXIndex(azDiff), 1d);
+				
+				Float azFloat = (float)azDiff;
+				List<Color> colors = azColorMap.get(azFloat);
+				if (colors == null) {
+					colors = new ArrayList<>();
+					azColorMap.put(azFloat, colors);
+				}
+				colors.add(oRake.color);
+				totCount++;
+			}
+		}
+		
+		System.out.println("Have "+azColorMap.size()+" unique azimuths, "+totCount+" total");
+//		Random r = new Random(azColorMap.keySet().size());
+		double alphaEach = 0.025;
+		if (totCount > 0)
+			alphaEach = Math.max(alphaEach, 1d/totCount);
+		for (Float azFloat : azColorMap.keySet()) {
+			double sumRed = 0d;
+			double sumGreen = 0d;
+			double sumBlue = 0d;
+			double sumAlpha = 0;
+			int count = 0;
+			for (Color azColor : azColorMap.get(azFloat)) {
+				sumRed += azColor.getRed();
+				sumGreen += azColor.getGreen();
+				sumBlue += azColor.getBlue();
+				if (sumAlpha < 1d)
+					sumAlpha += alphaEach;
+				count++;
+			}
+			double red = sumRed/(double)count;
+			double green = sumGreen/(double)count;
+			double blue = sumBlue/(double)count;
+			if (red > 1d)
+				red = 1d;
+			if (green > 1d)
+				green = 1d;
+			if (blue > 1d)
+				blue = 1d;
+			if (sumAlpha > 1d)
+				sumAlpha = 1d;
+			Color color = new Color((float)red, (float)green, (float)blue, (float)sumAlpha);
+//			if (destRake == null) {
+//				// multipe types, choose a random color sampled from the actual colors
+//				// for this azimuth
+//				List<Color> colorList = azColorMap.get(azFloat);
+//				color = colorList.get(r.nextInt(colorList.size()));
+//			} else {
+//				color = destRake.color;
+//			}
+			
+			DefaultXY_DataSet line = new DefaultXY_DataSet();
+			line.set(0d, 0d);
+			double azRad = azDiffDegreesToAngleRad(azFloat);
+			double x = Math.cos(azRad);
+			double y = Math.sin(azRad);
+			line.set(x, y);
+			
+			funcs.add(line);
+			chars.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 1f, color));
+		}
+		
+		double dip;
+		if (sourceRake == RakeType.LEFT_LATERAL || sourceRake == RakeType.RIGHT_LATERAL)
+			dip = 90d;
+		else if (sourceRake == RakeType.NORMAL || sourceRake == RakeType.REVERSE)
+			dip = 60d;
+		else
+			dip = 75d;
+		
+		double traceLen = 0.5d;
+		double lowerDepth = 0.25d;
+		if (dip < 90d) {
+			// add surface
+			
+			double horzWidth = lowerDepth/Math.tan(Math.toRadians(dip));
+			DefaultXY_DataSet outline = new DefaultXY_DataSet();
+			outline.set(0d, 0d);
+			outline.set(horzWidth, 0d);
+			outline.set(horzWidth, -traceLen);
+			outline.set(0d, -traceLen);
+			
+			funcs.add(outline);
+			chars.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 3f, Color.GRAY));
+		}
+		
+		DefaultXY_DataSet trace = new DefaultXY_DataSet();
+		trace.set(0d, 0d);
+		trace.set(0d, -traceLen);
+		
+		funcs.add(trace);
+		chars.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 6f, Color.BLACK));
+		PlotSpec spec = new PlotSpec(funcs, chars, title, "", " ");
+		
+		CPT cpt = GMT_CPT_Files.BLACK_RED_YELLOW_UNIFORM.instance().reverse();
+		cpt = cpt.rescale(2d*Float.MIN_VALUE, 0.25d);
+		cpt.setBelowMinColor(Color.WHITE);
+		double halfDelta = 0.5*hist.getDelta();
+		double innerMult = 0.95;
+		double outerMult = 1.05;
+		double sumY = Math.max(1d, hist.calcSumOfY_Vals());
+		for (int i=0; i<hist.size(); i++) {
+			double centerAz = hist.getX(i);
+			double startAz = azDiffDegreesToAngleRad(centerAz-halfDelta);
+			double endAz = azDiffDegreesToAngleRad(centerAz+halfDelta);
+			
+			List<Point2D> points = new ArrayList<>();
+			
+			double startX = Math.cos(startAz);
+			double startY = Math.sin(startAz);
+			double endX = Math.cos(endAz);
+			double endY = Math.sin(endAz);
+			
+			points.add(new Point2D.Double(innerMult*startX, innerMult*startY));
+			points.add(new Point2D.Double(outerMult*startX, outerMult*startY));
+			points.add(new Point2D.Double(outerMult*endX, outerMult*endY));
+			points.add(new Point2D.Double(innerMult*endX, innerMult*endY));
+			points.add(new Point2D.Double(innerMult*startX, innerMult*startY));
+			
+			double[] polygon = new double[points.size()*2];
+			int cnt = 0;
+			for (Point2D pt : points) {
+				polygon[cnt++] = pt.getX();
+				polygon[cnt++] = pt.getY();
+			}
+			Color color = cpt.getColor((float)(hist.getY(i)/sumY));
+			
+			Stroke stroke = PlotLineType.SOLID.buildStroke(2f);
+			spec.addPlotAnnotation(new XYPolygonAnnotation(polygon, stroke, Color.DARK_GRAY, color));
+		}
+		
+		PaintScaleLegend cptBar = XYZGraphPanel.getLegendForCPT(cpt, "Fraction",
+				24, 18, 0.05d, RectangleEdge.BOTTOM);
+		spec.addSubtitle(cptBar);
+		
+		Range xRange = new Range(-1.1d, 1.1d);
+		Range yRange = new Range(-1.1d, 1.1d);
+		
+		HeadlessGraphPanel gp = new HeadlessGraphPanel();
+		gp.setTickLabelFontSize(18);
+		gp.setAxisLabelFontSize(24);
+		gp.setPlotLabelFontSize(22);
+		gp.setBackgroundColor(Color.WHITE);
+		
+		gp.drawGraphPanel(spec, false, false, xRange, yRange);
+		
+		gp.getXAxis().setTickLabelsVisible(false);
+		gp.getYAxis().setTickLabelsVisible(false);
+		
+		File file = new File(outputDir, prefix+".png");
+		gp.getChartPanel().setSize(800, 800);
+		gp.saveAsPNG(file.getAbsolutePath());
+		return file;
 	}
 
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RuptureConnectionSearch.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RuptureConnectionSearch.java
@@ -56,7 +56,7 @@ import com.google.common.collect.Table.Cell;
 import scratch.UCERF3.FaultSystemRupSet;
 import scratch.UCERF3.utils.FaultSystemIO;
 
-public class RupSetConnectionSearch {
+public class RuptureConnectionSearch {
 	
 	private FaultSystemRupSet rupSet;
 	private SectionDistanceAzimuthCalculator distCalc;
@@ -69,16 +69,20 @@ public class RupSetConnectionSearch {
 	// if false, find connections via the smallest individual jump (possibly across multiple clusters)
 	private boolean cumulativeJumps;
 	
-	public RupSetConnectionSearch(FaultSystemRupSet rupSet, SectionDistanceAzimuthCalculator distCalc) {
+	public RuptureConnectionSearch(FaultSystemRupSet rupSet, SectionDistanceAzimuthCalculator distCalc) {
 		this(rupSet, distCalc, MAX_POSSIBLE_JUMP_DEFAULT, CUMULATIVE_JUMPS_DEFAULT);
 	}
 	
-	public RupSetConnectionSearch(FaultSystemRupSet rupSet, SectionDistanceAzimuthCalculator distCalc,
+	public RuptureConnectionSearch(FaultSystemRupSet rupSet, SectionDistanceAzimuthCalculator distCalc,
 			double maxJumpDist, boolean cumulativeJumps) {
 		this.rupSet = rupSet;
 		this.distCalc = distCalc;
 		this.maxJumpDist = maxJumpDist; 
 		this.cumulativeJumps = cumulativeJumps;
+	}
+	
+	public SectionDistanceAzimuthCalculator getDistAzCalc() {
+		return distCalc;
 	}
 	
 	public List<FaultSubsectionCluster> calcClusters(List<FaultSection> sects, final boolean debug) {
@@ -888,7 +892,7 @@ public class RupSetConnectionSearch {
 		
 		SectionDistanceAzimuthCalculator distCalc =
 				new SectionDistanceAzimuthCalculator(rupSet.getFaultSectionDataList());
-		RupSetConnectionSearch search = new RupSetConnectionSearch(rupSet, distCalc,
+		RuptureConnectionSearch search = new RuptureConnectionSearch(rupSet, distCalc,
 				maxPossibleJumpDist, CUMULATIVE_JUMPS_DEFAULT);
 		
 		Preconditions.checkState(outputDir.exists() || outputDir.mkdir());

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RuptureTreeNavigator.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RuptureTreeNavigator.java
@@ -1,0 +1,163 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.faultSurface.FaultSection;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Class for navigating the tree structure of ruptures. Each FaultSection or FaultSubsectionCluster
+ * can have one (or no) predecessors (above in the tree), and one or more (or no) descendants
+ * (below in the tree)
+ *  
+ * @author kevin
+ *
+ */
+public class RuptureTreeNavigator {
+	
+	private Map<Integer, FaultSubsectionCluster[]> parentClusterMap;
+	private Map<FaultSubsectionCluster, ClusterConnections> clusterConnectionsMap;
+	private ClusterRupture rupture;
+	
+	private class ClusterConnections {
+		final FaultSubsectionCluster predecessor;
+		final List<FaultSubsectionCluster> descendants;
+		final Jump jumpTo;
+		final List<Jump> jumpsFrom;
+		
+		public ClusterConnections(Jump jumpTo) {
+			this.predecessor = jumpTo == null ? null : jumpTo.fromCluster;
+			this.descendants = new ArrayList<>();
+			this.jumpTo = jumpTo;
+			this.jumpsFrom = new ArrayList<>();
+		}
+		
+		private void addJumpFrom(Jump jump) {
+			jumpsFrom.add(jump);
+			descendants.add(jump.toCluster);
+		}
+	}
+
+	public RuptureTreeNavigator(ClusterRupture rupture) {
+		this.rupture = rupture;
+		this.parentClusterMap = new HashMap<>();
+		this.clusterConnectionsMap = new HashMap<>();
+		// add the start cluster
+		clusterConnectionsMap.put(rupture.clusters[0], new ClusterConnections(null));
+		// build parent relationships
+		for (Jump jump : rupture.getJumpsIterable()) {
+			ClusterConnections connections = clusterConnectionsMap.get(jump.toCluster);
+			if (connections == null) {
+				connections = new ClusterConnections(jump);
+				clusterConnectionsMap.put(jump.toCluster, connections);
+			}
+		}
+		// build children relationships
+		for (Jump jump : rupture.getJumpsIterable()) {
+			ClusterConnections connections = clusterConnectionsMap.get(jump.fromCluster);
+			Preconditions.checkNotNull(connections);
+			connections.addJumpFrom(jump);
+		}
+		for (FaultSubsectionCluster cluster : clusterConnectionsMap.keySet()) {
+			int parentID = cluster.parentSectionID;
+			FaultSubsectionCluster[] matches = parentClusterMap.get(parentID);
+			if (matches == null) {
+				parentClusterMap.put(parentID, new FaultSubsectionCluster[] { cluster });
+			} else {
+				matches = Arrays.copyOf(matches, matches.length+1);
+				matches[matches.length-1] = cluster;
+				parentClusterMap.put(parentID, matches);
+			}
+		}
+	}
+
+	/**
+	 * @param cluster
+	 * @return the predecessor (up a level in the tree) to this cluster, or null if this is the
+	 * top level cluster
+	 */
+	public FaultSubsectionCluster getPredecessor(FaultSubsectionCluster cluster) {
+		return clusterConnectionsMap.get(cluster).predecessor;
+	}
+	
+	/**
+	 * @param cluster
+	 * @return a list of all descendants (down a level in the tree) from this cluster (empty list is
+	 * returned if no descendants exist)
+	 */
+	public List<FaultSubsectionCluster> getDescendants(FaultSubsectionCluster cluster) {
+		return clusterConnectionsMap.get(cluster).descendants;
+	}
+	
+	private FaultSubsectionCluster locateCluster(FaultSection sect) {
+		Preconditions.checkState(sect.getParentSectionId() >= 0, "parent section IDs must be populated");
+		FaultSubsectionCluster[] clusters = parentClusterMap.get(sect.getParentSectionId());
+		Preconditions.checkNotNull(clusters,
+				"Couldn't locate cluster with parent %s in rupture:\n%s", sect.getParentSectionId(), rupture);
+		if (clusters.length == 1)
+			return clusters[0];
+//		System.out.println("Locate cluster with len="+clusters.length);
+		// need to search, more expensive
+		for (FaultSubsectionCluster cluster : clusters) {
+			if (cluster.contains(sect)) {
+//				System.out.println("Cluster "+cluster+" contains "+sect.getSectionId());
+				return cluster;
+			}
+		}
+		throw new IllegalStateException("Section "+sect.getSectionName()+" not found in any clusters");
+	}
+	
+	private int indexWithinCluster(FaultSection sect, FaultSubsectionCluster cluster) {
+		int targetID = sect.getSectionId();
+		for (int i = 0; i < cluster.subSects.size(); i++) {
+			FaultSection test = cluster.subSects.get(i);
+			if (test.getSectionId() == targetID)
+				return i;
+		}
+		throw new IllegalStateException("Couldn't locate section "+sect.getParentSectionId()+":"
+				+targetID+" ("+sect.getSectionName()+") in cluster "+cluster+".\nFull rupture: "+rupture);
+	}
+	/**
+	 * @param sect
+	 * @return the direct predecessor of this section (either within its cluster or in the previous cluster)
+	 * null if this is the first section of the first cluster
+	 */
+	public FaultSection getPredecessor(FaultSection sect) {
+		FaultSubsectionCluster cluster = locateCluster(sect);
+		int indexInCluster = indexWithinCluster(sect, cluster);
+		if (indexInCluster > 0)
+			return cluster.subSects.get(indexInCluster-1);
+		// need upstream cluster
+		ClusterConnections connections = clusterConnectionsMap.get(cluster);
+		if (connections.jumpTo == null)
+			// start cluster
+			return null;
+		return connections.jumpTo.fromSection;
+	}
+	
+	/**
+	 * 
+	 * @param sect
+	 * @return a list of all descendants from this subsection, which could be in the same
+	 * cluster or on the other side of a jump (empty list is returned if no descendants exist)
+	 */
+	public List<FaultSection> getDescendants(FaultSection sect) {
+		FaultSubsectionCluster cluster = locateCluster(sect);
+		int indexInCluster = indexWithinCluster(sect, cluster);
+		List<FaultSection> descendants = new ArrayList<>();
+		if (indexInCluster < cluster.subSects.size()-1)
+			descendants.add(cluster.subSects.get(indexInCluster+1));
+		for (Jump jump : clusterConnectionsMap.get(cluster).jumpsFrom)
+			if (jump.fromSection.getSectionId() == sect.getSectionId())
+				descendants.add(jump.toSection);
+		return descendants;
+	}
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/SectIDRange.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/SectIDRange.java
@@ -1,0 +1,77 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import org.opensha.sha.faultSurface.FaultSection;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Range of section IDs, inclusive, for memory efficient tracking of unique ruptures and contains
+ * operations
+ * 
+ * @author kevin
+ *
+ */
+public final class SectIDRange implements Comparable<SectIDRange> {
+	
+	public final int startID;
+	public final int endID;
+	
+	public SectIDRange(int startID, int endID) {
+		Preconditions.checkArgument(startID >= 0, "startID=%s must be >= 0", startID);
+		Preconditions.checkArgument(endID >= startID, "startID=%s must be >= endID=%s", startID, endID);
+		this.startID = startID;
+		this.endID = endID;
+	}
+	
+	public int size() {
+		return 1 + endID - startID;
+	}
+	
+	public boolean contains(int id) {
+		return id >= startID && id <= endID;
+	}
+	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + endID;
+		result = prime * result + startID;
+		return result;
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		SectIDRange other = (SectIDRange) obj;
+		if (endID != other.endID)
+			return false;
+		if (startID != other.startID)
+			return false;
+		return true;
+	}
+
+	@Override
+	public int compareTo(SectIDRange o) {
+		int cmp = Integer.compare(startID, o.startID);
+		if (cmp != 0)
+			return cmp;
+		return Integer.compare(endID, o.endID);
+	}
+	
+	@Override
+	public String toString() {
+		return "["+startID+","+endID+"]";
+	}
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/SectionDistanceAzimuthCalculator.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/SectionDistanceAzimuthCalculator.java
@@ -42,6 +42,17 @@ public class SectionDistanceAzimuthCalculator {
 		azCache = CacheBuilder.newBuilder().build(new AzLoader());
 	}
 	
+	private RuptureSurface getSurface(int id) {
+		RuptureSurface surf = sectSurfs.get(id);
+		if (surf == null) {
+			FaultSection sect = subSects.get(id);
+			Preconditions.checkState(id == sect.getSectionId(), "Section IDs are not indexes");
+			surf = sect.getFaultSurface(1d, false, false);
+			sectSurfs.putIfAbsent(id, surf);
+		}
+		return surf;
+	}
+	
 	public List<? extends FaultSection> getSubSections() {
 		return subSects;
 	}
@@ -55,9 +66,9 @@ public class SectionDistanceAzimuthCalculator {
 			if (id1 == id2)
 				return 0d;
 			
-			RuptureSurface surf1 = sectSurfs.get(id1);
+			RuptureSurface surf1 = getSurface(id1);
 			Preconditions.checkNotNull(surf1);
-			RuptureSurface surf2 = sectSurfs.get(id2);
+			RuptureSurface surf2 = getSurface(id2);
 			Preconditions.checkNotNull(surf2);
 			
 			// if the quick distance is less than this value, calculate a full distance
@@ -87,9 +98,9 @@ public class SectionDistanceAzimuthCalculator {
 			if (id1 == id2)
 				return Double.NaN;
 			
-			RuptureSurface surf1 = sectSurfs.get(id1);
+			RuptureSurface surf1 = getSurface(id1);
 			Preconditions.checkNotNull(surf1);
-			RuptureSurface surf2 = sectSurfs.get(id2);
+			RuptureSurface surf2 = getSurface(id2);
 			Preconditions.checkNotNull(surf2);
 			
 			Location loc1 = GriddedSurfaceUtils.getSurfaceMiddleLoc(surf1);

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/SectionDistanceAzimuthCalculator.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/SectionDistanceAzimuthCalculator.java
@@ -24,19 +24,26 @@ import com.google.common.base.Preconditions;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
 
 public class SectionDistanceAzimuthCalculator {
 
+	private List<? extends FaultSection> subSects;
 	private LoadingCache<IDPairing, Double> distCache;
 	private LoadingCache<IDPairing, Double> azCache;
 	private Map<Integer, RuptureSurface> sectSurfs;
 
 	public SectionDistanceAzimuthCalculator(List<? extends FaultSection> subSects) {
+		this.subSects = ImmutableList.copyOf(subSects);
 		sectSurfs = new HashMap<>();
 		for (FaultSection subSect : subSects)
 			sectSurfs.put(subSect.getSectionId(), subSect.getFaultSurface(1d, false, false));
 		distCache = CacheBuilder.newBuilder().build(new DistLoader());
 		azCache = CacheBuilder.newBuilder().build(new AzLoader());
+	}
+	
+	public List<? extends FaultSection> getSubSections() {
+		return subSects;
 	}
 	
 	private class DistLoader extends CacheLoader<IDPairing, Double> {

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/UniqueRupture.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/UniqueRupture.java
@@ -1,10 +1,16 @@
 package org.opensha.sha.earthquake.faultSysSolution.ruptures.util;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
 import org.opensha.sha.faultSurface.FaultSection;
+
+import com.google.common.base.Preconditions;
 
 /**
  * Unique rupture as defined only by the set of subsection IDs included (regardless of order)
@@ -14,33 +20,162 @@ import org.opensha.sha.faultSurface.FaultSection;
  */
 public class UniqueRupture {
 	
-	private final HashSet<Integer> sectIDs;
+	private final List<SectIDRange> list;
+	private int size;
 	
-	public UniqueRupture(Collection<Integer> sectIDs) {
-		this.sectIDs = new HashSet<>(sectIDs);
+	public static UniqueRupture forIDs(Collection<Integer> sectIDs) {
+		UniqueRupture unique = new UniqueRupture();
+		unique.add(sectIDs);
+		return unique;
 	}
 	
-	public UniqueRupture(FaultSubsectionCluster cluster) {
-		sectIDs = new HashSet<>();
-		for (FaultSection sect : cluster.subSects)
-			sectIDs.add(sect.getSectionId());
+	public static UniqueRupture forSects(Collection<? extends FaultSection> sects) {
+		UniqueRupture unique = new UniqueRupture();
+		List<Integer> ids = new ArrayList<>(sects.size());
+		for (FaultSection sect : sects)
+			ids.add(sect.getSectionId());
+		unique.add(ids);
+		return unique;
 	}
 	
-	public UniqueRupture(UniqueRupture previous, FaultSubsectionCluster addition) {
-		sectIDs = new HashSet<>(previous.sectIDs);
-		for (FaultSection sect : addition.subSects)
-			sectIDs.add(sect.getSectionId());
+	public static UniqueRupture forClusters(FaultSubsectionCluster... clusters) {
+		UniqueRupture unique = new UniqueRupture();
+		for (FaultSubsectionCluster cluster : clusters)
+			for (SectIDRange range : cluster.unique.list)
+				unique.add(range);
+		return unique;
+	}
+
+	private UniqueRupture() {
+		list = new ArrayList<>();
+		size = 0;
+	}
+	
+	public UniqueRupture(UniqueRupture list, SectIDRange addition) {
+		this.list = new ArrayList<>(list.list);
+		this.size = list.size;
+		add(addition);
+	}
+	
+	public UniqueRupture(UniqueRupture list, FaultSubsectionCluster addition) {
+		this(list, addition.unique);
+	}
+	
+	public UniqueRupture(UniqueRupture list, UniqueRupture additions) {
+		this.list = new ArrayList<>(list.list);
+		this.size = list.size;
+		for (SectIDRange addition : additions.list)
+			add(addition);
 	}
 	
 	public int size() {
-		return sectIDs.size();
+		return size;
+	}
+	
+	private void add(Collection<Integer> ids) {
+		int rangeStartID = Integer.MIN_VALUE;
+		int rangeEndID = -2;
+		boolean backwards = false;
+		for (int id : ids) {
+			if (id == rangeEndID+1 && !backwards) {
+				// next in a forwards series
+				rangeEndID++;
+			} else if (id == rangeEndID-1 && backwards) {
+				// 3rd+ in a backwards series
+				rangeEndID--;
+			} else if (id == rangeStartID-1 && rangeStartID == rangeEndID) {
+				// 2nd in a backwards series
+				backwards = true;
+				rangeEndID--;
+			} else {
+				// it's a break in the range
+				if (rangeStartID != Integer.MIN_VALUE) {
+					if (backwards)
+						add(new SectIDRange(rangeEndID, rangeStartID));
+					else
+						add(new SectIDRange(rangeStartID, rangeEndID));
+				}
+				rangeStartID = id;
+				rangeEndID = id;
+				backwards = false;
+			}
+		}
+		if (rangeStartID != Integer.MIN_VALUE) {
+			if (backwards)
+				add(new SectIDRange(rangeEndID, rangeStartID));
+			else
+				add(new SectIDRange(rangeStartID, rangeEndID));
+		}
+		Preconditions.checkState(ids.size() == size,
+				"Size mismatch, duplicates? Expected %s, have %s", ids.size(), size);
+	}
+	
+	private int insertionIndex(SectIDRange range) {
+		int index = Collections.binarySearch(list, range);
+		if (index < 0)
+			index = -(index + 1);
+		return index;
+	}
+	
+	private void add(SectIDRange range) {
+		if (list.isEmpty()) {
+			list.add(range);
+			size += range.size();
+			return;
+		}
+		int index = insertionIndex(range);
+		int sizeAdd = range.size();
+		if (index > 0) {
+			SectIDRange before = list.get(index-1);
+			Preconditions.checkState(range.startID > before.endID,
+					"Overlappping ID ranges detected: %s %s", before, range);
+			if (range.startID == before.endID+1) {
+				// combine them
+				list.remove(index-1);
+				index--;
+				range = new SectIDRange(before.startID, range.endID);
+			}
+		}
+		if (index < list.size()-1) {
+			SectIDRange after = list.get(index+1);
+			Preconditions.checkState(range.endID < after.startID,
+					"Overlappping ID ranges detected: %s %s", range, after);
+			if (range.endID == after.startID-1) {
+				// combine them
+				list.remove(index+1);
+				range = new SectIDRange(range.startID, after.endID);
+			}
+		}
+		list.add(index, range);
+		size += sizeAdd;
+	}
+	
+	private static final Comparator<SectIDRange> containsCompare = new Comparator<SectIDRange>() {
+
+		@Override
+		public int compare(SectIDRange o1, SectIDRange o2) {
+			if (o1.size() == 1 && o2.contains(o1.startID) || o2.size() == 1 && o1.contains(o2.startID))
+				return 0;
+			return Integer.compare(o1.startID, o2.startID);
+		}
+		
+	};
+	
+	public boolean contains(int id) {
+		if (list.size() == 0)
+			return false;
+		if (list.size() == 1)
+			return list.get(0).contains(id);
+		int index = Collections.binarySearch(list, new SectIDRange(id, id), containsCompare);
+		return index >= 0;
 	}
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + sectIDs.hashCode();
+		result = prime * result + ((list == null) ? 0 : list.hashCode());
+		result = prime * result + size;
 		return result;
 	}
 
@@ -53,7 +188,12 @@ public class UniqueRupture {
 		if (getClass() != obj.getClass())
 			return false;
 		UniqueRupture other = (UniqueRupture) obj;
-		if (!sectIDs.equals(other.sectIDs))
+		if (size != other.size)
+			return false;
+		if (list == null) {
+			if (other.list != null)
+				return false;
+		} else if (!list.equals(other.list))
 			return false;
 		return true;
 	}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/UniqueRupture.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/UniqueRupture.java
@@ -11,6 +11,7 @@ import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionClust
 import org.opensha.sha.faultSurface.FaultSection;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Unique rupture as defined only by the set of subsection IDs included (regardless of order)
@@ -136,13 +137,13 @@ public class UniqueRupture {
 				range = new SectIDRange(before.startID, range.endID);
 			}
 		}
-		if (index < list.size()-1) {
-			SectIDRange after = list.get(index+1);
+		if (index < list.size()) {
+			SectIDRange after = list.get(index);
 			Preconditions.checkState(range.endID < after.startID,
 					"Overlappping ID ranges detected: %s %s", range, after);
 			if (range.endID == after.startID-1) {
 				// combine them
-				list.remove(index+1);
+				list.remove(index);
 				range = new SectIDRange(range.startID, after.endID);
 			}
 		}
@@ -196,6 +197,25 @@ public class UniqueRupture {
 		} else if (!list.equals(other.list))
 			return false;
 		return true;
+	}
+	
+	/**
+	 * @return immutable view of the list of ID ranges
+	 */
+	public ImmutableList<SectIDRange> getRanges() {
+		return ImmutableList.copyOf(list);
+	}
+	
+	@Override
+	public String toString() {
+		StringBuilder str = new StringBuilder();
+		str.append("UniqueRupture(size="+size+"): ");
+		for (int i=0; i<list.size(); i++) {
+			if (i > 0)
+				str.append(",");
+			str.append(list.get(i));
+		}
+		return str.toString();
 	}
 
 }

--- a/src/org/opensha/sha/simulators/stiffness/RuptureCoulombResult.java
+++ b/src/org/opensha/sha/simulators/stiffness/RuptureCoulombResult.java
@@ -1,0 +1,136 @@
+package org.opensha.sha.simulators.stiffness;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
+import org.opensha.sha.faultSurface.FaultSection;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessAggregationMethod;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessResult;
+import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.StiffnessType;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
+
+public class RuptureCoulombResult {
+	
+	public final ImmutableMap<FaultSection, Double> sectSumCFFs;
+	public final ImmutableMap<FaultSection, Double> sectFractPositiveCFFs;
+	public final int numNetPositiveCFFs;
+	public final int numNetNegativeCFFs;
+	public final int numSects;
+	
+	public enum RupCoulombQuantity {
+		MEAN_SECT_CFF("Mean Sect Net ΔCFF", "MPa"),
+		MIN_SECT_CFF("Min Sect Net ΔCFF", "MPa"),
+		MEAN_SECT_FRACT_POSITIVES("Mean Sect Fract ΔCFF > 0"),
+		MIN_SECT_FRACT_POSITIVES("Min Sect Fract ΔCFF > 0"),
+		NUM_NET_NEGATIVE_SECTS("Num Sects w/ Net ΔCFF < 0");
+		
+		private String name;
+		private String units;
+		
+		private RupCoulombQuantity(String name) {
+			this(name, null);
+		}
+		
+		private RupCoulombQuantity(String name, String units) {
+			this.name = name;
+			this.units = units;
+		}
+		
+		@Override
+		public String toString() {
+			if (units == null)
+				return name;
+			return name+" ("+units+")";
+		}
+		
+	}
+	
+	public RuptureCoulombResult(ClusterRupture rupture, SubSectStiffnessCalculator calc,
+			StiffnessAggregationMethod calcAggMethod) {
+		this(clusterRupSects(rupture), calc, calcAggMethod);
+	}
+	
+	private static List<FaultSection> clusterRupSects(ClusterRupture rupture) {
+		List<FaultSection> allSects = new ArrayList<>();
+		for (FaultSubsectionCluster cluster : rupture.getClustersIterable())
+			allSects.addAll(cluster.subSects);
+		return allSects;
+	}
+	
+	public RuptureCoulombResult(List<? extends FaultSection> rupSects, SubSectStiffnessCalculator calc,
+			StiffnessAggregationMethod calcAggMethod) {
+		Builder<FaultSection, Double> sumCFFsBuilder = ImmutableMap.builder();
+		Builder<FaultSection, Double> fractPosCFFsBuilder = ImmutableMap.builder();
+		
+		Preconditions.checkArgument(rupSects.size() > 1);
+		this.numSects = rupSects.size();
+		int numNetPositive = 0;
+		int numNetNegative = 0;
+		for (FaultSection receiver : rupSects) {
+			double sumCFF = 0d;
+			double fractPositives = 0d;
+			for (FaultSection source : rupSects) {
+				if (source == receiver)
+					continue;
+				StiffnessResult[] stiffness = calc.calcStiffness(source, receiver);
+				double cff = calc.getValue(stiffness, StiffnessType.CFF, calcAggMethod);
+				double fractPositive = calc.getValue(
+						stiffness, StiffnessType.CFF, StiffnessAggregationMethod.FRACT_POSITIVE);
+				Preconditions.checkState(Double.isFinite(cff), "CFF is %s from %s to %s",
+						cff, source.getSectionName(), receiver.getSectionName());
+				sumCFF += cff;
+				fractPositives += fractPositive;
+			}
+			fractPositives /= (rupSects.size()-1);
+			sumCFFsBuilder.put(receiver, sumCFF);
+			fractPosCFFsBuilder.put(receiver, fractPositives);
+			if (sumCFF > 0d)
+				numNetPositive++;
+			if (sumCFF < 0d)
+				numNetNegative++;
+		}
+		this.sectSumCFFs = sumCFFsBuilder.build();
+		this.sectFractPositiveCFFs = fractPosCFFsBuilder.build();
+		this.numNetPositiveCFFs = numNetPositive;
+		this.numNetNegativeCFFs = numNetNegative;
+	}
+	
+	public double getValue(RupCoulombQuantity quantity) {
+		switch (quantity) {
+		case MEAN_SECT_CFF:
+			return mean(sectSumCFFs.values());
+		case MIN_SECT_CFF:
+			return min(sectSumCFFs.values());
+		case MEAN_SECT_FRACT_POSITIVES:
+			return mean(sectFractPositiveCFFs.values());
+		case MIN_SECT_FRACT_POSITIVES:
+			return min(sectFractPositiveCFFs.values());
+		case NUM_NET_NEGATIVE_SECTS:
+			return numNetNegativeCFFs;
+
+		default:
+			throw new IllegalStateException();
+		}
+	}
+	
+	private static double mean(Collection<Double> values) {
+		double sum = 0d;
+		for (double val : values)
+			sum += val;
+		return sum/(double)values.size();
+	}
+	
+	private static double min(Collection<Double> values) {
+		double min = Double.POSITIVE_INFINITY;
+		for (Double val : values)
+			min = Math.min(val, min);
+		return min;
+	}
+
+}

--- a/src/org/opensha/sha/simulators/stiffness/SubSectStiffnessCalculator.java
+++ b/src/org/opensha/sha/simulators/stiffness/SubSectStiffnessCalculator.java
@@ -131,7 +131,7 @@ public class SubSectStiffnessCalculator {
 		double centerLon = lonTrack.getMin() + 0.5*(lonTrack.getMax() - lonTrack.getMin());
 		utmZone = UTM.calcZone(centerLon);
 		utmChar = UTM.calcLetter(centerLat);
-		System.out.println("UTM zone: "+utmZone+" "+utmChar);
+//		System.out.println("UTM zone: "+utmZone+" "+utmChar);
 	}
 	
 	private void checkInit() {

--- a/src/org/opensha/sha/simulators/stiffness/SubSectStiffnessCalculator.java
+++ b/src/org/opensha/sha/simulators/stiffness/SubSectStiffnessCalculator.java
@@ -1,0 +1,568 @@
+package org.opensha.sha.simulators.stiffness;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.zip.ZipException;
+
+import org.dom4j.DocumentException;
+import org.opensha.commons.geo.Location;
+import org.opensha.commons.geo.LocationUtils;
+import org.opensha.commons.geo.utm.UTM;
+import org.opensha.commons.util.DataUtils;
+import org.opensha.commons.util.DataUtils.MinMaxAveTracker;
+import org.opensha.commons.util.ExceptionUtils;
+import org.opensha.commons.util.IDPairing;
+import org.opensha.sha.earthquake.FocalMechanism;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
+import org.opensha.sha.faultSurface.EvenlyGriddedSurface;
+import org.opensha.sha.faultSurface.FaultSection;
+import org.opensha.sha.faultSurface.RuptureSurface;
+import org.opensha.sha.simulators.stiffness.StiffnessCalc.Patch;
+
+import com.google.common.base.Preconditions;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.primitives.Doubles;
+
+import scratch.UCERF3.FaultSystemRupSet;
+import scratch.UCERF3.utils.FaultSystemIO;
+
+public class SubSectStiffnessCalculator {
+	
+	private List<? extends FaultSection> subSects;
+	
+	private int utmZone;
+	private char utmChar;
+	
+	private transient Map<FaultSection, List<Patch>> patchesMap;
+	
+	private transient LoadingCache<IDPairing, StiffnessResult[]> subSectStiffnessCache;
+
+	private double gridSpacing;
+	private double lameLambda;
+	private double lameMu;
+	private double coeffOfFriction;
+	
+	public enum StiffnessType {
+		SIGMA("ΔSigma", "&Delta;Sigma", "MPa"),
+		TAU("ΔTau", "&Delta;Tau", "MPa"),
+		CFF("ΔCFF", "&Delta;CFF", "MPa");
+		
+		private String name;
+		private String html;
+		private String units;
+		
+		private StiffnessType(String name, String html, String units) {
+			this.name = name;
+			this.html = html;
+			this.units = units;
+		}
+		
+		@Override
+		public String toString() {
+			return name+" ("+units+")";
+		}
+		
+		public String getName() {
+			return name;
+		}
+		
+		public String getHTML() {
+			return html;
+		}
+		
+		public String getUnits() {
+			return units;
+		}
+	}
+	
+	public enum StiffnessAggregationMethod {
+		MEAN("Mean", "Mean stiffness across all patch-to-patch calculations"),
+		MEDIAN("Median", "Median stiffness across all patch-to-patch calculations"),
+		MIN("Min", "Minimum individual stiffness across all patch-to-patch calculations"),
+		MAX("Max", "Maximum individual stiffness across all patch-to-patch calculations"),
+		FRACT_POSITIVE("Fract Positive", "The fraction of individual patch-to-patch stiffness "
+				+ "calculations which are &ge;0");
+		
+		private String name;
+		private String description;
+		private StiffnessAggregationMethod(String name, String description) {
+			this.name = name;
+			this.description = description;
+		}
+		
+		@Override
+		public String toString() {
+			return name;
+		}
+		
+		public String getDescription() {
+			return description;
+		}
+	}
+
+	public SubSectStiffnessCalculator(List<? extends FaultSection> subSects, double gridSpacing,
+			double lameLambda, double lameMu, double coeffOfFriction) {
+		this.subSects = subSects;
+		this.gridSpacing = gridSpacing;
+		this.lameLambda = lameLambda;
+		this.lameMu = lameMu;
+		this.coeffOfFriction = coeffOfFriction;
+		
+		MinMaxAveTracker latTrack = new MinMaxAveTracker();
+		MinMaxAveTracker lonTrack = new MinMaxAveTracker();
+		for (FaultSection sect : subSects) {
+			for (Location loc : sect.getFaultTrace()) {
+				latTrack.addValue(loc.getLatitude());
+				lonTrack.addValue(loc.getLongitude());
+			}
+		}
+		
+		double centerLat = latTrack.getMin() + 0.5*(latTrack.getMax() - latTrack.getMin());
+		double centerLon = lonTrack.getMin() + 0.5*(lonTrack.getMax() - lonTrack.getMin());
+		utmZone = UTM.calcZone(centerLon);
+		utmChar = UTM.calcLetter(centerLat);
+		System.out.println("UTM zone: "+utmZone+" "+utmChar);
+	}
+	
+	private void checkInit() {
+		if (subSectStiffnessCache == null) {
+			synchronized (this) {
+				if (subSectStiffnessCache != null)
+					return;
+				System.out.println("Building source patches...");
+				patchesMap = new HashMap<>();
+				MinMaxAveTracker patchCountTrack = new MinMaxAveTracker();
+				for (FaultSection sect : subSects) {
+					RuptureSurface surf = sect.getFaultSurface(gridSpacing, false, false);
+					Preconditions.checkState(surf instanceof EvenlyGriddedSurface);
+					EvenlyGriddedSurface gridSurf = (EvenlyGriddedSurface)surf;
+					
+					double aveDip = surf.getAveDip();
+					double aveRake = sect.getAveRake();
+					
+					MinMaxAveTracker lenTrack = new MinMaxAveTracker();
+					MinMaxAveTracker widthTrack = new MinMaxAveTracker();
+					MinMaxAveTracker strikeTrack = new MinMaxAveTracker();
+					
+					List<Patch> myPatches = new ArrayList<>();
+					
+					for (int row=0; row<gridSurf.getNumRows()-1; row++) {
+						for (int col=0; col<gridSurf.getNumCols()-1; col++) {
+							Location loc1 = gridSurf.getLocation(row, col);
+							Location loc2 = gridSurf.getLocation(row, col + 1);
+							Location loc3 = gridSurf.getLocation(row + 1, col);
+							Location loc4 = gridSurf.getLocation(row + 1, col + 1);
+							double locLat = (loc1.getLatitude() + loc2.getLatitude() +
+									loc3.getLatitude() +
+									loc4.getLatitude()) / 4;
+							double locLon = (loc1.getLongitude() + loc2.getLongitude() +
+									loc3.getLongitude() +
+									loc4.getLongitude()) / 4;
+							double locDepth = (loc1.getDepth() + loc2.getDepth() + loc3.getDepth() +
+									loc4.getDepth()) / 4;
+							double strike = LocationUtils.azimuth(loc1, loc2);
+							Location center = new Location(locLat, locLon, locDepth);
+							FocalMechanism mech = new FocalMechanism(strike, aveDip, aveRake);
+//							double length = LocationUtils.horzDistanceFast(loc1, loc2)*1000d;
+//							double width = LocationUtils.vertDistance(loc1, loc3)*1000d;
+							// use the input grid spacing instead. this will be less than or equal
+							// to the full grid spacing, and ensures that the moment is identical for
+							// all patches across all subsections
+							double length = gridSpacing*1000d; // km -> m
+							double width = length;
+							strikeTrack.addValue(strike);
+							lenTrack.addValue(length);
+							widthTrack.addValue(width);
+							myPatches.add(new Patch(center, utmZone, utmChar, length, width, mech));
+						}
+					}
+					Preconditions.checkState(myPatches.size() > 0, "must have at least 1 patch");
+					patchCountTrack.addValue(myPatches.size());
+//					System.out.println(sect.getSectionName()+" has "+myPatches.size()
+//						+" patches, aveStrike="+sect.getFaultTrace().getAveStrike());
+//					System.out.println("\tStrike range: "+strikeTrack);
+//					System.out.println("\tLength range: "+lenTrack);
+//					System.out.println("\tWidth range: "+widthTrack);
+					patchesMap.put(sect, myPatches);
+				}
+				System.out.println("Patch stats: "+patchCountTrack);
+				
+				int concurLevel = Runtime.getRuntime().availableProcessors();
+				concurLevel = Integer.max(concurLevel, 4);
+				concurLevel = Integer.min(concurLevel, 20);
+				LoadingCache<IDPairing, StiffnessResult[]> cache = CacheBuilder.newBuilder()
+						.concurrencyLevel(concurLevel).build(
+						new CacheLoader<IDPairing, StiffnessResult[]>() {
+
+					@Override
+					public StiffnessResult[] load(IDPairing key) throws Exception {
+						List<Patch> sourcePatches = patchesMap.get(subSects.get(key.getID1()));
+						List<Patch> receiverPatches = patchesMap.get(subSects.get(key.getID2()));
+						
+						int count = sourcePatches.size()*receiverPatches.size();
+						
+						double[] sigmaVals = new double[count];
+						double[] tauVals = new double[count];
+						double[] cffVals = new double[count];
+						
+						int index = 0;
+						for (Patch source : sourcePatches) {
+							for (Patch receiver : receiverPatches) {
+								double[] stiffness = StiffnessCalc.calcStiffness(
+										lameLambda, lameMu, source, receiver);
+								if (stiffness == null) {
+									sigmaVals[index] = Double.NaN;
+									tauVals[index] = Double.NaN;
+									cffVals[index] = Double.NaN;
+								} else {
+									sigmaVals[index] = stiffness[0];
+									tauVals[index] = stiffness[1];
+									cffVals[index] = StiffnessCalc.calcCoulombStress(
+											stiffness[1], stiffness[0], coeffOfFriction);
+								}
+								index++;
+							}
+						}
+						
+						return new StiffnessResult[] {
+								new StiffnessResult(key.getID1(), key.getID2(), sigmaVals, StiffnessType.SIGMA),
+								new StiffnessResult(key.getID1(), key.getID2(), tauVals, StiffnessType.TAU),
+								new StiffnessResult(key.getID1(), key.getID2(), cffVals, StiffnessType.CFF)
+						};
+					}
+					
+				});
+				this.subSectStiffnessCache = cache;
+			}
+		}
+	}
+	
+	/**
+	 * Calculates stiffness between the given sub sections
+	 * 
+	 * @param sourceSect
+	 * @param receiverSect
+	 * @return { sigma, tau, cff }
+	 */
+	public StiffnessResult[] calcStiffness(FaultSection sourceSect, FaultSection receiverSect) {
+		checkInit();
+		try {
+			return subSectStiffnessCache.get(
+					new IDPairing(sourceSect.getSectionId(), receiverSect.getSectionId()));
+		} catch (ExecutionException e) {
+			throw ExceptionUtils.asRuntimeException(e);
+		}
+	}
+	
+	/**
+	 * @return calculated UTM zone for the center of the fault region
+	 */
+	public int getUTMZone() {
+		return utmZone;
+	}
+
+	/**
+	 * @return calculated UTM letter for the center of the fault region
+	 */
+	public char getUTMLetter() {
+		return utmChar;
+	}
+
+	/**
+	 * @return grid spacing used to subdivide subsections into patches for stiffness calculations (km)
+	 */
+	public double getGridSpacing() {
+		return gridSpacing;
+	}
+
+	/**
+	 * @return Lame lambda (first parameter) MPa
+	 */
+	public double getLameLambda() {
+		return lameLambda;
+	}
+
+	/**
+	 * Lame mu (second parameter, shear modulus) in MPa
+	 * @return
+	 */
+	public double getLameMu() {
+		return lameMu;
+	}
+	
+	/**
+	 * @return coefficient of friction used in Coulomb stress change calculations
+	 */
+	public double getCoeffOfFriction() {
+		return coeffOfFriction;
+	}
+
+	/**
+	 * Calculates stiffness between the given parent sections
+	 * 
+	 * @param sourceSect
+	 * @param receiverSect
+	 * @return { sigma, tau, cff }
+	 */
+	public StiffnessResult[] calcParentStiffness(int sourceParentID, int receiverParentID) {
+		List<FaultSection> sourceSects = new ArrayList<>();
+		List<FaultSection> receiverSects = new ArrayList<>();
+		for (FaultSection sect : subSects) {
+			int parentID = sect.getParentSectionId();
+			if (parentID == sourceParentID)
+				sourceSects.add(sect);
+			if (parentID == receiverParentID)
+				receiverSects.add(sect);
+		}
+		return calcCombinedStiffness(sourceSects, receiverSects, sourceParentID, receiverParentID);
+	}
+	
+	/**
+	 * Calculates stiffness between the given clusters
+	 * 
+	 * @param sourceSect
+	 * @param receiverSect
+	 * @return { sigma, tau, cff }
+	 */
+	public StiffnessResult[] calcClusterStiffness(FaultSubsectionCluster sourceCluster,
+			FaultSubsectionCluster receiverCluster) {
+		return calcCombinedStiffness(sourceCluster.subSects, receiverCluster.subSects,
+				sourceCluster.parentSectionID, receiverCluster.parentSectionID);
+	}
+	
+	/**
+	 * Calculates aggregated stiffness from the given rupture to the given clusters
+	 * 
+	 * @param sourceSect
+	 * @param receiverSect
+	 * @return { sigma, tau, cff }
+	 */
+	public StiffnessResult[] calcAggRupToClusterStiffness(ClusterRupture sourceRupture,
+			FaultSubsectionCluster receiverCluster) {
+		List<FaultSection> sourceSects = new ArrayList<>();
+		for (FaultSubsectionCluster cluster : sourceRupture.getClustersIterable())
+			if (cluster != receiverCluster)
+				sourceSects.addAll(cluster.subSects);
+		return calcCombinedStiffness(sourceSects, receiverCluster.subSects,
+				-1, receiverCluster.parentSectionID);
+	}
+	
+	/**
+	 * Calculates aggregated stiffness from the given set of clusters to the given cluster
+	 * 
+	 * @param sourceSect
+	 * @param receiverSect
+	 * @return { sigma, tau, cff }
+	 */
+	public StiffnessResult[] calcAggClustersToClusterStiffness(Collection<FaultSubsectionCluster> sourceClusters,
+			FaultSubsectionCluster receiverCluster) {
+		List<FaultSection> sourceSects = new ArrayList<>();
+		for (FaultSubsectionCluster cluster : sourceClusters)
+			if (cluster != receiverCluster)
+				sourceSects.addAll(cluster.subSects);
+		return calcCombinedStiffness(sourceSects, receiverCluster.subSects,
+				-1, receiverCluster.parentSectionID);
+	}
+	
+	private StiffnessResult[] calcCombinedStiffness(List<FaultSection> sources, List<FaultSection> receivers,
+			int sourceID, int receiverID) {
+		List<StiffnessResult> sigmaResults = new ArrayList<>();
+		List<StiffnessResult> tauResults = new ArrayList<>();
+		List<StiffnessResult> cffResults = new ArrayList<>();
+		checkInit();
+		for (FaultSection source : sources) {
+			for (FaultSection receiver : receivers) {
+				try {
+					StiffnessResult[] myResults = subSectStiffnessCache.get(
+							new IDPairing(source.getSectionId(), receiver.getSectionId()));
+					sigmaResults.add(myResults[0]);
+					tauResults.add(myResults[1]);
+					cffResults.add(myResults[2]);
+				} catch (ExecutionException e) {
+					throw ExceptionUtils.asRuntimeException(e);
+				}
+			}
+		}
+		
+		return new StiffnessResult[] { new StiffnessResult(sourceID, receiverID, sigmaResults),
+				new StiffnessResult(sourceID, receiverID, tauResults),
+				new StiffnessResult(sourceID, receiverID, cffResults) };
+	}
+	
+	public double getValue(StiffnessResult[] stiffness, StiffnessType type, StiffnessAggregationMethod quantity) {
+		if (type == StiffnessType.SIGMA)
+			return getValue(stiffness[0], quantity);
+		if (type == StiffnessType.TAU)
+			return getValue(stiffness[1], quantity);
+		// CFF
+		Preconditions.checkState(type == StiffnessType.CFF);
+		return getValue(stiffness[2], quantity);
+	}
+	
+	public static double getValue(StiffnessResult stiffness, StiffnessAggregationMethod quantity) {
+		switch (quantity) {
+		case MEAN:
+			return stiffness.mean;
+		case MEDIAN:
+			return stiffness.median;
+		case MIN:
+			return stiffness.min;
+		case MAX:
+			return stiffness.max;
+		case FRACT_POSITIVE:
+			return stiffness.fractPositive;
+
+		default:
+			throw new IllegalStateException("Unexpected quantity: "+quantity);
+		}
+	}
+	
+	public class StiffnessResult {
+		public final int sourceID;
+		public final int receiverID;
+		public final double mean;
+		public final double median;
+		public final double min;
+		public final double max;
+		public final double fractPositive;
+		public final double fractSingular;
+		public final StiffnessType type;
+		public final int numValues;
+		
+		public StiffnessResult(int sourceID, int receiverID,
+				double[] vals, StiffnessType type) {
+			super();
+			this.sourceID = sourceID;
+			this.receiverID = receiverID;
+			this.type = type;
+			int numSingular = 0;
+			double mean = 0d;
+			double min = Double.POSITIVE_INFINITY;
+			double max = Double.NEGATIVE_INFINITY;
+			double fractPositive = 0d;
+			List<Double> nonSingularSortedVals = new ArrayList<>();
+			for (double val : vals) {
+				if (Double.isNaN(val)) {
+					numSingular++;
+				} else {
+					min = Math.min(min, val);
+					max = Math.max(max, val);
+					mean += val;
+					if (val > 0)
+						fractPositive += 1d;
+					int index = Collections.binarySearch(nonSingularSortedVals, val);
+					if (index < 0)
+						index = -(index+1);
+					nonSingularSortedVals.add(index, val);
+				}
+			}
+			int nonSingular = vals.length - numSingular;
+			fractPositive /= (double)vals.length;
+			this.mean = mean/(double)nonSingular;
+			this.median = DataUtils.median_sorted(Doubles.toArray(nonSingularSortedVals));
+			this.min = min;
+			this.max = max;
+			this.fractPositive = fractPositive;
+			this.fractSingular = (double)numSingular/(double)vals.length;
+			this.numValues = vals.length;
+		}
+		
+		public StiffnessResult(int sourceID, int receiverID,
+				List<StiffnessResult> results) {
+			// combine
+			double min = Double.POSITIVE_INFINITY;
+			double max = Double.NEGATIVE_INFINITY;
+			// will sum mean & medians across all
+			double mean = 0d;
+			double median = 0d;
+			// will average fractions
+			double fractPositive = 0d;
+			double fractSingular = 0d;
+			
+			int num = 0;
+			
+			StiffnessType type = results.get(0).type;
+			for (StiffnessResult result : results) {
+				Preconditions.checkState(result.type == type);
+				min = Math.min(min, result.min);
+				max = Math.max(max, result.max);
+				mean += result.mean;
+				median += result.median;
+				fractPositive += result.fractPositive;
+				fractSingular += result.fractSingular;
+				num += result.numValues;
+			}
+			
+			fractPositive /= results.size();
+			fractSingular /= results.size();
+			
+			this.sourceID = sourceID;
+			this.receiverID = receiverID;
+			this.mean = mean;
+			this.median = median;
+			this.min = min;
+			this.max = max;
+			this.fractPositive = fractPositive;
+			this.fractSingular = fractSingular;
+			this.type = type;
+			this.numValues = num;
+		}
+		
+		@Override
+		public String toString() {
+			StringBuilder str = new StringBuilder();
+			str.append("[").append(sourceID).append("=>").append(receiverID).append("] ");
+			str.append(type.name).append(":\t");
+			str.append("mean=").append((float)mean);
+			str.append("\tmedian=").append((float)median);
+			str.append("\trange=[").append((float)min).append(",").append((float)max).append("]");
+			str.append("\tfractPositive=").append((float)fractPositive);
+			str.append("\tfractSingular=").append((float)fractSingular);
+			return str.toString();
+		}
+	}
+	
+	public static void main(String[] args) throws ZipException, IOException, DocumentException {
+		File fssFile = new File("/home/kevin/Simulators/catalogs/rundir4983_stitched/fss/"
+				+ "rsqsim_sol_m6.5_skip5000_sectArea0.2.zip");
+		FaultSystemRupSet rupSet = FaultSystemIO.loadRupSet(fssFile);
+		double lambda = 30000;
+		double mu = 30000;
+		double coeffOfFriction = 0.5;
+		SubSectStiffnessCalculator calc = new SubSectStiffnessCalculator(
+				rupSet.getFaultSectionDataList(), 2d, lambda, mu, coeffOfFriction);
+		
+		System.out.println(calc.utmZone+" "+calc.utmChar);
+
+		FaultSection[] sects = {
+				calc.subSects.get(1836), calc.subSects.get(1837),
+//				calc.subSects.get(625), calc.subSects.get(1772),
+//				calc.subSects.get(771), calc.subSects.get(1811)
+		};
+		
+		StiffnessAggregationMethod quantity = StiffnessAggregationMethod.MEDIAN;
+		
+		for (int i=0; i<sects.length; i++) {
+			for (int j=0; j<sects.length; j++) {
+				System.out.println("Source: "+sects[i].getSectionName());
+				System.out.println("Receiver: "+sects[j].getSectionName());
+				StiffnessResult[] stiffness = calc.calcStiffness(sects[i], sects[j]);
+				for (StiffnessType type : StiffnessType.values())
+					System.out.println("\t"+type+": "+calc.getValue(stiffness, type, quantity));
+//				System.out.println("\t"+stiffness[0]);
+//				System.out.println("\t"+stiffness[1]);
+			}
+		}
+	}
+	
+}

--- a/src/org/opensha/sha/simulators/stiffness/SubSectStiffnessCalculator.java
+++ b/src/org/opensha/sha/simulators/stiffness/SubSectStiffnessCalculator.java
@@ -324,7 +324,7 @@ public class SubSectStiffnessCalculator {
 			if (parentID == receiverParentID)
 				receiverSects.add(sect);
 		}
-		return calcCombinedStiffness(sourceSects, receiverSects, sourceParentID, receiverParentID);
+		return calcAggStiffness(sourceSects, receiverSects, sourceParentID, receiverParentID);
 	}
 	
 	/**
@@ -336,7 +336,7 @@ public class SubSectStiffnessCalculator {
 	 */
 	public StiffnessResult[] calcClusterStiffness(FaultSubsectionCluster sourceCluster,
 			FaultSubsectionCluster receiverCluster) {
-		return calcCombinedStiffness(sourceCluster.subSects, receiverCluster.subSects,
+		return calcAggStiffness(sourceCluster.subSects, receiverCluster.subSects,
 				sourceCluster.parentSectionID, receiverCluster.parentSectionID);
 	}
 	
@@ -353,7 +353,7 @@ public class SubSectStiffnessCalculator {
 		for (FaultSubsectionCluster cluster : sourceRupture.getClustersIterable())
 			if (cluster != receiverCluster)
 				sourceSects.addAll(cluster.subSects);
-		return calcCombinedStiffness(sourceSects, receiverCluster.subSects,
+		return calcAggStiffness(sourceSects, receiverCluster.subSects,
 				-1, receiverCluster.parentSectionID);
 	}
 	
@@ -370,11 +370,11 @@ public class SubSectStiffnessCalculator {
 		for (FaultSubsectionCluster cluster : sourceClusters)
 			if (cluster != receiverCluster)
 				sourceSects.addAll(cluster.subSects);
-		return calcCombinedStiffness(sourceSects, receiverCluster.subSects,
+		return calcAggStiffness(sourceSects, receiverCluster.subSects,
 				-1, receiverCluster.parentSectionID);
 	}
 	
-	private StiffnessResult[] calcCombinedStiffness(List<FaultSection> sources, List<FaultSection> receivers,
+	public StiffnessResult[] calcAggStiffness(List<FaultSection> sources, List<FaultSection> receivers,
 			int sourceID, int receiverID) {
 		List<StiffnessResult> sigmaResults = new ArrayList<>();
 		List<StiffnessResult> tauResults = new ArrayList<>();

--- a/src/scratch/UCERF3/CompoundFaultSystemSolution.java
+++ b/src/scratch/UCERF3/CompoundFaultSystemSolution.java
@@ -253,6 +253,7 @@ public class CompoundFaultSystemSolution extends FaultSystemSolutionFetcher {
 		dependencyMap.put("grid_sources.bin", null);
 		dependencyMap.put("rup_mfds.bin", null);
 		dependencyMap.put("sub_seismo_on_fault_mfds.bin", null);
+		dependencyMap.put("plausibility.json", buildList(FaultModels.class));
 	}
 	
 	private static List<Class<? extends LogicTreeBranchNode<?>>> buildList(

--- a/src/scratch/UCERF3/FaultSystemRupSet.java
+++ b/src/scratch/UCERF3/FaultSystemRupSet.java
@@ -11,24 +11,18 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
 
 import org.apache.commons.math3.stat.StatUtils;
 import org.opensha.commons.calc.FaultMomentCalc;
-import org.opensha.commons.data.function.EvenlyDiscretizedFunc;
 import org.opensha.commons.geo.LocationList;
 import org.opensha.commons.geo.Region;
 import org.opensha.commons.geo.RegionUtils;
-import org.opensha.refFaultParamDb.vo.FaultSectionPrefData;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityConfiguration;
 import org.opensha.sha.faultSurface.CompoundSurface;
-import org.opensha.sha.faultSurface.EvenlyGriddedSurface;
 import org.opensha.sha.faultSurface.FaultSection;
 import org.opensha.sha.faultSurface.FaultTrace;
-import org.opensha.sha.faultSurface.QuadSurface;
 import org.opensha.sha.faultSurface.RuptureSurface;
-import org.opensha.sha.faultSurface.StirlingGriddedSurface;
 import org.opensha.sha.gui.infoTools.CalcProgressBar;
-import org.opensha.sha.magdist.IncrementalMagFreqDist;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
@@ -60,6 +54,8 @@ public class FaultSystemRupSet implements Serializable {
 	private double[] sectAreas;
 	private List<List<Integer>> sectionForRups;
 	private String info;
+	
+	private PlausibilityConfiguration plausibilityConfig;
 	
 	// for caching
 	protected boolean showProgress = false;
@@ -536,7 +532,7 @@ public class FaultSystemRupSet implements Serializable {
 	 * @param gridSpacing
 	 * @return
 	 */
-	public RuptureSurface getSurfaceForRupupture(int rupIndex, double gridSpacing) {
+	public RuptureSurface getSurfaceForRupture(int rupIndex, double gridSpacing) {
 		return surfCache.getSurfaceForRupture(rupIndex, gridSpacing);
 	}
 	
@@ -791,6 +787,17 @@ public class FaultSystemRupSet implements Serializable {
 		return StatUtils.min(getMagForAllRups());
 	}
 	
+	/**
+	 * This gives the plausibility configuration used to create this rupture set if available,
+	 * otherwise null;
+	 * @return
+	 */
+	public PlausibilityConfiguration getPlausibilityConfiguration() {
+		return plausibilityConfig;
+	}
 	
+	public void setPlausibilityConfiguration(PlausibilityConfiguration plausibilityConfig) {
+		this.plausibilityConfig = plausibilityConfig;
+	}
 	
 }

--- a/src/scratch/UCERF3/erf/ETAS/ETAS_MultiSimAnalysisTools.java
+++ b/src/scratch/UCERF3/erf/ETAS/ETAS_MultiSimAnalysisTools.java
@@ -3703,7 +3703,7 @@ public class ETAS_MultiSimAnalysisTools {
 				// FaultSectionPrefData last = sectData.get(sectData.size()-1);
 				// Location start = first.getFaultTrace().first();
 				// Location end = last.getFaultTrace().last();
-				RuptureSurface surf = rupSet.getSurfaceForRupupture(rup.getFSSIndex(), 1d);
+				RuptureSurface surf = rupSet.getSurfaceForRupture(rup.getFSSIndex(), 1d);
 				Location hypo = rup.getHypocenterLocation();
 				// Location start = surf.getFirstLocOnUpperEdge();
 				// Location end = surf.getLastLocOnUpperEdge();
@@ -3860,7 +3860,7 @@ public class ETAS_MultiSimAnalysisTools {
 			sects = new HashSet<Integer>();
 			List<Location> scenarioLocs = Lists.newArrayList();
 			if (scenario.getFSS_Index() >= 0)
-				scenarioLocs.addAll(rupSet.getSurfaceForRupupture(scenario.getFSS_Index(), 1d).getUpperEdge());
+				scenarioLocs.addAll(rupSet.getSurfaceForRupture(scenario.getFSS_Index(), 1d).getUpperEdge());
 			else
 				scenarioLocs.add(scenario.getLocation());
 			for (FaultSection sect : rupSet.getFaultSectionDataList()) {
@@ -5427,7 +5427,7 @@ public class ETAS_MultiSimAnalysisTools {
 			else if (scenario.getLocation() != null)
 				surf = new PointSurface(scenario.getLocation());
 			else
-				surf = fss.getRupSet().getSurfaceForRupupture(scenario.getFSS_Index(), 1d);
+				surf = fss.getRupSet().getSurfaceForRupture(scenario.getFSS_Index(), 1d);
 
 			File parentDir = resultsFile.getParentFile();
 

--- a/src/scratch/UCERF3/erf/ETAS/ETAS_SimAnalysisTools.java
+++ b/src/scratch/UCERF3/erf/ETAS/ETAS_SimAnalysisTools.java
@@ -1973,7 +1973,7 @@ public class ETAS_SimAnalysisTools {
 			if (fssIndex >= 0) {
 				Preconditions.checkState((float)rup.getMag() == (float)rupSet.getMagForRup(fssIndex),
 						"Magnitude discrepancy: "+(float)rup.getMag()+" != "+(float)rupSet.getMagForRup(fssIndex));
-				rup.setRuptureSurface(rupSet.getSurfaceForRupupture(fssIndex, 1d));
+				rup.setRuptureSurface(rupSet.getSurfaceForRupture(fssIndex, 1d));
 			}
 		}
 	}

--- a/src/scratch/UCERF3/erf/ETAS/analysis/ETAS_GriddedNucleationPlot.java
+++ b/src/scratch/UCERF3/erf/ETAS/analysis/ETAS_GriddedNucleationPlot.java
@@ -161,7 +161,7 @@ public class ETAS_GriddedNucleationPlot extends ETAS_AbstractPlot {
 				Map<Integer, HashSet<Integer>> rupToGridNodes = new HashMap<>();
 				for (int r=0; r<rupSet.getNumRuptures(); r++) {
 					HashSet<Integer> nodes = new HashSet<>();
-					for (Location l : rupSet.getSurfaceForRupupture(r, 1d).getEvenlyDiscritizedListOfLocsOnSurface()) {
+					for (Location l : rupSet.getSurfaceForRupture(r, 1d).getEvenlyDiscritizedListOfLocsOnSurface()) {
 						int node = gridReg.indexForLocation(l);
 						if (node >= 0)
 							nodes.add(node);

--- a/src/scratch/UCERF3/erf/ETAS/analysis/ETAS_SimulatedCatalogPlot.java
+++ b/src/scratch/UCERF3/erf/ETAS/analysis/ETAS_SimulatedCatalogPlot.java
@@ -240,7 +240,7 @@ public class ETAS_SimulatedCatalogPlot extends ETAS_AbstractPlot {
 				catalogLocs.add(hypo);
 				// populate the surface
 				if (rup.getFSSIndex() >= 0) {
-					RuptureSurface surf = fss.getRupSet().getSurfaceForRupupture(rup.getFSSIndex(), 1d);
+					RuptureSurface surf = fss.getRupSet().getSurfaceForRupture(rup.getFSSIndex(), 1d);
 					rup.setRuptureSurface(surf);
 //					catalogLocs.addAll(surf.getEvenlyDiscritizedListOfLocsOnSurface());
 				}

--- a/src/scratch/UCERF3/erf/ETAS/association/FiniteFaultMapper.java
+++ b/src/scratch/UCERF3/erf/ETAS/association/FiniteFaultMapper.java
@@ -88,7 +88,7 @@ public class FiniteFaultMapper {
 		
 		for (int i=0; i<rupSet.getNumRuptures(); i++) {
 			lengths[i] = rupSet.getLengthForRup(i)/1000d; // convert to km
-			surfs[i] = rupSet.getSurfaceForRupupture(i, surfSpacing);
+			surfs[i] = rupSet.getSurfaceForRupture(i, surfSpacing);
 			centers[i] = calcCenter(surfs[i]);
 		}
 		

--- a/src/scratch/UCERF3/erf/ETAS/association/FiniteFaultMappingData.java
+++ b/src/scratch/UCERF3/erf/ETAS/association/FiniteFaultMappingData.java
@@ -79,7 +79,7 @@ public class FiniteFaultMappingData implements XMLSaveable {
 		if (mappings != null) {
 			Integer rupIndex = mappings.get(fm);
 			Preconditions.checkNotNull(rupIndex, "No mapping exists for "+fm.name());
-			return rupSet.getSurfaceForRupupture(rupIndex, 1d);
+			return rupSet.getSurfaceForRupture(rupIndex, 1d);
 		}
 		RuptureSurface external = mappedSurfaces.get(index);
 		Preconditions.checkNotNull(external);

--- a/src/scratch/UCERF3/erf/ETAS/association/FiniteFaultSectionResetCalc.java
+++ b/src/scratch/UCERF3/erf/ETAS/association/FiniteFaultSectionResetCalc.java
@@ -1133,7 +1133,7 @@ public class FiniteFaultSectionResetCalc {
 		RuptureSurface[] surfs = new RuptureSurface[rupSet.getNumRuptures()];
 		double totRate = sol.getTotalRateForAllFaultSystemRups();
 		for (int r=0; r<rupSet.getNumRuptures(); r++)
-			surfs[r] = rupSet.getSurfaceForRupupture(r, 1d);
+			surfs[r] = rupSet.getSurfaceForRupture(r, 1d);
 		
 		ExecutorService exec = Executors.newFixedThreadPool(threads);
 		

--- a/src/scratch/UCERF3/erf/ETAS/launcher/TriggerRupture.java
+++ b/src/scratch/UCERF3/erf/ETAS/launcher/TriggerRupture.java
@@ -119,7 +119,7 @@ public abstract class TriggerRupture {
 			
 			rupture.setAveRake(rupSet.getAveRakeForRup(fssIndex));
 			rupture.setMag(origMag);
-			rupture.setRuptureSurface(rupSet.getSurfaceForRupupture(fssIndex, 1d));
+			rupture.setRuptureSurface(rupSet.getSurfaceForRupture(fssIndex, 1d));
 			rupture.setFSSIndex(fssIndex);
 			
 			if (overrideMag != null && overrideMag > 0) {

--- a/src/scratch/UCERF3/erf/ETAS/launcher/util/ETAS_ComcatEventConfigBuilder.java
+++ b/src/scratch/UCERF3/erf/ETAS/launcher/util/ETAS_ComcatEventConfigBuilder.java
@@ -47,7 +47,8 @@ public class ETAS_ComcatEventConfigBuilder extends ETAS_AbstractComcatConfigBuil
 //			argz += " --event-id ci39126079"; // 4/4/2020 SJC Anza M4.9
 //			argz += " --event-id ci38488354"; // 4/4/2020 SJC Anza M4.9
 //			argz += " --event-id ci39493944"; // 6/24/2020 Long Pine M5.8
-			argz += " --event-id ci39338407"; // 6/24/2020 Long Pine M5.8
+//			argz += " --event-id ci39338407"; // 6/24/2020 Long Pine M5.8
+			argz += " --event-id ci38695658"; // 9/18/2020 El Monte M4.6
 			argz += " --radius 10";
 //			argz += " --mag-complete 2.5";
 			
@@ -59,7 +60,7 @@ public class ETAS_ComcatEventConfigBuilder extends ETAS_AbstractComcatConfigBuil
 			argz += " --days-before 7";
 //			argz += " --days-after 7";
 //			argz += " --hours-after 33.75";
-			argz += " --end-now";
+//			argz += " --end-now";
 //			argz += " --end-time 1591234330000";
 //			argz += " --name-add Before-M5.5";
 //			argz += " --gridded-only";

--- a/src/scratch/UCERF3/erf/ETAS/launcher/util/ETAS_RuptureSearch.java
+++ b/src/scratch/UCERF3/erf/ETAS/launcher/util/ETAS_RuptureSearch.java
@@ -139,7 +139,7 @@ public class ETAS_RuptureSearch {
 			if (mag < minMag || mag > maxMag)
 				continue;
 			
-			RuptureSurface surf = rupSet.getSurfaceForRupupture(r, 1d);
+			RuptureSurface surf = rupSet.getSurfaceForRupture(r, 1d);
 			
 			System.out.println("Rupture "+r+", M="+(float)mag);
 			double dist = surf.getDistanceJB(centerLoc);

--- a/src/scratch/UCERF3/erf/ETAS/launcher/util/U3TD_ComparisonLauncher.java
+++ b/src/scratch/UCERF3/erf/ETAS/launcher/util/U3TD_ComparisonLauncher.java
@@ -227,7 +227,7 @@ public class U3TD_ComparisonLauncher {
 					etasRups.add(etasRup);
 				} else {
 					Preconditions.checkState(fssIndex >= 0 && fssIndex < rupSet.getNumRuptures(), "bad FSS index=%s", fssIndex);
-					LocationList rupLocs = rupSet.getSurfaceForRupupture(fssIndex, 1d).getEvenlyDiscritizedListOfLocsOnSurface();
+					LocationList rupLocs = rupSet.getSurfaceForRupture(fssIndex, 1d).getEvenlyDiscritizedListOfLocsOnSurface();
 					Location hypoLoc = rupLocs.get(r.nextInt(rupLocs.size()));
 					
 					ObsEqkRupture rup = new ObsEqkRupture(id+"", epochMillis, hypoLoc, rupSet.getMagForRup(fssIndex));

--- a/src/scratch/UCERF3/erf/FaultSystemSolutionERF.java
+++ b/src/scratch/UCERF3/erf/FaultSystemSolutionERF.java
@@ -905,7 +905,7 @@ public class FaultSystemSolutionERF extends AbstractNthRupERF {
 					prob = 1-Math.exp(-aftRateCorr*probGain*faultSysSolution.getRateForRup(fltSystRupIndex)*duration);
 
 				src = new FaultRuptureSource(meanMag, 
-						rupSet.getSurfaceForRupupture(fltSystRupIndex, faultGridSpacing), 
+						rupSet.getSurfaceForRupture(fltSystRupIndex, faultGridSpacing), 
 						rupSet.getAveRakeForRup(fltSystRupIndex), prob, isPoisson);
 			} else {
 					// apply aftershock and/or gain corrections
@@ -924,7 +924,7 @@ public class FaultSystemSolutionERF extends AbstractNthRupERF {
 					
 				// this set the source as Poisson for U3; does this matter? TODO
 				src = new FaultRuptureSource(rupMFDcorrected, 
-						rupSet.getSurfaceForRupupture(fltSystRupIndex, faultGridSpacing),
+						rupSet.getSurfaceForRupture(fltSystRupIndex, faultGridSpacing),
 						rupSet.getAveRakeForRup(fltSystRupIndex), timeSpan.getDuration());
 			}
 		} else {
@@ -941,7 +941,7 @@ public class FaultSystemSolutionERF extends AbstractNthRupERF {
 			GaussianMagFreqDist srcMFD = new GaussianMagFreqDist(5.05,8.65,37,meanMag,myAleatoryMagAreaStdDev,totMoRate,2.0,2);
 			// this also sets the source as Poisson for U3; does this matter? TODO
 			src = new FaultRuptureSource(srcMFD, 
-					rupSet.getSurfaceForRupupture(fltSystRupIndex, faultGridSpacing),
+					rupSet.getSurfaceForRupture(fltSystRupIndex, faultGridSpacing),
 					rupSet.getAveRakeForRup(fltSystRupIndex), timeSpan.getDuration());
 			Preconditions.checkState(src.getNumRuptures() > 0,
 					"Source has zero rups! Mag="+meanMag+", aleatoryMagAreaStdDev="+myAleatoryMagAreaStdDev

--- a/src/scratch/UCERF3/inversion/CommandLineInversionRunner.java
+++ b/src/scratch/UCERF3/inversion/CommandLineInversionRunner.java
@@ -1937,7 +1937,7 @@ public class CommandLineInversionRunner {
 				rupSet.getSlipRateStdDevForAllSections(), rupSet.getAreaForAllSections(),
 				sectionForRups, mags, rakes, rupAreas, rupLengths, rupSet.getInfoString());
 		
-		return new InversionFaultSystemRupSet(subset, rupSet.getLogicTreeBranch(), rupSet.getPlausibilityConfiguration(), rupAveSlips,
+		return new InversionFaultSystemRupSet(subset, rupSet.getLogicTreeBranch(), rupSet.getOldPlausibilityConfiguration(), rupAveSlips,
 				null, null, null);
 	}
 	
@@ -1980,7 +1980,7 @@ public class CommandLineInversionRunner {
 				rupSet.getSlipRateStdDevForAllSections(), rupSet.getAreaForAllSections(),
 				sectionForRups, mags, rakes, rupAreas, rupLengths, rupSet.getInfoString());
 		
-		return new InversionFaultSystemRupSet(subset, rupSet.getLogicTreeBranch(), rupSet.getPlausibilityConfiguration(), rupAveSlips,
+		return new InversionFaultSystemRupSet(subset, rupSet.getLogicTreeBranch(), rupSet.getOldPlausibilityConfiguration(), rupAveSlips,
 				null, null, null);
 	}
 	
@@ -2008,7 +2008,7 @@ public class CommandLineInversionRunner {
 				rupSet.getSlipRateStdDevForAllSections(), rupSet.getAreaForAllSections(),
 				sectionForRups, mags, rakes, rupAreas, rupLengths, rupSet.getInfoString());
 		
-		return new InversionFaultSystemRupSet(subset, rupSet.getLogicTreeBranch(), rupSet.getPlausibilityConfiguration(), rupAveSlips,
+		return new InversionFaultSystemRupSet(subset, rupSet.getLogicTreeBranch(), rupSet.getOldPlausibilityConfiguration(), rupAveSlips,
 				null, null, null);
 	}
 	

--- a/src/scratch/UCERF3/inversion/InversionFaultSystemRupSetFactory.java
+++ b/src/scratch/UCERF3/inversion/InversionFaultSystemRupSetFactory.java
@@ -279,7 +279,7 @@ public class InversionFaultSystemRupSetFactory {
 			// test loading
 			InversionFaultSystemRupSet invRupSet = FaultSystemIO.loadInvRupSet(new File("/tmp/mean_rupSet.zip"));
 			System.out.println(invRupSet.getLogicTreeBranch());
-			System.out.println(invRupSet.getPlausibilityConfiguration());
+			System.out.println(invRupSet.getOldPlausibilityConfiguration());
 			System.exit(0);
 //			new SimpleFaultSystemRupSet(rupSet).toZipFile(new File("/tmp/rup_set_0.05_1.25.zip"));
 //			filter.setAllowSingleSectDuringJumps(false);

--- a/src/scratch/UCERF3/inversion/SectionCluster.java
+++ b/src/scratch/UCERF3/inversion/SectionCluster.java
@@ -25,7 +25,7 @@ import scratch.UCERF3.inversion.laughTest.BuggyCoulombFilter;
 import scratch.UCERF3.inversion.laughTest.CoulombFilter;
 import scratch.UCERF3.inversion.laughTest.AbstractPlausibilityFilter;
 import scratch.UCERF3.inversion.laughTest.UCERF3PlausibilityConfig;
-import scratch.UCERF3.inversion.laughTest.PlausibilityConfiguration;
+import scratch.UCERF3.inversion.laughTest.OldPlausibilityConfiguration;
 import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
 
 /**
@@ -50,7 +50,7 @@ public class SectionCluster extends ArrayList<Integer> {
 	// elements here are section IDs (same as indices in sectonDataList)
 	private List<List<Integer>> rupListIndices;
 	private int numRupsAdded;
-	private PlausibilityConfiguration plausibility;
+	private OldPlausibilityConfiguration plausibility;
 	private Map<IDPairing, Double> sectionAzimuths;
 	private Map<IDPairing, Double> subSectionDistances;
 	
@@ -67,7 +67,7 @@ public class SectionCluster extends ArrayList<Integer> {
 	 * @param maxTotAzimuthChange
 	 * @param maxRakeDiff
 	 */
-	public SectionCluster(PlausibilityConfiguration plausibility, List<? extends FaultSection> sectionDataList,
+	public SectionCluster(OldPlausibilityConfiguration plausibility, List<? extends FaultSection> sectionDataList,
 			SectionConnectionStrategy connStrategy, List<List<Integer>> sectionConnectionsListList, Map<IDPairing, Double> subSectionAzimuths,
 			Map<IDPairing, Double> subSectionDistances) {
 		this.sectionDataList = sectionDataList;

--- a/src/scratch/UCERF3/inversion/SectionClusterList.java
+++ b/src/scratch/UCERF3/inversion/SectionClusterList.java
@@ -19,7 +19,7 @@ import scratch.UCERF3.enumTreeBranches.DeformationModels;
 import scratch.UCERF3.enumTreeBranches.FaultModels;
 import scratch.UCERF3.inversion.coulomb.CoulombRates;
 import scratch.UCERF3.inversion.laughTest.UCERF3PlausibilityConfig;
-import scratch.UCERF3.inversion.laughTest.PlausibilityConfiguration;
+import scratch.UCERF3.inversion.laughTest.OldPlausibilityConfiguration;
 import scratch.UCERF3.utils.DeformationModelFetcher;
 
 public class SectionClusterList extends ArrayList<SectionCluster> {
@@ -32,26 +32,26 @@ public class SectionClusterList extends ArrayList<SectionCluster> {
 	public static final boolean D = false;
 	
 	private List<List<Integer>> sectionConnectionsListList;
-	private PlausibilityConfiguration plausibility;
+	private OldPlausibilityConfiguration plausibility;
 	private List<? extends FaultSection> faultSectionData;
 	
 	private Map<IDPairing, Double> subSectionDistances;
 	
 	public SectionClusterList(FaultModels faultModel, DeformationModels defModel, File precomputedDataDir,
-			SectionConnectionStrategy connectionStrategy, PlausibilityConfiguration plausibility) {
+			SectionConnectionStrategy connectionStrategy, OldPlausibilityConfiguration plausibility) {
 		this(new DeformationModelFetcher(faultModel, defModel, precomputedDataDir,
 				InversionFaultSystemRupSetFactory.DEFAULT_ASEIS_VALUE), connectionStrategy, plausibility);
 	}
 	
 	public SectionClusterList(DeformationModelFetcher defModelFetcher, SectionConnectionStrategy connectionStrategy,
-			PlausibilityConfiguration plausibility) {
+			OldPlausibilityConfiguration plausibility) {
 		faultSectionData = defModelFetcher.getSubSectionList();
 		Map<IDPairing, Double> subSectionDistances = defModelFetcher.getSubSectionDistanceMap(plausibility.getMaxJumpDist());
 		Map<IDPairing, Double> subSectionAzimuths = defModelFetcher.getSubSectionAzimuthMap(subSectionDistances.keySet());
 		init(connectionStrategy, plausibility, faultSectionData, subSectionDistances, subSectionAzimuths);
 	}
 	
-	public SectionClusterList(SectionConnectionStrategy connectionStrategy, PlausibilityConfiguration plausibility,
+	public SectionClusterList(SectionConnectionStrategy connectionStrategy, OldPlausibilityConfiguration plausibility,
 			List<? extends FaultSection> faultSectionData, Map<IDPairing, Double> subSectionDistances,
 			Map<IDPairing, Double> subSectionAzimuths) {
 		init(connectionStrategy, plausibility, faultSectionData,
@@ -59,7 +59,7 @@ public class SectionClusterList extends ArrayList<SectionCluster> {
 	}
 
 	private void init(SectionConnectionStrategy connectionStrategy,
-			PlausibilityConfiguration plausibility,
+			OldPlausibilityConfiguration plausibility,
 			List<? extends FaultSection> faultSectionData,
 			Map<IDPairing, Double> subSectionDistances,
 			Map<IDPairing, Double> subSectionAzimuths) {
@@ -152,7 +152,7 @@ public class SectionClusterList extends ArrayList<SectionCluster> {
 		return sectionConnectionsListList;
 	}
 
-	public PlausibilityConfiguration getPlausibilityConfiguration() {
+	public OldPlausibilityConfiguration getPlausibilityConfiguration() {
 		return plausibility;
 	}
 

--- a/src/scratch/UCERF3/inversion/UCERF2_ComparisonSolutionFetcher.java
+++ b/src/scratch/UCERF3/inversion/UCERF2_ComparisonSolutionFetcher.java
@@ -94,7 +94,7 @@ public class UCERF2_ComparisonSolutionFetcher {
 		}
 
 		InversionFaultSystemRupSet modRupSet = new InversionFaultSystemRupSet(rupSet, rupSet.getLogicTreeBranch(),
-				rupSet.getPlausibilityConfiguration(), aveSlips, rupSet.getCloseSectionsListList(),
+				rupSet.getOldPlausibilityConfiguration(), aveSlips, rupSet.getCloseSectionsListList(),
 				rupSet.getRupturesForClusters(), rupSet.getSectionsForClusters());
 
 		modRupSet.setMagForallRups(mags);

--- a/src/scratch/UCERF3/inversion/laughTest/OldPlausibilityConfiguration.java
+++ b/src/scratch/UCERF3/inversion/laughTest/OldPlausibilityConfiguration.java
@@ -8,7 +8,7 @@ import org.opensha.commons.metadata.XMLSaveable;
 import org.opensha.commons.util.IDPairing;
 import org.opensha.sha.faultSurface.FaultSection;
 
-public interface PlausibilityConfiguration extends XMLSaveable {
+public interface OldPlausibilityConfiguration extends XMLSaveable {
 	
 	/**
 	 * Builds (or re-builds) the plausibility filters

--- a/src/scratch/UCERF3/inversion/laughTest/UCERF3PlausibilityConfig.java
+++ b/src/scratch/UCERF3/inversion/laughTest/UCERF3PlausibilityConfig.java
@@ -19,7 +19,7 @@ import scratch.UCERF3.inversion.coulomb.CoulombRates;
 import scratch.UCERF3.inversion.coulomb.CoulombRatesTester;
 import scratch.UCERF3.inversion.coulomb.CoulombRatesTester.TestType;
 
-public class UCERF3PlausibilityConfig implements PlausibilityConfiguration {
+public class UCERF3PlausibilityConfig implements OldPlausibilityConfiguration {
 	
 	public static final String XML_METADATA_NAME = "LaughTestFilter";
 	

--- a/src/scratch/UCERF3/utils/FaultSystemIO.java
+++ b/src/scratch/UCERF3/utils/FaultSystemIO.java
@@ -10,6 +10,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -115,6 +116,28 @@ public class FaultSystemIO {
 		Preconditions.checkArgument(sol instanceof InversionFaultSystemSolution,
 				"Solution cannot be loaded as an InversionFaultSystemSolution");
 		return (InversionFaultSystemSolution)sol;
+	}
+	
+	/**
+	 * 
+	 * @param file
+	 * @return true if the given zip file is a fault sytem solution, false otherwise
+	 */
+	public static boolean isSolution(File file) throws IOException {
+		ZipFile zip = new ZipFile(file);
+		boolean found = false;
+		
+		Enumeration<? extends ZipEntry> entries = zip.entries();
+		while (entries.hasMoreElements()) {
+			ZipEntry entry = entries.nextElement();
+			if (entry.getName().endsWith("rates.bin")) {
+				found = true;
+				break;
+			}
+		}
+		
+		zip.close();
+		return found;
 	}
 	
 	/**

--- a/src/scratch/kevin/ucerf3/etas/MPJ_ETAS_Simulator.java
+++ b/src/scratch/kevin/ucerf3/etas/MPJ_ETAS_Simulator.java
@@ -263,7 +263,7 @@ public class MPJ_ETAS_Simulator extends MPJTaskCalculator {
 //			mainshockRup.setRuptureSurface(rupFromERF.getRuptureSurface());
 			mainshockRup.setAveRake(rupSet.getAveRakeForRup(fssScenarioRupID));
 			mainshockRup.setMag(rupSet.getMagForRup(fssScenarioRupID));
-			mainshockRup.setRuptureSurface(rupSet.getSurfaceForRupupture(fssScenarioRupID, 1d));
+			mainshockRup.setRuptureSurface(rupSet.getSurfaceForRupture(fssScenarioRupID, 1d));
 			mainshockRup.setID(0);
 			mainshockRup.setFSSIndex(fssScenarioRupID);
 //			debug("test Mainshock: "+erf.getSource(srcID).getName());

--- a/src/scratch/kevin/ucerf3/etas/StandaloneCalc.java
+++ b/src/scratch/kevin/ucerf3/etas/StandaloneCalc.java
@@ -142,7 +142,7 @@ public class StandaloneCalc {
 //			mainshockRup.setRuptureSurface(rupFromERF.getRuptureSurface());
 			mainshockRup.setAveRake(rupSet.getAveRakeForRup(fssScenarioRupID));
 			mainshockRup.setMag(rupSet.getMagForRup(fssScenarioRupID));
-			mainshockRup.setRuptureSurface(rupSet.getSurfaceForRupupture(fssScenarioRupID, 1d));
+			mainshockRup.setRuptureSurface(rupSet.getSurfaceForRupture(fssScenarioRupID, 1d));
 			mainshockRup.setID(0);
 			mainshockRup.setFSSIndex(fssScenarioRupID);
 //			debug("test Mainshock: "+erf.getSource(srcID).getName());

--- a/test/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/UniqueRuptureTest.java
+++ b/test/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/UniqueRuptureTest.java
@@ -1,0 +1,29 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.util;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class UniqueRuptureTest {
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+	}
+
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	@Test
+	public void testForwardsBackwards() {
+//		fail("Not yet implemented");
+		
+	}
+	
+	private void checkEquals(UniqueRupture rup1, UniqueRupture rup2) {
+		
+	}
+
+}

--- a/test/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/UniqueRuptureTest.java
+++ b/test/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/UniqueRuptureTest.java
@@ -2,11 +2,21 @@ package org.opensha.sha.earthquake.faultSysSolution.ruptures.util;
 
 import static org.junit.Assert.*;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.google.common.base.Preconditions;
+
 public class UniqueRuptureTest {
+	
+	private static Random r = new Random();
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
@@ -18,12 +28,98 @@ public class UniqueRuptureTest {
 
 	@Test
 	public void testForwardsBackwards() {
-//		fail("Not yet implemented");
+		checkEquals(UniqueRupture.forIDs(cluster(0, 10, false)), UniqueRupture.forIDs(cluster(0, 10, true)));
 		
+		checkEquals(UniqueRupture.forIDs(union(cluster(0, 10, false), cluster(20, 30, false))),
+				UniqueRupture.forIDs(union(cluster(0, 10, true), cluster(20, 30, true))));
+		checkEquals(UniqueRupture.forIDs(union(cluster(0, 10, false), cluster(20, 30, true))),
+				UniqueRupture.forIDs(union(cluster(0, 10, true), cluster(20, 30, false))));
+		checkEquals(UniqueRupture.forIDs(union(cluster(0, 10, true), cluster(20, 30, false))),
+				UniqueRupture.forIDs(union(cluster(0, 10, false), cluster(20, 30, true))));
+	}
+
+	@Test
+	public void testAddOrder() {
+		for (int i=0; i<10; i++)
+			checkEquals(UniqueRupture.forIDs(union(cluster(0, 10, r.nextBoolean()), cluster(20, 30, r.nextBoolean()))),
+					UniqueRupture.forIDs(union(cluster(20, 30, r.nextBoolean()), cluster(0, 10, r.nextBoolean()))));
+		
+		testContains(UniqueRupture.forIDs(union(cluster(20, 30, r.nextBoolean()),
+				cluster(0, 10, r.nextBoolean()))));
+	}
+
+	@Test
+	public void testMerge() {
+		for (int i=0; i<10; i++)
+			checkEquals(UniqueRupture.forIDs(union(cluster(0, 10, r.nextBoolean()), cluster(11, 20, r.nextBoolean()))),
+					UniqueRupture.forIDs(union(cluster(0, 20, r.nextBoolean()))));
+		for (int i=0; i<10; i++)
+			checkEquals(UniqueRupture.forIDs(union(cluster(0, 10, r.nextBoolean()),
+					cluster(15, 20, r.nextBoolean()), cluster(21, 25, r.nextBoolean()))),
+					UniqueRupture.forIDs(union(cluster(0, 10, r.nextBoolean()), cluster(15, 25, r.nextBoolean()))));
+		for (int i=0; i<10; i++)
+			checkEquals(UniqueRupture.forIDs(union(cluster(0, 15, r.nextBoolean()),
+					cluster(16, 20, r.nextBoolean()), cluster(21, 25, r.nextBoolean()))),
+					UniqueRupture.forIDs(union(cluster(0, 25, r.nextBoolean()))));
+	}
+	
+	@SafeVarargs
+	private static List<Integer> union(List<Integer>... clusters) {
+		List<Integer> ret = new ArrayList<>();
+		
+		// add them in random order
+		List<Integer> indexes = new ArrayList<>();
+		for (int i=0; i<clusters.length; i++)
+			indexes.add(i);
+		Collections.shuffle(indexes);
+		
+		for (int i : indexes)
+			ret.addAll(clusters[i]);
+		
+		return ret;
+	}
+	
+	private static List<Integer> cluster(int startIndex, int endIndex, boolean reverse) {
+		List<Integer> ids = new ArrayList<>();
+		Preconditions.checkState(endIndex >= startIndex);
+		for (int i=startIndex; i<=endIndex; i++)
+			ids.add(i);
+		if (reverse)
+			Collections.reverse(ids);
+		return ids;
 	}
 	
 	private void checkEquals(UniqueRupture rup1, UniqueRupture rup2) {
+		assertEquals(rup1, rup2);
+		assertEquals(rup1.hashCode(), rup2.hashCode());
+	}
+	
+	private void testContains(UniqueRupture rup) {
+		int minID = Integer.MAX_VALUE;
+		int maxID = Integer.MIN_VALUE;
 		
+		HashSet<Integer> set = new HashSet<>();
+		
+		for (SectIDRange range : rup.getRanges()) {
+			minID = Integer.min(minID, range.startID);
+			maxID = Integer.max(maxID, range.endID);
+			for (int i=range.startID; i<=range.endID; i++)
+				set.add(i);
+		}
+		
+		int actualSize = 0;
+		
+		for (int i=Integer.max(0, minID-10); i<=maxID+10; i++) {
+			boolean refContains = set.contains(i);
+			boolean contains = rup.contains(i);
+			if (refContains) {
+				assertTrue(contains);
+				actualSize++;
+			} else {
+				assertFalse(contains);
+			}
+		}
+		assertEquals(actualSize, rup.size());
 	}
 
 }


### PR DESCRIPTION
This adds a number of features to rupture set building and diagnostics:

## PlausibilityConfiguration serialization

PlausibilityConfiguration can now be [de]serialized to/from JSON using Gson. This gets a bit tricky, as plausibility filters can be quite complicated. To enable complex [de]serialization, there is a new PlausibilityFilter.getTypeAdapter() method to return a Gson TypeAdapter to handle serialization. The default return value is null, which will delegate to default Gson serialization. Various TypeAdapters are added at runtime to handle serialization of common objects, including the SectionDistanceAzimuthCalculator, AzimuthCalc, etc.

Plausibility configuration will be included in rupture set/solution zip files in a file named "plausibility.json" and are currently only used by the rupture set diagnostics page generator class.

## ClusterRupture memory improvements

ClusterRupture was taking up a ton of memory, upwards of 10 GB to represent the UCERF3 rupture set. This was due primarily to:

* FaultSubsectionCluster's internal HashSet of included sections
* UniqueRupture which had a HashSet of all section IDs
* Multimap instances for rupture navigation

All of these have been replaced with memory-efficient replacements:

* UniqueRupture now stores a sorted list of a new SectIDRange object, which efficiently identifies a range of contiguous section indexes.
* FaultSubsectionCluster now uses SectIDRange instead of the HashSet of section IDs
* Multimaps were replaced by a new RuptureTreeNavigator class which allows for memory-efficient (and still fast) navigation of rupture section/cluster trees

The result of this is over an order of magnitude of memory improvements, and also significantly faster rupture set generation (typically >2x faster)

## Threaded rupture set building

Added a new multithreaded method to build ruptures:
ClusterRuptureBuilder.build(ClusterPermutationStrategy permutationStrategy, int numThreads)

Order of returned ruptures will still match the single threaded version, this will use slightly more memory than the single threaded version. You can typically use Runtime.getRuntime().availableProcessors() for a good numThreads value.

## Rupture set diagnostics page gen

Added a new class, org.opensha.sha.earthquake.faultSysSolution.ruptures.util.RupSetDiagnosticsPageGen, which will create a diagnostics HTML page with lots of plots and tables for viewing rupture sets. Right now the inputs are hardcoded in the main method, but this will eventually become a command line tool. It can also include a comparison rupture set, and will test new ruptures against old filters and visa-versa.

[Here is an example report comparing a new Coulomb-based rupture set with UCERF3](http://opensha.usc.edu/ftp/kmilner/markdown/rupture-sets/fm3_1_cmlAz_cffClusterPathPositive/comp_fm3_1_ucerf3/).