### PR TITLE
Lots of updates to plausibility be described in the pull request

### DIFF
--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRupture.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRupture.java
@@ -50,7 +50,7 @@ import com.google.gson.stream.JsonWriter;
  * strand defined by the clusters listed below in the 'clusters' array. Additional
  * splays off of that primary strand are contained in the splays map. These ruptures are recursive
  * in nature: splays can have splays. The key contract is that sections only exist once in the
- * rupture, and although each section can have multiple descendcents (sections directly downstream
+ * rupture, and although each section can have multiple descendants (sections directly downstream
  * of that section), there can only be one predecessor (section directly upstream of that section).
  * 
  * Build ruptures by starting with an initial cluster and calling the public constructor, and then
@@ -86,7 +86,10 @@ public class ClusterRupture {
 	
 	private RuptureTreeNavigator navigator;
 	
-	private final UniqueRupture internalUnique;
+	/**
+	 * UniqueRupture instance for only the primary strand
+	 */
+	public final UniqueRupture internalUnique;
 	
 	/**
 	 * Initiate a ClusterRupture with the given starting cluster. You can grow it later with the
@@ -98,7 +101,7 @@ public class ClusterRupture {
 				ImmutableMap.of(), cluster.unique, cluster.unique);
 	}
 
-	private ClusterRupture(FaultSubsectionCluster[] clusters, ImmutableSet<Jump> internalJumps,
+	protected ClusterRupture(FaultSubsectionCluster[] clusters, ImmutableSet<Jump> internalJumps,
 			ImmutableMap<Jump, ClusterRupture> splays, UniqueRupture unique, UniqueRupture internalUnique) {
 		super();
 		this.clusters = clusters;
@@ -316,7 +319,7 @@ public class ClusterRupture {
 	 * @param connSearch {@link RuptureConnectionSearch} to find the best paths through this rupture
 	 * @return
 	 */
-	public List<ClusterRupture> getPreferredInversions(RuptureConnectionSearch connSearch) {
+	public List<ClusterRupture> getPreferredAltRepresentations(RuptureConnectionSearch connSearch) {
 		List<ClusterRupture> inversions = new ArrayList<>();
 
 		if (splays.isEmpty()) {
@@ -389,7 +392,7 @@ public class ClusterRupture {
 	 * 
 	 * @return
 	 */
-	public List<ClusterRupture> getInversions(ClusterConnectionStrategy connStrat, int maxNumSplays) {
+	public List<ClusterRupture> getAllAltRepresentations(ClusterConnectionStrategy connStrat, int maxNumSplays) {
 		List<ClusterRupture> inversions = new ArrayList<>();
 
 		if (getTotalNumClusters() == 1) {
@@ -579,6 +582,20 @@ public class ClusterRupture {
 		iterables.add(Lists.newArrayList(clusters));
 		for (ClusterRupture splay : splays.values())
 			iterables.add(splay.getClustersIterable());
+		return Iterables.concat(iterables);
+	}
+	
+	/**
+	 * 
+	 * @return Iterable over all strands in this rupture
+	 */
+	public Iterable<ClusterRupture> getStrandsIterable() {
+		if (splays.isEmpty())
+			return Lists.newArrayList(this);
+		List<Iterable<ClusterRupture>> iterables = new ArrayList<>();
+		iterables.add(Lists.newArrayList(this));
+		for (ClusterRupture splay : splays.values())
+			iterables.add(splay.getStrandsIterable());
 		return Iterables.concat(iterables);
 	}
 	

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/JumpPlausibilityFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/JumpPlausibilityFilter.java
@@ -25,5 +25,15 @@ public abstract class JumpPlausibilityFilter implements PlausibilityFilter {
 		}
 		return result;
 	}
+	
+	/**
+	 * Apply the plausibility filter to the given jump only
+	 * 
+	 * @param rupture
+	 * @param newJump
+	 * @param verbose
+	 * @return
+	 */
+	public abstract PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose);
 
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/PlausibilityFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/PlausibilityFilter.java
@@ -25,16 +25,6 @@ public interface PlausibilityFilter extends ShortNamed {
 	public PlausibilityResult apply(ClusterRupture rupture, boolean verbose);
 	
 	/**
-	 * Apply the plausibility filter to the given jump, assuming that existing rupture already passes
-	 * or failed with FAIL_CAN_CONTINUE
-	 * @param rupture
-	 * @param newJump
-	 * @param verbose
-	 * @return
-	 */
-	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose);
-	
-	/**
 	 * This allows filters to declare that they are directional, i.e., they might fail for a rupture
 	 * presented in one direction but pass for an inversion of that rupture. In that case, evaluation
 	 * of an existing set of ruptures with this filter should wrap it in the

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/ScalarValuePlausibiltyFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/ScalarValuePlausibiltyFilter.java
@@ -23,14 +23,6 @@ public interface ScalarValuePlausibiltyFilter<E extends Number & Comparable<E>> 
 	public E getValue(ClusterRupture rupture);
 	
 	/**
-	 * @param rupture
-	 * @param newJump
-	 * @return scalar value for the new jump, assuming that existing rupture already passes
-	 * or failed with FAIL_CAN_CONTINUE
-	 */
-	public E getValue(ClusterRupture rupture, Jump newJump);
-	
-	/**
 	 * @return acceptable range of values, or null if rules are more complex
 	 */
 	public Range<E> getAcceptableRange();

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/ClusterCoulombCompatibilityFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/ClusterCoulombCompatibilityFilter.java
@@ -51,34 +51,11 @@ public class ClusterCoulombCompatibilityFilter implements ScalarCoulombPlausibil
 	}
 
 	@Override
-	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
-//		StiffnessResult[] stiffness = stiffnessCalc.calcAggRupToClusterStiffness(rupture, newJump.toCluster);
-//		double val = stiffnessCalc.getValue(stiffness, StiffnessType.CFF, aggMethod);
-		List<FaultSubsectionCluster> clusters = new ArrayList<>();
-		for (FaultSubsectionCluster cluster : rupture.getClustersIterable())
-			clusters.add(cluster);
-		double val = doTest(clusters, newJump.toCluster, null, verbose, !verbose);
-		PlausibilityResult result =
-				(float)val >= threshold ? PlausibilityResult.PASS : PlausibilityResult.FAIL_HARD_STOP;
-		if (verbose)
-			System.out.println(getShortName()+": val="+val+"\tresult="+result.name());
-		return result;
-	}
-
-	@Override
 	public Float getValue(ClusterRupture rupture) {
 		if (rupture.getTotalNumJumps()  == 0)
 			return null;
 		return (float)doTest(new ArrayList<>(), rupture.clusters[0], rupture.getTreeNavigator(),
 				false, false);
-	}
-
-	@Override
-	public Float getValue(ClusterRupture rupture, Jump newJump) {
-		List<FaultSubsectionCluster> clusters = new ArrayList<>();
-		for (FaultSubsectionCluster cluster : rupture.getClustersIterable())
-			clusters.add(cluster);
-		return (float)doTest(clusters, newJump.toCluster, null, false, false);
 	}
 	
 	private double doTest(List<FaultSubsectionCluster> curClusters, FaultSubsectionCluster nextCluster,

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/CumulativeAzimuthChangeFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/CumulativeAzimuthChangeFilter.java
@@ -43,37 +43,6 @@ public class CumulativeAzimuthChangeFilter implements ScalarValuePlausibiltyFilt
 			System.out.println(getShortName()+": failing with tot="+tot);
 		return PlausibilityResult.FAIL_HARD_STOP;
 	}
-
-	@Override
-	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
-		if (rupture.getTotalNumSects() < 2) {
-			// need at least 2 sections on the first cluster
-			if (verbose)
-				System.out.println(getShortName()+": failing with <2 sects on first cluster");
-			return PlausibilityResult.FAIL_HARD_STOP;
-		}
-		RuptureTreeNavigator navigator = rupture.getTreeNavigator();
-		double tot = calc(navigator, rupture.clusters[0].startSect, null, null, verbose);
-		if ((float)tot <= threshold || verbose) {
-			List<FaultSection> subSects = new ArrayList<>(newJump.toCluster.subSects.size()+2);
-			subSects.add(navigator.getPredecessor(newJump.fromSection));
-			subSects.add(newJump.fromSection);
-			subSects.addAll(newJump.toCluster.subSects);
-			for (int i=0; i<subSects.size()-2; i++) {
-				tot += doCalc(subSects.get(i), subSects.get(i+1), subSects.get(i+2), verbose);
-				if ((float)tot > threshold && !verbose)
-					return PlausibilityResult.FAIL_HARD_STOP;
-			}
-		}
-		if ((float)tot <= threshold) {
-			if (verbose)
-				System.out.println(getShortName()+".testJump: passing with tot="+tot);
-			return PlausibilityResult.PASS;
-		}
-		if (verbose)
-			System.out.println(getShortName()+".testJump: failing with tot="+tot);
-		return PlausibilityResult.FAIL_HARD_STOP;
-	}
 	
 	private double calc(RuptureTreeNavigator navigator, FaultSection sect1, FaultSection sect2,
 			FaultSection sect3, boolean verbose) {
@@ -136,11 +105,6 @@ public class CumulativeAzimuthChangeFilter implements ScalarValuePlausibiltyFilt
 		}
 		RuptureTreeNavigator navigator = rupture.getTreeNavigator();
 		return (float)calc(navigator, rupture.clusters[0].startSect, null, null, false);
-	}
-
-	@Override
-	public Float getValue(ClusterRupture rupture, Jump newJump) {
-		return (getValue(rupture.take(newJump)));
 	}
 
 	@Override

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/CumulativePenaltyFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/CumulativePenaltyFilter.java
@@ -1,0 +1,357 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import org.opensha.commons.data.Named;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityConfiguration;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.ScalarValuePlausibiltyFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.JumpAzimuthChangeFilter.AzimuthCalc;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterConnectionStrategy;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.RuptureTreeNavigator;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
+import org.opensha.sha.faultSurface.FaultSection;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Range;
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
+
+public class CumulativePenaltyFilter implements ScalarValuePlausibiltyFilter<Float> {
+	
+	private float threshold;
+	// if true, then avoid any 'double counting' for a single jump by taking the maximum penalty
+	// for each individual jump, rather than summing all penalties for that jump
+	private boolean noDoubleCount = false;
+	private Penalty[] penalties;
+
+	public static interface Penalty extends Named {
+		
+		public double calcPenalty(ClusterRupture fullRup, Jump jump);
+		
+	}
+	
+	public static class JumpPenalty implements Penalty {
+		
+		private float minDistance;
+		private double penalty;
+		private boolean isDistMultiplier;
+
+		public JumpPenalty(float minDistance, double penalty, boolean isDistMultiplier) {
+			this.minDistance = minDistance;
+			this.penalty = penalty;
+			this.isDistMultiplier = isDistMultiplier;
+			
+		}
+
+		@Override
+		public double calcPenalty(ClusterRupture fullRup, Jump jump) {
+			if ((float)jump.distance <= minDistance)
+				return 0;
+			if (isDistMultiplier)
+				return penalty*jump.distance;
+			return penalty;
+		}
+
+		@Override
+		public String getName() {
+			return "Jump Penalty > "+minDistance+" km: "+penalty+(isDistMultiplier ? " (multiplier)" : "");
+		}
+		
+	}
+	
+	public static class RakeChangePenalty implements Penalty {
+		
+		private float minDifference;
+		private double penalty;
+		private boolean isDiffMultiplier;
+
+		public RakeChangePenalty(float minDifference, double penalty, boolean isDiffMultiplier) {
+			this.minDifference = minDifference;
+			this.penalty = penalty;
+			this.isDiffMultiplier = isDiffMultiplier;
+		}
+
+		@Override
+		public double calcPenalty(ClusterRupture fullRup, Jump jump) {
+			double diff = CumulativeRakeChangeFilter.rakeDiff(
+					jump.fromSection.getAveRake(), jump.toSection.getAveRake());
+			if ((float)diff <= minDifference)
+				return 0;
+			if (isDiffMultiplier)
+				return diff*penalty;
+			return penalty;
+		}
+
+		@Override
+		public String getName() {
+			return "Rake Penalty > "+minDifference+" deg: "+penalty+(isDiffMultiplier ? " (multiplier)" : "");
+		}
+		
+	}
+	
+	public static class DipChangePenalty implements Penalty {
+		
+		private float minDifference;
+		private double penalty;
+		private boolean isDiffMultiplier;
+
+		public DipChangePenalty(float minDifference, double penalty, boolean isDiffMultiplier) {
+			this.minDifference = minDifference;
+			this.penalty = penalty;
+			this.isDiffMultiplier = isDiffMultiplier;
+		}
+
+		@Override
+		public double calcPenalty(ClusterRupture fullRup, Jump jump) {
+			double diff = Math.abs(jump.fromSection.getAveDip() - jump.toSection.getAveDip());
+			if ((float)diff <= minDifference)
+				return 0;
+			if (isDiffMultiplier)
+				return diff*penalty;
+			return penalty;
+		}
+
+		@Override
+		public String getName() {
+			return "Dip Change Penalty > "+minDifference+" deg: "+penalty+(isDiffMultiplier ? " (multiplier)" : "");
+		}
+		
+	}
+	
+	public static class AzimuthChangePenalty implements Penalty {
+		
+		private float minDifference;
+		private double penalty;
+		private boolean isDiffMultiplier;
+		private AzimuthCalc calc;
+
+		public AzimuthChangePenalty(float minDifference, double penalty, boolean isDiffMultiplier,
+				AzimuthCalc calc) {
+			this.minDifference = minDifference;
+			this.penalty = penalty;
+			this.isDiffMultiplier = isDiffMultiplier;
+			this.calc = calc;
+		}
+
+		@Override
+		public double calcPenalty(ClusterRupture fullRup, Jump jump) {
+			RuptureTreeNavigator nav = fullRup.getTreeNavigator();
+			FaultSection before2 = jump.fromSection;
+			FaultSection before1 = nav.getPredecessor(before2);
+			if (before1 == null)
+				return 0d;
+			FaultSection after1 = jump.toSection;
+			FaultSection after2s[];
+			if (jump.toCluster.subSects.size() > 1) {
+				after2s = new FaultSection[] { jump.toCluster.subSects.get(1) };
+			} else if (fullRup.contains(after1)) {
+				// this is an existing jump
+				after2s = nav.getDescendants(after1).toArray(new FaultSection[0]);
+			} else {
+				// new jump to a single section, bail
+				return 0d;
+			}
+			double beforeAz = calc.calcAzimuth(before1, before2);
+			double max = 0d;
+			for (FaultSection after2 : after2s) {
+				double afterAz = calc.calcAzimuth(after1, after2);
+				double diff = JumpAzimuthChangeFilter.getAzimuthDifference(beforeAz, afterAz);
+				if ((float)diff > minDifference) {
+					if (isDiffMultiplier)
+						max = Math.max(max, diff*penalty);
+					else
+						max = Math.max(max, penalty);
+				}
+			}
+			return max;
+		}
+
+		@Override
+		public String getName() {
+			return "Azimuth Penalty > "+minDifference+" deg: "+penalty;
+		}
+		
+	}
+	
+	public CumulativePenaltyFilter(float threshold, boolean noDoubleCount, Penalty... penalties) {
+		Preconditions.checkArgument(threshold > 0f, "Penalty threshold must be positive");
+		this.threshold = threshold;
+		Preconditions.checkArgument(penalties.length > 0, "Must supply at least 1 penalty");
+		this.penalties = penalties;
+		this.noDoubleCount = noDoubleCount;
+	}
+
+	@Override
+	public PlausibilityResult apply(ClusterRupture rupture, boolean verbose) {
+		double sum = calcTotalPenalty(rupture, verbose);
+		if ((float)sum > threshold)
+			return PlausibilityResult.FAIL_HARD_STOP;
+		return PlausibilityResult.PASS;
+	}
+
+	@Override
+	public String getShortName() {
+		return "CumPenalty";
+	}
+
+	@Override
+	public String getName() {
+		return "Cumulative Penalty Filter";
+	}
+	
+	public double calcTotalPenalty(ClusterRupture rupture, boolean verbose) {
+		double sum = 0d;
+		for (Jump jump : rupture.getJumpsIterable())
+			sum += calcJumpPenalty(rupture, jump, verbose);
+		if (verbose)
+			System.out.println(getShortName()+": total penalty: "+sum);
+		return sum;
+	}
+	
+	public double calcJumpPenalty(ClusterRupture rupture, Jump jump, boolean verbose) {
+		double ret = 0d;
+		if (verbose)
+			System.out.println(getShortName()+": Jump="+jump);
+		for (Penalty penalty : penalties) {
+			double val = penalty.calcPenalty(rupture, jump);
+			Preconditions.checkState(val >= 0d, "Penalty must be postitive. Jump=%s, %s=%s",
+					jump, penalty.getName(), val);
+			if (verbose)
+				System.out.println("\t"+penalty.getName()+" = "+val);
+			if (noDoubleCount)
+				ret = Math.max(ret, val);
+			else
+				ret += val;
+		}
+		if (verbose)
+			System.out.println("\taggregated jump penalty: "+ret);
+		return ret;
+	}
+
+	@Override
+	public Float getValue(ClusterRupture rupture) {
+		return (float)calcTotalPenalty(rupture, false);
+	}
+
+	@Override
+	public Range<Float> getAcceptableRange() {
+		return Range.closed(0f, threshold);
+	}
+
+	@Override
+	public String getScalarName() {
+		return "Penalty";
+	}
+
+	@Override
+	public String getScalarUnits() {
+		return null;
+	}
+
+	@Override
+	public TypeAdapter<PlausibilityFilter> getTypeAdapter() {
+		return new Adapter();
+	}
+	
+	public static class Adapter extends PlausibilityFilterTypeAdapter {
+
+		private Gson gson;
+
+		@Override
+		public void init(ClusterConnectionStrategy connStrategy, SectionDistanceAzimuthCalculator distAzCalc,
+				Gson gson) {
+			this.gson = gson;
+		}
+
+		@Override
+		public void write(JsonWriter out, PlausibilityFilter value) throws IOException {
+			Preconditions.checkState(value instanceof CumulativePenaltyFilter);
+			CumulativePenaltyFilter filter = (CumulativePenaltyFilter)value;
+			out.beginObject();
+			
+			out.name("threshold").value(filter.threshold);
+			out.name("noDoubleCount").value(filter.noDoubleCount);
+			out.name("penalties").beginArray();
+			for (Penalty penalty : filter.penalties) {
+				out.beginObject();
+				out.name("class").value(penalty.getClass().getName());
+				out.name("value");
+				gson.toJson(penalty, penalty.getClass(), out);
+				out.endObject();
+			}
+			out.endArray();
+			
+			out.endObject();
+		}
+
+		@Override
+		public PlausibilityFilter read(JsonReader in) throws IOException {
+			in.beginObject();
+			
+			Float threshold = null;
+			boolean noDoubleCount = false;
+			Penalty[] penalties = null;
+			
+			while (in.hasNext()) {
+				switch (in.nextName()) {
+				case "threshold":
+					threshold = (float)in.nextDouble();
+					break;
+				case "noDoubleCount":
+					noDoubleCount = in.nextBoolean();
+					break;
+				case "penalties":
+					ArrayList<Penalty> list = new ArrayList<>();
+					in.beginArray();
+					while (in.hasNext()) {
+						in.beginObject();
+						
+						Class<Penalty> type = null;
+						Penalty penalty = null;
+						
+						while (in.hasNext()) {
+							switch (in.nextName()) {
+							case "class":
+								type = PlausibilityConfiguration.getDeclaredTypeClass(in.nextString());
+								break;
+							case "value":
+								Preconditions.checkNotNull(type, "Class must preceed value in Penalty JSON");
+								penalty = gson.fromJson(in, type);
+								break;
+
+							default:
+								throw new IllegalStateException("Unexpected JSON field");
+							}
+						}
+						Preconditions.checkNotNull(penalty, "Penalty is null?");
+						list.add(penalty);
+						
+						in.endObject();
+					}
+					in.endArray();
+					Preconditions.checkState(!list.isEmpty(), "No penalties?");
+					penalties = list.toArray(new Penalty[0]);
+					break;
+
+				default:
+					throw new IllegalStateException("Unexpected JSON field");
+				}
+			}
+			in.endObject();
+			
+			Preconditions.checkNotNull(threshold, "threshold not supplied");
+			Preconditions.checkNotNull(penalties, "penalties not supplied");
+			return new CumulativePenaltyFilter(threshold, noDoubleCount, penalties);
+		}
+		
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/CumulativeProbabilityFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/CumulativeProbabilityFilter.java
@@ -1,0 +1,485 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import org.opensha.commons.data.Named;
+import org.opensha.commons.data.function.EvenlyDiscretizedFunc;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityConfiguration;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.ScalarValuePlausibiltyFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterConnectionStrategy;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.RupSetDiagnosticsPageGen.RakeType;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.RuptureTreeNavigator;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
+import org.opensha.sha.faultSurface.FaultSection;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Range;
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
+
+public class CumulativeProbabilityFilter implements ScalarValuePlausibiltyFilter<Float> {
+	
+	public static interface RuptureProbabilityCalc extends Named {
+		
+		/**
+		 * This computes the probability of this rupture occurring as defined, conditioned on
+		 * it beginning at the first cluster in this rupture
+		 * 
+		 * @param rupture
+		 * @return conditional probability of this rupture
+		 */
+		public double calcRuptureProb(ClusterRupture rupture);
+	}
+	
+	public static abstract class JumpProbabilityCalc implements RuptureProbabilityCalc {
+		
+		/**
+		 * This computes the probability of this jump occurring conditioned on the rupture
+		 * up to that point having occurred, and relative to the rupture arresting rather
+		 * than taking that jump.
+		 * 
+		 * @param fullRupture
+		 * @param jump
+		 * @return conditional jump probability
+		 */
+		public abstract double calcJumpProbability(ClusterRupture fullRupture, Jump jump);
+
+		@Override
+		public double calcRuptureProb(ClusterRupture rupture) {
+			double prob = 1d;
+			for (Jump jump : rupture.getJumpsIterable())
+				prob *= calcJumpProbability(rupture, jump);
+			return prob;
+		}
+		
+	}
+	
+	public static class BiasiWesnousky2016CombJumpDistProb extends JumpProbabilityCalc {
+
+		private double minJumpDist;
+		private BiasiWesnousky2016SSJumpProb ssJumpProb;
+
+		public BiasiWesnousky2016CombJumpDistProb() {
+			this(1d);
+		}
+		
+		public BiasiWesnousky2016CombJumpDistProb(double minJumpDist) {
+			this.minJumpDist = minJumpDist;
+			ssJumpProb = new BiasiWesnousky2016SSJumpProb(minJumpDist);
+		}
+		
+		private boolean isStrikeSlip(FaultSection sect) {
+			return RakeType.LEFT_LATERAL.isMatch(sect.getAveRake())
+					|| RakeType.RIGHT_LATERAL.isMatch(sect.getAveRake());
+		}
+		
+		public double getDistanceIndepentProb(RakeType type) {
+			// Table 4 of Biasi & Wesnousky (2016)
+			if (type == RakeType.REVERSE)
+				return 0.62;
+			if (type == RakeType.NORMAL)
+				return 0.37;
+			// generic dip slip or SS
+			return 0.46;
+		}
+
+		@Override
+		public double calcJumpProbability(ClusterRupture fullRupture, Jump jump) {
+			if (jump.distance < minJumpDist)
+				return 1d;
+			RakeType type1 = RakeType.getType(jump.fromSection.getAveRake());
+			RakeType type2 = RakeType.getType(jump.toSection.getAveRake());
+			if (type1 == type2 && (type1 == RakeType.LEFT_LATERAL || type1 == RakeType.RIGHT_LATERAL))
+				// only use distance-dependent model if both are SS
+				return ssJumpProb.calcJumpProbability(fullRupture, jump);
+			// average probabilities from each mechanism
+			// TODO is this right? should we take the minimum or maximum? check with Biasi 
+			return 0.5*(getDistanceIndepentProb(type1)+getDistanceIndepentProb(type2));
+		}
+
+		@Override
+		public String getName() {
+			return "BW16 JumpDist";
+		}
+		
+	}
+	
+	public static double passingRatioToProb(double passingRatio) {
+		return passingRatio/(passingRatio + 1);
+	}
+	
+	public static double probToPassingRatio(double prob) {
+		return -prob/(prob-1d);
+	}
+	
+	public static class BiasiWesnousky2016SSJumpProb extends JumpProbabilityCalc {
+		
+		private double minJumpDist;
+		
+		public BiasiWesnousky2016SSJumpProb() {
+			this(1d);
+		}
+		
+		public BiasiWesnousky2016SSJumpProb(double minJumpDist) {
+			this.minJumpDist = minJumpDist;
+		}
+		
+		public double calcPassingRatio(double distance) {
+			// this is the ratio of of times the rupture passes through a jump of this size
+			// relative to the number of times it stops there
+			return Math.max(0, 1.89 - 0.31*distance);
+		}
+		
+		public double calcPassingProb(double distance) {
+			return passingRatioToProb(calcPassingRatio(distance));
+		}
+
+		@Override
+		public double calcJumpProbability(ClusterRupture fullRupture, Jump jump) {
+			if (jump.distance < minJumpDist)
+				return 1d;
+			return calcPassingProb(jump.distance);
+		}
+
+		@Override
+		public String getName() {
+			return "BW16 SS JumpDist";
+		}
+		
+	}
+	
+	public static final EvenlyDiscretizedFunc bw2017_ss_passRatio;
+	static {
+		// tabulated by eye from Figure 8c (10km bin size)
+		// TODO: get exact values from Biasi
+		bw2017_ss_passRatio = new EvenlyDiscretizedFunc(5d, 45d, 5);
+		bw2017_ss_passRatio.set(5d,		2.7d);
+		bw2017_ss_passRatio.set(15d,	1.35d);
+		bw2017_ss_passRatio.set(25d,	1.3d);
+		bw2017_ss_passRatio.set(35d,	0.1d);
+		bw2017_ss_passRatio.set(45d,	0.08d);
+	}
+	
+	public static class BiasiWesnousky2017JumpAzChangeProb extends JumpProbabilityCalc {
+		
+		private SectionDistanceAzimuthCalculator distAzCalc;
+
+		public BiasiWesnousky2017JumpAzChangeProb(SectionDistanceAzimuthCalculator distAzCalc) {
+			this.distAzCalc = distAzCalc;
+		}
+
+		@Override
+		public double calcJumpProbability(ClusterRupture fullRupture, Jump jump) {
+			RuptureTreeNavigator nav = fullRupture.getTreeNavigator();
+			
+			RakeType type1 = RakeType.getType(jump.fromSection.getAveRake());
+			RakeType type2 = RakeType.getType(jump.toSection.getAveRake());
+			if (type1 != type2)
+				// only evaluate within mechanism
+				// rely on other models for mechanism change probabilities
+				return 1d;
+			
+			FaultSection before2 = jump.fromSection;
+			FaultSection before1 = nav.getPredecessor(before2);
+			if (before1 == null)
+				return 1d;
+			double beforeAz = distAzCalc.getAzimuth(before1, before2);
+			FaultSection after1 = jump.toSection;
+			double prob = 1d;
+			for (FaultSection after2 : nav.getDescendants(after1)) {
+				double afterAz = distAzCalc.getAzimuth(after1, after2);
+				double diff = Math.abs(JumpAzimuthChangeFilter.getAzimuthDifference(beforeAz, afterAz));
+				double passingRatio;
+				if (type1 == RakeType.LEFT_LATERAL || type1 == RakeType.RIGHT_LATERAL) {
+					// strike-slip case
+					// will just grab the closest binned value
+					// this extends the last bin uniformly to 180 degree differences, TODO confer with Biasi
+					passingRatio = bw2017_ss_passRatio.getY(bw2017_ss_passRatio.getClosestXIndex(diff));
+				} else {
+					// not well defined, arbitrary choice here based loosely on Figure 8d
+					// TODO: confer with Biasi
+					if (diff < 60d)
+						passingRatio = 2d;
+					else
+						passingRatio = 0.5d;
+				}
+				prob = Math.min(prob, passingRatioToProb(passingRatio));
+			}
+			return prob;
+		}
+
+		@Override
+		public String getName() {
+			return "BW17 AzChange";
+		}
+		
+	}
+	
+	public static class BiasiWesnousky2017_SSJumpAzChangeProb extends JumpProbabilityCalc {
+		
+		private SectionDistanceAzimuthCalculator distAzCalc;
+
+		public BiasiWesnousky2017_SSJumpAzChangeProb(SectionDistanceAzimuthCalculator distAzCalc) {
+			this.distAzCalc = distAzCalc;
+		}
+
+		@Override
+		public double calcJumpProbability(ClusterRupture fullRupture, Jump jump) {
+			RuptureTreeNavigator nav = fullRupture.getTreeNavigator();
+			
+			RakeType type1 = RakeType.getType(jump.fromSection.getAveRake());
+			RakeType type2 = RakeType.getType(jump.toSection.getAveRake());
+			if (type1 != type2)
+				// only evaluate within mechanism
+				// rely on other models for mechanism change probabilities
+				return 1d;
+			if (type1 != RakeType.RIGHT_LATERAL && type1 != RakeType.LEFT_LATERAL)
+				// SS only
+				return 1d;
+			
+			FaultSection before2 = jump.fromSection;
+			FaultSection before1 = nav.getPredecessor(before2);
+			if (before1 == null)
+				return 1d;
+			double beforeAz = distAzCalc.getAzimuth(before1, before2);
+			FaultSection after1 = jump.toSection;
+			double prob = 1d;
+			for (FaultSection after2 : nav.getDescendants(after1)) {
+				double afterAz = distAzCalc.getAzimuth(after1, after2);
+				double diff = Math.abs(JumpAzimuthChangeFilter.getAzimuthDifference(beforeAz, afterAz));
+				// will just grab the closest binned value
+				// this extends the last bin uniformly to 180 degree differences, TODO confer with Biasi
+				double passingRatio = bw2017_ss_passRatio.getY(bw2017_ss_passRatio.getClosestXIndex(diff));
+				prob = Math.min(prob, passingRatioToProb(passingRatio));
+			}
+			return prob;
+		}
+
+		@Override
+		public String getName() {
+			return "BW17 SS AzChange";
+		}
+		
+	}
+	
+	public static final double bw2017_mech_change_prob = 4d/75d;
+	
+	public static class BiasiWesnousky2017MechChangeProb extends JumpProbabilityCalc {
+
+		public BiasiWesnousky2017MechChangeProb() {
+		}
+
+		@Override
+		public double calcJumpProbability(ClusterRupture fullRupture, Jump jump) {
+			RakeType type1 = RakeType.getType(jump.fromSection.getAveRake());
+			RakeType type2 = RakeType.getType(jump.toSection.getAveRake());
+			if (type1 == type2)
+				// no mechanism change
+				return 1d;
+			// only 4 of 75 ruptures had a mechanism change of any type
+			// TODO consult Biasi
+			return bw2017_mech_change_prob;
+		}
+
+		@Override
+		public String getName() {
+			return "BW17 MechChange";
+		}
+		
+	}
+	
+	public static RuptureProbabilityCalc[] getPrefferedBWCalcs(SectionDistanceAzimuthCalculator distAzCalc) {
+		return new RuptureProbabilityCalc[] {
+				new BiasiWesnousky2016CombJumpDistProb(),
+				new BiasiWesnousky2017JumpAzChangeProb(distAzCalc),
+				new BiasiWesnousky2017MechChangeProb()
+		};
+	}
+	
+	private float minProbability;
+	private RuptureProbabilityCalc[] calcs;
+	
+	public CumulativeProbabilityFilter(float minProbability, RuptureProbabilityCalc... calcs) {
+		Preconditions.checkArgument(minProbability > 0d && minProbability <= 1d,
+				"Minimum probability (%s) not in the range (0,1]", minProbability);
+		this.minProbability = minProbability;
+		Preconditions.checkArgument(calcs.length > 0);
+		this.calcs = calcs;
+	}
+
+	@Override
+	public PlausibilityResult apply(ClusterRupture rupture, boolean verbose) {
+		float prob = getValue(rupture, verbose);
+		if (verbose)
+			System.out.println(getShortName()+": final prob="+prob+", pass="+(prob >= minProbability));
+		if ((float)prob >= minProbability)
+			return PlausibilityResult.PASS;
+		return PlausibilityResult.FAIL_HARD_STOP;
+	}
+
+	@Override
+	public String getShortName() {
+		if (calcs.length > 1)
+			return "CumProb≥"+minProbability;
+		return "P("+calcs[0].getName()+")≥"+minProbability;
+	}
+
+	@Override
+	public String getName() {
+		if (calcs.length > 1)
+			return "Cumulative Probability Filter ≥"+minProbability;
+		return calcs[0]+" ≥"+minProbability;
+	}
+
+	@Override
+	public Float getValue(ClusterRupture rupture) {
+		return getValue(rupture, false);
+	}
+
+	public Float getValue(ClusterRupture rupture, boolean verbose) {
+		double prob = 1d;
+		for (RuptureProbabilityCalc calc : calcs) {
+			double indvProb = calc.calcRuptureProb(rupture);
+			if (verbose)
+				System.out.println("\t"+calc.getName()+": P="+indvProb);
+			Preconditions.checkState(indvProb >= 0d && indvProb <= 1d,
+					"Bad probability for %s: %s\n\tRupture: %s", indvProb, calc.getName(), rupture);
+			prob *= indvProb;
+		}
+		return (float)prob;
+	}
+
+	@Override
+	public Range<Float> getAcceptableRange() {
+		return Range.closed(minProbability, 1f);
+	}
+
+	@Override
+	public String getScalarName() {
+		return "Conditionaly Probability";
+	}
+
+	@Override
+	public String getScalarUnits() {
+		return null;
+	}
+
+	@Override
+	public TypeAdapter<PlausibilityFilter> getTypeAdapter() {
+		return new Adapter();
+	}
+	
+	public static class Adapter extends PlausibilityFilterTypeAdapter {
+
+		private Gson gson;
+
+		@Override
+		public void init(ClusterConnectionStrategy connStrategy, SectionDistanceAzimuthCalculator distAzCalc,
+				Gson gson) {
+			this.gson = gson;
+		}
+
+		@Override
+		public void write(JsonWriter out, PlausibilityFilter value) throws IOException {
+			Preconditions.checkState(value instanceof CumulativeProbabilityFilter);
+			CumulativeProbabilityFilter filter = (CumulativeProbabilityFilter)value;
+			out.beginObject();
+			
+			out.name("minProbability").value(filter.minProbability);
+			out.name("calcs").beginArray();
+			for (RuptureProbabilityCalc calc : filter.calcs) {
+				out.beginObject();
+				out.name("class").value(calc.getClass().getName());
+				out.name("value");
+				gson.toJson(calc, calc.getClass(), out);
+				out.endObject();
+			}
+			out.endArray();
+			
+			out.endObject();
+		}
+
+		@Override
+		public PlausibilityFilter read(JsonReader in) throws IOException {
+			in.beginObject();
+			
+			Float minProbability = null;
+			RuptureProbabilityCalc[] calcs = null;
+			
+			while (in.hasNext()) {
+				switch (in.nextName()) {
+				case "minProbability":
+					minProbability = (float)in.nextDouble();
+					break;
+				case "calcs":
+					ArrayList<RuptureProbabilityCalc> list = new ArrayList<>();
+					in.beginArray();
+					while (in.hasNext()) {
+						in.beginObject();
+						
+						Class<RuptureProbabilityCalc> type = null;
+						RuptureProbabilityCalc calc = null;
+						
+						while (in.hasNext()) {
+							switch (in.nextName()) {
+							case "class":
+								type = PlausibilityConfiguration.getDeclaredTypeClass(in.nextString());
+								break;
+							case "value":
+								Preconditions.checkNotNull(type, "Class must preceed value in ProbCalc JSON");
+								calc = gson.fromJson(in, type);
+								break;
+
+							default:
+								throw new IllegalStateException("Unexpected JSON field");
+							}
+						}
+						Preconditions.checkNotNull(calc, "Penalty is null?");
+						list.add(calc);
+						
+						in.endObject();
+					}
+					in.endArray();
+					Preconditions.checkState(!list.isEmpty(), "No prob calcs?");
+					calcs = list.toArray(new RuptureProbabilityCalc[0]);
+					break;
+
+				default:
+					throw new IllegalStateException("Unexpected JSON field");
+				}
+			}
+			in.endObject();
+			
+			Preconditions.checkNotNull(minProbability, "threshold not supplied");
+			Preconditions.checkNotNull(calcs, "penalties not supplied");
+			return new CumulativeProbabilityFilter(minProbability, calcs);
+		}
+		
+	}
+	
+	public static void main(String[] args) {
+		BiasiWesnousky2016SSJumpProb jumpProb = new BiasiWesnousky2016SSJumpProb(0d);
+		
+		for (double len=0; len<=10d; len++) {
+			System.out.println("Length="+(float)len+"\tr="+(float)jumpProb.calcPassingRatio(len)
+				+"\tp="+(float)jumpProb.calcPassingProb(len));
+		}
+		
+		System.out.println("\nSS Azimuth Passing Ratios/Probs");
+		for (int i=0; i<bw2017_ss_passRatio.size(); i++) {
+			double x = bw2017_ss_passRatio.getX(i);
+			double ratio = bw2017_ss_passRatio.getY(i);
+			double prob = passingRatioToProb(ratio);
+			System.out.println("azDiff="+(float)x+"\tr="+(float)ratio+"\tp="+(float)prob);
+		}
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/CumulativeRakeChangeFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/CumulativeRakeChangeFilter.java
@@ -45,25 +45,6 @@ public class CumulativeRakeChangeFilter implements ScalarValuePlausibiltyFilter<
 			System.out.println(getShortName()+": failing with tot="+tot);
 		return PlausibilityResult.FAIL_HARD_STOP;
 	}
-
-	@Override
-	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
-		double tot = calc(rupture.getTreeNavigator(), rupture.clusters[0].startSect, verbose, !verbose);
-		if ((float)tot <= threshold || verbose) {
-			List<FaultSection> subSects = new ArrayList<>(newJump.toCluster.subSects.size()+2);
-			subSects.add(newJump.fromSection);
-			subSects.addAll(newJump.toCluster.subSects);
-			tot += calc(subSects, verbose);
-		}
-		if ((float)tot <= threshold) {
-			if (verbose)
-				System.out.println(getShortName()+": passing with tot="+tot);
-			return PlausibilityResult.PASS;
-		}
-		if (verbose)
-			System.out.println(getShortName()+": failing with tot="+tot);
-		return PlausibilityResult.FAIL_HARD_STOP;
-	}
 	
 	private double calc(RuptureTreeNavigator navigator, FaultSection sect1,
 			boolean verbose, boolean shortCircuit) {
@@ -122,11 +103,6 @@ public class CumulativeRakeChangeFilter implements ScalarValuePlausibiltyFilter<
 	@Override
 	public Float getValue(ClusterRupture rupture) {
 		return (float)calc(rupture.getTreeNavigator(), rupture.clusters[0].startSect, false, false);
-	}
-
-	@Override
-	public Float getValue(ClusterRupture rupture, Jump newJump) {
-		return getValue(rupture.take(newJump));
 	}
 
 	@Override

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/JumpAzimuthChangeFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/JumpAzimuthChangeFilter.java
@@ -401,11 +401,6 @@ implements ScalarValuePlausibiltyFilter<Float> {
 	}
 
 	@Override
-	public Float getValue(ClusterRupture rupture, Jump newJump) {
-		return calc(rupture, newJump, false);
-	}
-
-	@Override
 	public Range<Float> getAcceptableRange() {
 		return Range.atMost(threshold);
 	}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/JumpCumulativeRakeChangeFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/JumpCumulativeRakeChangeFilter.java
@@ -37,23 +37,6 @@ public class JumpCumulativeRakeChangeFilter implements ScalarValuePlausibiltyFil
 			System.out.println(getShortName()+": failing with tot="+tot);
 		return PlausibilityResult.FAIL_HARD_STOP;
 	}
-
-	@Override
-	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
-		double tot = calc(rupture, verbose, !verbose);
-		if (verbose)
-			System.out.println(getShortName()+": orig rup was "+tot+", now testing jump "+newJump);
-		if ((float)tot <= threshold || verbose)
-			tot += calc(newJump, verbose);
-		if ((float)tot <= threshold) {
-			if (verbose)
-				System.out.println(getShortName()+": passing with tot="+tot);
-			return PlausibilityResult.PASS;
-		}
-		if (verbose)
-			System.out.println(getShortName()+": failing with tot="+tot);
-		return PlausibilityResult.FAIL_HARD_STOP;
-	}
 	
 	private double calc(ClusterRupture rupture, boolean verbose, boolean shortCircuit) {
 		double tot = 0d;
@@ -91,11 +74,6 @@ public class JumpCumulativeRakeChangeFilter implements ScalarValuePlausibiltyFil
 	@Override
 	public Float getValue(ClusterRupture rupture) {
 		return (float)calc(rupture, false, false);
-	}
-
-	@Override
-	public Float getValue(ClusterRupture rupture, Jump newJump) {
-		return getValue(rupture.take(newJump));
 	}
 
 	@Override

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/JumpDistFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/JumpDistFilter.java
@@ -51,11 +51,6 @@ public class JumpDistFilter extends JumpPlausibilityFilter implements ScalarValu
 	}
 
 	@Override
-	public Float getValue(ClusterRupture rupture, Jump newJump) {
-		return (float)newJump.distance;
-	}
-
-	@Override
 	public Range<Float> getAcceptableRange() {
 		return Range.atMost((float)maxDist);
 	}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/MinSectsPerParentFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/MinSectsPerParentFilter.java
@@ -151,25 +151,6 @@ public class MinSectsPerParentFilter implements PlausibilityFilter {
 	}
 
 	@Override
-	public PlausibilityResult testJump(ClusterRupture rupture, Jump jump, boolean verbose) {
-		if (allowIfNoDirect) {
-			// need to test the whole rupture
-			boolean failPossible = jump.toCluster.subSects.size() < minPerParent
-					|| jump.fromCluster.subSects.size() < minPerParent;
-			for (Jump prevJump : rupture.internalJumps)
-				failPossible = failPossible || prevJump.fromCluster.subSects.size() < minPerParent;
-			for (Jump prevJump : rupture.splays.keySet())
-				failPossible = failPossible || prevJump.fromCluster.subSects.size() < minPerParent;
-			if (failPossible)
-				return apply(rupture.take(jump), verbose);
-			return PlausibilityResult.PASS;
-		}
-		if (jump.toCluster.subSects.size() >= minPerParent)
-			return PlausibilityResult.PASS;
-		return PlausibilityResult.FAIL_HARD_STOP;
-	}
-
-	@Override
 	public String getShortName() {
 		return "SectsPerParent";
 	}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/MultiDirectionalPlausibilityFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/MultiDirectionalPlausibilityFilter.java
@@ -98,17 +98,12 @@ public class MultiDirectionalPlausibilityFilter implements PlausibilityFilter {
 	private List<ClusterRupture> getInversions(ClusterRupture rupture) {
 		if (plausibilityConfig != null)
 			// this will test all possible inversions as defined by the connection strategy
-			return rupture.getInversions(plausibilityConfig.getConnectionStrategy(),
+			return rupture.getAllAltRepresentations(plausibilityConfig.getConnectionStrategy(),
 					plausibilityConfig.getMaxNumSplays());
 		Preconditions.checkNotNull(connSearch);
 		// this will test all starting points for the rupture, but chooses the best
 		// path through the rupture from each starting point (not exhaustive)
-		return rupture.getPreferredInversions(connSearch);
-	}
-
-	@Override
-	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
-		return apply(rupture.take(newJump), verbose);
+		return rupture.getPreferredAltRepresentations(connSearch);
 	}
 	
 	public static class Scalar<E extends Number & Comparable<E>> extends MultiDirectionalPlausibilityFilter
@@ -180,11 +175,6 @@ public class MultiDirectionalPlausibilityFilter implements PlausibilityFilter {
 			// we have both, use distance to center (lower being better)
 			double center = 0.5*(lower + upper);
 			return Math.abs(curVal - center) < Math.abs(prevVal - center);
-		}
-
-		@Override
-		public E getValue(ClusterRupture rupture, Jump newJump) {
-			return getValue(rupture.take(newJump));
 		}
 
 		@Override

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/NetClusterCoulombFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/NetClusterCoulombFilter.java
@@ -51,16 +51,6 @@ public class NetClusterCoulombFilter implements ScalarCoulombPlausibilityFilter 
 	}
 
 	@Override
-	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
-		float val = getValue(rupture, newJump);
-		PlausibilityResult result = val < threshold ?
-				PlausibilityResult.FAIL_HARD_STOP : PlausibilityResult.PASS;
-		if (verbose)
-			System.out.println(getShortName()+": val="+val+", result="+result);
-		return result;
-	}
-
-	@Override
 	public String getShortName() {
 		if (threshold == 0f)
 			return "NetClusterCFF≥0";
@@ -94,13 +84,6 @@ public class NetClusterCoulombFilter implements ScalarCoulombPlausibilityFilter 
 		if (rupture.getTotalNumClusters() == 1)
 			return null;
 		return getMinValue(getClusterList(rupture));
-	}
-
-	@Override
-	public Float getValue(ClusterRupture rupture, Jump newJump) {
-		List<FaultSubsectionCluster> clusterList = getClusterList(rupture);
-		clusterList.add(newJump.toCluster);
-		return getMinValue(clusterList);
 	}
 
 	@Override

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/NetRuptureCoulombFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/NetRuptureCoulombFilter.java
@@ -55,16 +55,6 @@ public class NetRuptureCoulombFilter implements ScalarCoulombPlausibilityFilter 
 	}
 
 	@Override
-	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
-		float val = getValue(rupture, newJump);
-		PlausibilityResult result = val < threshold ?
-				PlausibilityResult.FAIL_HARD_STOP : PlausibilityResult.PASS;
-		if (verbose)
-			System.out.println(getShortName()+": val="+val+", result="+result);
-		return result;
-	}
-
-	@Override
 	public String getShortName() {
 		if (threshold == 0f)
 			return "NetRupCFF≥0";
@@ -81,15 +71,6 @@ public class NetRuptureCoulombFilter implements ScalarCoulombPlausibilityFilter 
 		if (rupture.getTotalNumSects() == 1)
 			return null;
 		return (float)new RuptureCoulombResult(rupture, stiffnessCalc, aggMethod).getValue(quantity);
-	}
-
-	@Override
-	public Float getValue(ClusterRupture rupture, Jump newJump) {
-		List<FaultSection> sects = new ArrayList<>();
-		for (FaultSubsectionCluster cluster : rupture.getClustersIterable())
-			sects.addAll(cluster.subSects);
-		sects.addAll(newJump.toCluster.subSects);
-		return (float)new RuptureCoulombResult(sects, stiffnessCalc, aggMethod).getValue(quantity);
 	}
 
 	@Override

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/NumClustersFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/NumClustersFilter.java
@@ -41,20 +41,8 @@ public class NumClustersFilter implements ScalarValuePlausibiltyFilter<Integer> 
 	}
 
 	@Override
-	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
-		if (rupture.getTotalNumClusters() > maxNumClusters-1)
-			return PlausibilityResult.FAIL_HARD_STOP;
-		return PlausibilityResult.PASS;
-	}
-
-	@Override
 	public Integer getValue(ClusterRupture rupture) {
 		return rupture.getTotalNumClusters();
-	}
-
-	@Override
-	public Integer getValue(ClusterRupture rupture, Jump newJump) {
-		return rupture.getTotalNumClusters()+1;
 	}
 
 	@Override

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/ParentCoulombCompatibilityFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/ParentCoulombCompatibilityFilter.java
@@ -125,8 +125,7 @@ implements ScalarCoulombPlausibilityFilter {
 		return min;
 	}
 
-	@Override
-	public Float getValue(ClusterRupture rupture, Jump newJump) {
+	private Float getValue(ClusterRupture rupture, Jump newJump) {
 		// swap out with full parent section clusters
 		int fromID = newJump.fromCluster.parentSectionID;
 		int toID = newJump.toCluster.parentSectionID;

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/SingleClusterPerParentFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/SingleClusterPerParentFilter.java
@@ -51,20 +51,5 @@ public class SingleClusterPerParentFilter implements PlausibilityFilter {
 		return PlausibilityResult.PASS;
 	}
 
-	@Override
-	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
-		HashSet<Integer> parents = new HashSet<>();
-		List<FaultSubsectionCluster> clusters = new ArrayList<>();
-		count(rupture, parents, clusters);
-		parents.add(newJump.toCluster.parentSectionID);
-		clusters.add(newJump.toCluster);
-		if (parents.size() != clusters.size()) {
-			if (verbose) System.out.println(getShortName()+": have "+parents.size()
-				+" parents but "+clusters.size()+" clusters");
-			return PlausibilityResult.FAIL_HARD_STOP;
-		}
-		return PlausibilityResult.PASS;
-	}
-
 }
 

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/SplayCountFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/SplayCountFilter.java
@@ -50,40 +50,10 @@ public class SplayCountFilter implements ScalarValuePlausibiltyFilter<Integer> {
 			return PlausibilityResult.FAIL_HARD_STOP;
 		return PlausibilityResult.PASS;
 	}
-	
-	private boolean isContinuationJump(ClusterRupture rupture, Jump newJump) {
-		if (rupture.containsInternal(newJump.fromSection)) {
-			// it's on the primary strand, check if it's an addition off of the end
-			return rupture.clusters[rupture.clusters.length-1].endSects.contains(newJump.fromSection);
-		}
-		// it's on a splay, see if it's a splay continuation or a splay off of a splay
-		for (ClusterRupture splay : rupture.splays.values())
-			if (splay.contains(newJump.fromSection))
-				return isContinuationJump(splay, newJump);
-		throw new IllegalStateException("newJump.fromSection isn't contained by the rupture");
-	}
-
-	@Override
-	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
-		int count = rupture.getTotalNumSplays();
-		// now check the jump
-		if (!isContinuationJump(rupture, newJump))
-			count++;
-		if (verbose)
-			System.out.println("Have "+count+" splays");
-		if (count > maxSplays)
-			return PlausibilityResult.FAIL_HARD_STOP;
-		return PlausibilityResult.PASS;
-	}
 
 	@Override
 	public Integer getValue(ClusterRupture rupture) {
 		return rupture.getTotalNumSplays();
-	}
-
-	@Override
-	public Integer getValue(ClusterRupture rupture, Jump newJump) {
-		return getValue(rupture.take(newJump));
 	}
 
 	@Override

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/SplayLengthFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/SplayLengthFilter.java
@@ -82,69 +82,6 @@ public class SplayLengthFilter implements PlausibilityFilter {
 	}
 
 	@Override
-	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
-		boolean isSplayJump = !rupture.clusters[rupture.clusters.length-1].endSects.contains(newJump.fromSection);
-		if (rupture.splays.isEmpty() && !isSplayJump)
-			return PlausibilityResult.PASS;
-		if (verbose)
-			System.out.println(getShortName()+": isSplayJump="+isSplayJump);
-		double maxLen = isFractOfMain ?
-				this.maxLen*calcLen(rupture, isSplayJump ? null : newJump.toCluster, false) : this.maxLen;
-		if (verbose)
-			System.out.println(getShortName()+": maxLen="+maxLen);
-		double totSplay = 0d;
-		boolean jumpFound = false;
-		for (ClusterRupture splay : rupture.splays.values()) {
-			double splayLen;
-			if (splay.contains(newJump.fromSection)) {
-				jumpFound = true;
-				splayLen = calcLen(splay, newJump.toCluster, true);
-				if (verbose)
-					System.out.println(getShortName()+": jump located on splay with length="+splayLen);
-			} else {
-				splayLen = calcLen(splay, null, true);
-				if (verbose)
-					System.out.println(getShortName()+": splay with length="+splayLen);
-			}
-			if (totalAcrossSplays) {
-				totSplay += splayLen;
-				if ((float)totSplay > (float)maxLen) {
-					if (verbose)
-						System.out.println(getShortName()+": failing with cumulative length="+totSplay);
-					return PlausibilityResult.FAIL_HARD_STOP;
-				}
-			} else {
-				if ((float)splayLen > (float)maxLen) {
-					if (verbose)
-						System.out.println(getShortName()+": failing");
-					return PlausibilityResult.FAIL_HARD_STOP;
-				}
-			}
-		}
-		if (!jumpFound) {
-			// it's a new splay
-			double splayLen = calcLen(null, newJump.toCluster, true);
-			if (verbose)
-				System.out.println(getShortName()+": jump is new splay with length="+splayLen);
-			if (totalAcrossSplays) {
-				totSplay += splayLen;
-				if ((float)totSplay > (float)maxLen) {
-					if (verbose)
-						System.out.println(getShortName()+": failing with cumulative length="+totSplay);
-					return PlausibilityResult.FAIL_HARD_STOP;
-				}
-			} else {
-				if ((float)splayLen > (float)maxLen) {
-					if (verbose)
-						System.out.println(getShortName()+": failing");
-					return PlausibilityResult.FAIL_HARD_STOP;
-				}
-			}
-		}
-		return PlausibilityResult.PASS;
-	}
-
-	@Override
 	public boolean isDirectional(boolean splayed) {
 		// only directional if splayed
 		return splayed;

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/TotalAzimuthChangeFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/TotalAzimuthChangeFilter.java
@@ -70,12 +70,6 @@ public class TotalAzimuthChangeFilter implements ScalarValuePlausibiltyFilter<Fl
 					splay.clusters[splay.clusters.length-1], navigator, null, verbose));
 		return result;
 	}
-
-	@Override
-	public PlausibilityResult testJump(ClusterRupture rupture, Jump jump, boolean verbose) {
-		return apply(rupture.clusters[0], jump.toCluster, rupture.getTreeNavigator(), jump, verbose);
-//		return apply(rupture.take(jump), verbose);
-	}
 	
 	private PlausibilityResult apply(FaultSubsectionCluster startCluster,
 			FaultSubsectionCluster endCluster, RuptureTreeNavigator navigator, Jump newJump,
@@ -175,11 +169,6 @@ public class TotalAzimuthChangeFilter implements ScalarValuePlausibiltyFilter<Fl
 	@Override
 	public Float getValue(ClusterRupture rupture) {
 		return getValue(rupture.clusters[0], rupture, rupture.getTreeNavigator());
-	}
-
-	@Override
-	public Float getValue(ClusterRupture rupture, Jump newJump) {
-		return getValue(rupture.take(newJump));
 	}
 
 	@Override

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/U3CompatibleCumulativeRakeChangeFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/U3CompatibleCumulativeRakeChangeFilter.java
@@ -51,11 +51,6 @@ public class U3CompatibleCumulativeRakeChangeFilter implements ScalarValuePlausi
 			System.out.println(getShortName()+": failing with tot="+tot);
 		return PlausibilityResult.FAIL_HARD_STOP;
 	}
-
-	@Override
-	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
-		return apply(rupture.take(newJump), verbose);
-	}
 	
 	private double calc(RuptureTreeNavigator navigator, FaultSection sect1, FaultSection stopAt,
 			double tot, boolean verbose, boolean shortCircuit) {
@@ -102,11 +97,6 @@ public class U3CompatibleCumulativeRakeChangeFilter implements ScalarValuePlausi
 		}
 		FaultSection stopAt = rupture.clusters[rupture.clusters.length-1].startSect;
 		return calc(rupture.getTreeNavigator(), rupture.clusters[0].startSect, stopAt, 0d, false, false);
-	}
-
-	@Override
-	public Double getValue(ClusterRupture rupture, Jump newJump) {
-		return getValue(rupture.take(newJump));
 	}
 
 	@Override

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/U3CoulombJunctionFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/U3CoulombJunctionFilter.java
@@ -40,11 +40,6 @@ public class U3CoulombJunctionFilter implements PlausibilityFilter {
 		
 		return testPaths(paths, verbose);
 	}
-
-	@Override
-	public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
-		return apply(rupture.take(newJump), verbose);
-	}
 	
 	private void findPaths(RuptureTreeNavigator navigator,
 			List<List<IDPairing>> fullPaths, List<IDPairing> curPath, FaultSection curSect) {

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/SectCountAdaptivePermutationStrategy.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/SectCountAdaptivePermutationStrategy.java
@@ -214,12 +214,6 @@ public class SectCountAdaptivePermutationStrategy implements ClusterPermutationS
 			
 			return result;
 		}
-
-		@Override
-		public PlausibilityResult testJump(ClusterRupture rupture, Jump newJump, boolean verbose) {
-			// simple case, testing a new jump not part of the rupture
-			return testCluster(rupture.getTotalNumSects(), newJump.toCluster, null, verbose);
-		}
 		
 		private PlausibilityResult testCluster(int rupSizeBefore, FaultSubsectionCluster cluster,
 				RuptureTreeNavigator navigator, boolean verbose) {

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/ClusterRupturePlausibilityDebug.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/ClusterRupturePlausibilityDebug.java
@@ -101,28 +101,6 @@ public class ClusterRupturePlausibilityDebug {
 				System.out.println("result: "+result);
 				System.out.println("===================");
 			}
-			if (tryLastJump && rup.splays.isEmpty() && rup.clusters.length > 1) {
-				// also test by offering jumps
-				ClusterRupture newRup = new ClusterRupture(rup.clusters[0]);
-				for (int i=1; i<rup.clusters.length-1; i++) {
-					Jump jump = newRup.clusters[i-1].getConnectionsTo(rup.clusters[i]).iterator().next();
-					newRup = newRup.take(jump);
-				}
-				FaultSubsectionCluster addition = rup.clusters[rup.clusters.length-1];
-				Jump newJump = newRup.clusters[newRup.clusters.length-1].getConnectionsTo(addition)
-						.iterator().next();
-				System.out.println("Now trying testJump for at last jump");
-				System.out.println("Main rupture: "+newRup);
-				System.out.println("Addition: "+newJump);
-				System.out.println("===================");
-				for (PlausibilityFilter filter : testFilters) {
-					System.out.println("Testing "+filter.getName());
-					PlausibilityResult result = filter.testJump(newRup, newJump, true);
-					System.out.println("result: "+result);
-					System.out.println("===================");
-				}
-				
-			}
 			System.out.println();
 		}
 	}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/CompareClusterRuptureBuild.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/CompareClusterRuptureBuild.java
@@ -123,12 +123,21 @@ public class CompareClusterRuptureBuild {
 			
 			System.out.println("Building UCERF3 original plausibility filters...");
 			UCERF3PlausibilityConfig u3Config = UCERF3PlausibilityConfig.getDefault();
-			Map<IDPairing, Double> distances = new HashMap<>(distAzCalc.getCachedDistances());
-			Map<IDPairing, Double> azimuths = new HashMap<>(distAzCalc.getCachedAzimuths());
-			for (IDPairing pair : new ArrayList<>(distances.keySet())) {
-				distances.put(pair.getReversed(), distances.get(pair));
-				azimuths.put(pair, distAzCalc.getAzimuth(pair.getID1(), pair.getID2()));
-				azimuths.put(pair.getReversed(), distAzCalc.getAzimuth(pair.getID2(), pair.getID1()));
+//			Map<IDPairing, Double> distances = new HashMap<>(distAzCalc.getCachedDistances());
+//			Map<IDPairing, Double> azimuths = new HashMap<>(distAzCalc.getCachedAzimuths());
+			Map<IDPairing, Double> distances = new HashMap<>();
+			Map<IDPairing, Double> azimuths = new HashMap<>();
+			for (int id1=0; id1<subSects.size(); id1++) {
+				for (int id2=0; id2<subSects.size(); id2++) {
+					if (distAzCalc.isDistanceCached(id1, id2)) {
+						IDPairing pair = new IDPairing(id1, id2);
+						double dist = distAzCalc.getDistance(id1, id2);
+						distances.put(pair, dist);
+						distances.put(pair.getReversed(), dist);
+						azimuths.put(pair, distAzCalc.getAzimuth(id1, id2));
+						azimuths.put(pair.getReversed(), distAzCalc.getAzimuth(id2, id1));
+					}
+				}
 			}
 			for (int i=1; i<subSects.size(); i++) {
 				azimuths.put(new IDPairing(i-1, i), distAzCalc.getAzimuth(i-1, i));

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/FilterDataClusterRupture.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/FilterDataClusterRupture.java
@@ -1,0 +1,65 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Extension of {@link ClusterRupture} that can store a payload of data for plausibility filters.
+ * This allows filters to speed up their checks during rupture building if results from the prior (smaller)
+ * version of this rupture can inform how to proceed at this step.
+ * 
+ * @author kevin
+ *
+ */
+public class FilterDataClusterRupture extends ClusterRupture {
+	
+	private Map<PlausibilityFilter, Object> filterData;
+
+	public FilterDataClusterRupture(FaultSubsectionCluster cluster) {
+		super(cluster);
+	}
+	
+	private FilterDataClusterRupture(FaultSubsectionCluster[] clusters, ImmutableSet<Jump> internalJumps,
+			ImmutableMap<Jump, ClusterRupture> splays, UniqueRupture unique, UniqueRupture internalUnique) {
+		super(clusters, internalJumps, splays, unique, internalUnique);
+	}
+
+	public synchronized void addFilterData(PlausibilityFilter filter, Object data) {
+		if (filterData == null)
+			filterData = new HashMap<>();
+		filterData.put(filter, data);
+	}
+	
+	public synchronized boolean removeFilterData(PlausibilityFilter filter) {
+		if (filterData == null)
+			return false;
+		return filterData.remove(filter) != null;
+	}
+	
+	public synchronized Object getFilterData(PlausibilityFilter filter) {
+		if (filterData == null)
+			return null;
+		return filterData.get(filter);
+	}
+
+	@Override
+	public synchronized FilterDataClusterRupture take(Jump jump) {
+		ClusterRupture orig = super.take(jump);
+		
+		FilterDataClusterRupture ret = new FilterDataClusterRupture(orig.clusters, orig.internalJumps,
+				orig.splays, orig.unique, orig.internalUnique);
+		if (filterData != null)
+			ret.filterData = new HashMap<>(filterData);
+		
+		return ret;
+	}
+
+}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/SectionDistanceAzimuthCalculator.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/SectionDistanceAzimuthCalculator.java
@@ -29,8 +29,9 @@ import com.google.common.collect.ImmutableList;
 public class SectionDistanceAzimuthCalculator {
 
 	private List<? extends FaultSection> subSects;
-	private LoadingCache<IDPairing, Double> distCache;
-	private LoadingCache<IDPairing, Double> azCache;
+	
+	private double[][] distCache;
+	private double[][] azCache;
 	private Map<Integer, RuptureSurface> sectSurfs;
 
 	public SectionDistanceAzimuthCalculator(List<? extends FaultSection> subSects) {
@@ -38,8 +39,8 @@ public class SectionDistanceAzimuthCalculator {
 		sectSurfs = new HashMap<>();
 		for (FaultSection subSect : subSects)
 			sectSurfs.put(subSect.getSectionId(), subSect.getFaultSurface(1d, false, false));
-		distCache = CacheBuilder.newBuilder().build(new DistLoader());
-		azCache = CacheBuilder.newBuilder().build(new AzLoader());
+		distCache = new double[subSects.size()][];
+		azCache = new double[subSects.size()][];
 	}
 	
 	private RuptureSurface getSurface(int id) {
@@ -57,122 +58,193 @@ public class SectionDistanceAzimuthCalculator {
 		return subSects;
 	}
 	
-	private class DistLoader extends CacheLoader<IDPairing, Double> {
-
-		@Override
-		public Double load(IDPairing pair) throws Exception {
-			int id1 = pair.getID1();
-			int id2 = pair.getID2();
-			if (id1 == id2)
-				return 0d;
-			
-			RuptureSurface surf1 = getSurface(id1);
-			Preconditions.checkNotNull(surf1);
-			RuptureSurface surf2 = getSurface(id2);
-			Preconditions.checkNotNull(surf2);
-			
-			// if the quick distance is less than this value, calculate a full distance
-			double quickDistThreshold = 5d*Math.max(surf1.getAveLength(), surf2.getAveLength());
-			double minDist = Double.POSITIVE_INFINITY;
-			
-			for (Location loc : surf1.getPerimeter()) {
-				minDist = Math.min(minDist, surf2.getQuickDistance(loc));
-				if (minDist < quickDistThreshold)
-					break;
-			}
-			
-			if (minDist < quickDistThreshold)
-				// do the full calculation
-				minDist = surf1.getMinDistance(surf2);
-			return minDist;
+	public boolean isDistanceCached(int id1, int id2) {
+		if (id1 == id2)
+			return false;
+		if (id2 < id1) {
+			// swap them
+			int tmp = id1;
+			id1 = id2;
+			id2 = tmp;
 		}
-		
+		return distCache[id1] != null && Double.isFinite(distCache[id1][calcDistIndexOffset(id1, id2)]);
 	}
 	
-	private class AzLoader extends CacheLoader<IDPairing, Double> {
-
-		@Override
-		public Double load(IDPairing pair) throws Exception {
-			int id1 = pair.getID1();
-			int id2 = pair.getID2();
-			if (id1 == id2)
-				return Double.NaN;
-			
-			RuptureSurface surf1 = getSurface(id1);
-			Preconditions.checkNotNull(surf1);
-			RuptureSurface surf2 = getSurface(id2);
-			Preconditions.checkNotNull(surf2);
-			
-			Location loc1 = GriddedSurfaceUtils.getSurfaceMiddleLoc(surf1);
-			Location loc2 = GriddedSurfaceUtils.getSurfaceMiddleLoc(surf2);
-			return LocationUtils.azimuth(loc1, loc2);
+	public synchronized void setDistance(int id1, int id2, double dist) {
+		if (id1 == id2)
+			return;
+		if (id2 < id1) {
+			// swap them
+			int tmp = id1;
+			id1 = id2;
+			id2 = tmp;
 		}
-		
+		if (distCache[id1] == null) {
+			double[] cache = new double[subSects.size()-id1];
+			for (int i=0; i<cache.length; i++)
+				cache[i] = Double.NaN;
+			distCache[id1] = cache;
+		}
+		distCache[id1][calcDistIndexOffset(id1, id2)] = dist;
 	}
 	
 	public double getDistance(FaultSection sect1, FaultSection sect2) {
 		return getDistance(sect1.getSectionId(), sect2.getSectionId());
 	}
 	
+	private static int calcDistIndexOffset(int id1, int id2) {
+		Preconditions.checkState(id1 < id2);
+		return id2 - (id1 + 1);
+	}
+	
 	public double getDistance(int id1, int id2) {
-		try {
-			if (id1 < id2)
-				return distCache.get(new IDPairing(id1, id2));
-			return distCache.get(new IDPairing(id2, id1));
-		} catch (ExecutionException e) {
-			throw ExceptionUtils.asRuntimeException(e);
+		if (id1 == id2)
+			return 0d;
+		if (id2 < id1) {
+			// swap them
+			int tmp = id1;
+			id1 = id2;
+			id2 = tmp;
 		}
+		int offset = calcDistIndexOffset(id1, id2);
+		
+		if (distCache[id1] == null) {
+			synchronized (distCache) {
+				if (distCache[id1] == null) {
+					double[] cache = new double[subSects.size()-id1];
+					for (int i=0; i<cache.length; i++)
+						cache[i] = Double.NaN;
+					distCache[id1] = cache;
+				}
+			}
+		} else if (Double.isFinite(distCache[id1][offset])) {
+			return distCache[id1][offset];
+		}
+		RuptureSurface surf1 = getSurface(id1);
+		Preconditions.checkNotNull(surf1);
+		RuptureSurface surf2 = getSurface(id2);
+		Preconditions.checkNotNull(surf2);
+		
+		// if the quick distance is less than this value, calculate a full distance
+		double quickDistThreshold = 5d*Math.max(surf1.getAveLength(), surf2.getAveLength());
+		double minDist = Double.POSITIVE_INFINITY;
+		
+		for (Location loc : surf1.getPerimeter()) {
+			minDist = Math.min(minDist, surf2.getQuickDistance(loc));
+			if (minDist < quickDistThreshold)
+				break;
+		}
+		
+		if (minDist < quickDistThreshold)
+			// do the full calculation
+			minDist = surf1.getMinDistance(surf2);
+		distCache[id1][offset] = minDist;
+		return minDist;
+	}
+	
+	public synchronized void setAzimuth(int id1, int id2, double azimuth) {
+		if (id1 == id2)
+			return;
+		if (azCache[id1] == null) {
+			double[] cache = new double[subSects.size()];
+			for (int i=0; i<cache.length; i++)
+				cache[i] = Double.NaN;
+			azCache[id1] = cache;
+		}
+		azCache[id1][id2] = azimuth;
 	}
 	
 	public double getAzimuth(FaultSection sect1, FaultSection sect2) {
 		return getAzimuth(sect1.getSectionId(), sect2.getSectionId());
 	}
 	
+	public boolean isAzimuthCached(int id1, int id2) {
+		return azCache[id1] != null && Double.isFinite(azCache[id1][id2]);
+	}
+	
 	public double getAzimuth(int id1, int id2) {
-		try {
-			return azCache.get(new IDPairing(id1, id2));
-		} catch (ExecutionException e) {
-			throw ExceptionUtils.asRuntimeException(e);
+		if (id1 == id2)
+			return Double.NaN;
+		if (azCache[id1] == null) {
+			synchronized (azCache) {
+				if (azCache[id1] == null) {
+					double[] cache = new double[subSects.size()];
+					for (int i=0; i<cache.length; i++)
+						cache[i] = Double.NaN;
+					azCache[id1] = cache;
+					
+				}
+			}
+		} else if (Double.isFinite(azCache[id1][id2])) {
+			return azCache[id1][id2];
 		}
+		
+		RuptureSurface surf1 = getSurface(id1);
+		Preconditions.checkNotNull(surf1);
+		RuptureSurface surf2 = getSurface(id2);
+		Preconditions.checkNotNull(surf2);
+		
+		Location loc1 = GriddedSurfaceUtils.getSurfaceMiddleLoc(surf1);
+		Location loc2 = GriddedSurfaceUtils.getSurfaceMiddleLoc(surf2);
+		azCache[id1][id2] = LocationUtils.azimuth(loc1, loc2);
+		return azCache[id1][id2];
 	}
 	
-	public ConcurrentMap<IDPairing, Double> getCachedDistances() {
-		return distCache.asMap();
+	public int getNumCachedDistances() {
+		int count = 0;
+		for (double[] cache : distCache) {
+			if (cache == null)
+				continue;
+			for (double val : cache)
+				if (Double.isFinite(val))
+					count++;
+		}
+		return count;
 	}
 	
-	public ConcurrentMap<IDPairing, Double> getCachedAzimuths() {
-		return azCache.asMap();
+	public int getNumCachedAzimuths() {
+		int count = 0;
+		for (double[] cache : azCache) {
+			if (cache == null)
+				continue;
+			for (double val : cache)
+				if (Double.isFinite(val))
+					count++;
+		}
+		return count;
 	}
 	
 	public void writeCacheFile(File cacheFile) throws IOException {
 		CSVFile<String> csv = new CSVFile<>(true);
 		csv.addLine("ID1", "ID2", "Distance", "Azimuth");
-		Set<IDPairing> distPairings = getCachedDistances().keySet();
-		Set<IDPairing> azPairings = getCachedAzimuths().keySet();
-		HashSet<IDPairing> combPairings = new HashSet<>();
-		combPairings.addAll(distPairings);
-		combPairings.addAll(azPairings);
-//		int distPresent = distCache.
-//		List<IDPairing> allPairings = new ArrayList<>(distCache.g);
-		for (IDPairing pair : combPairings) {
-			List<String> line = new ArrayList<>();
-			line.add(pair.getID1()+"");
-			line.add(pair.getID2()+"");
-			Double dist = distCache.getIfPresent(pair);
-			if (dist == null)
-				line.add("");
-			else
-				line.add(dist.toString());
-			Double az = azCache.getIfPresent(pair);
-			if (az == null)
-				line.add("");
-			else
-				line.add(az.toString());
-			csv.addLine(line);
+		int numDist = 0;
+		int numAz = 0;
+		for (int id1=0; id1<subSects.size(); id1++) {
+			for (int id2=0; id2<subSects.size(); id2++) {
+				boolean distCached = isDistanceCached(id1, id2);
+				boolean azCached = isAzimuthCached(id1, id2);
+				if (distCached || azCached) {
+					List<String> line = new ArrayList<>();
+					line.add(id1+"");
+					line.add(id2+"");
+					if (distCached) {
+						line.add(getDistance(id1, id2)+"");
+						numDist++;
+					} else {
+						line.add("");
+					}
+					if (azCached) {
+						line.add(getAzimuth(id1, id2)+"");
+						numAz++;
+					} else {
+						line.add("");
+					}
+					csv.addLine(line);
+				}
+			}
 		}
 		csv.writeToFile(cacheFile);
-		System.out.println("Wrote cache file for "+distPairings.size()
-			+" distances and "+azPairings.size()+" azimuths");
+		System.out.println("Wrote cache file for "+numDist+" distances and "+numAz+" azimuths");
 	}
 	
 	public void loadCacheFile(File cacheFile) throws IOException {
@@ -182,16 +254,17 @@ public class SectionDistanceAzimuthCalculator {
 		for (int row=1; row<csv.getNumRows(); row++) {
 			int id1 = csv.getInt(row, 0);
 			int id2 = csv.getInt(row, 1);
+			if (id1 == id2)
+				continue;
 			
-			IDPairing pair = new IDPairing(id1, id2);
 			String distStr = csv.get(row, 2);
 			if (!distStr.isEmpty()) {
-				distCache.put(pair, Double.parseDouble(distStr));
+				setDistance(id1, id2, Double.parseDouble(distStr));
 				numDist++;
 			}
 			String azStr = csv.get(row, 3);
 			if (!azStr.isEmpty()) {
-				azCache.put(pair, Double.parseDouble(azStr));
+				setAzimuth(id1, id2, Double.parseDouble(azStr));
 				numAz++;
 			}
 		}

--- a/src/scratch/UCERF3/FaultSystemRupSet.java
+++ b/src/scratch/UCERF3/FaultSystemRupSet.java
@@ -911,7 +911,7 @@ public class FaultSystemRupSet implements Serializable {
 				for (FaultSubsectionCluster cluster : rupture.clusters)
 					for (FaultSection sect : cluster.subSects)
 						mainStrandLen += sect.getTraceLength();
-				for (ClusterRupture alternative : rupture.getPreferredInversions(search)) {
+				for (ClusterRupture alternative : rupture.getPreferredAltRepresentations(search)) {
 					int altNumSplays = alternative.getTotalNumSplays();
 					double altStrandLen = 0d;
 					for (FaultSubsectionCluster cluster : alternative.clusters)

--- a/test/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/CumulativeAzimuthChangeFilterTests.java
+++ b/test/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/CumulativeAzimuthChangeFilterTests.java
@@ -11,7 +11,7 @@ public class CumulativeAzimuthChangeFilterTests {
         JumpDataMock data = new JumpDataMock(fromAzimuths, jumpAzimuth, toAzimuths);
 
         CumulativeAzimuthChangeFilter jumpFilter = new CumulativeAzimuthChangeFilter(data.calc, threshold);
-        return jumpFilter.testJump(data.rupture, data.jump, false);
+        return jumpFilter.apply(data.rupture.take(data.jump), false);
     }
 
     @Test

--- a/test/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/TotalAzimuthChangeFilterTests.java
+++ b/test/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/TotalAzimuthChangeFilterTests.java
@@ -11,7 +11,7 @@ public class TotalAzimuthChangeFilterTests {
         JumpDataMock data = new JumpDataMock(new double[]{fromAzimuth}, Double.MAX_VALUE, toAzimuths);
         
         TotalAzimuthChangeFilter jumpFilter = new TotalAzimuthChangeFilter(data.calc, threshold, true, testFullEnd);
-        return jumpFilter.testJump(data.rupture, data.jump, false);
+        return jumpFilter.apply(data.rupture.take(data.jump), false);
     }
 
     @Test


### PR DESCRIPTION
This pull request contains the following updates to plausibility filters and rupture building:

- Simplified PlausibilityFilter interface by removing the testJump(ClusterRupture, Jump, Boolean) method. That method was intended to speed up calculations by allowing a filter to only test a given jump without retesting the whole rupture, but was rarely called in practice and often required significant added complexity in filter representations.
- Added ClusterRupture subclass, FilterDataClusterRupture. This subclass is used by ClusterRuptureBuilder when building rupture sets and allows PlausibilityFilter instances to attach data to a cluster rupture. That data will be attached to all extensions of the rupture (via the take(Jump) method), and can be used to accelerate rupture building by reducing repeated calculations. The ClusterPathCoulombCompatibilityFilter is the initial implementation of this capability, and uses it to keep from retrying nucleation points which already failed a smaller version of the rupture.
- New experimental cumulative filters based on accrued penalties (for things such as jumping x amount) or some level of rupture improbability (e.g., based on Biasi & Wesnousky 2016-1017 probabilities).
- Improved distance-azimuth cache performance by using simple arrays rather than Google Guava LoadingCache implementations. The latter were slower to retrieve values from large caches.