### PR TITLE
Updates to distance-dependence of plausibility filters

### DIFF
--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRuptureBuilder.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRuptureBuilder.java
@@ -72,6 +72,7 @@ public class ClusterRuptureBuilder {
 	private List<FaultSubsectionCluster> clusters;
 	private List<PlausibilityFilter> filters;
 	private int maxNumSplays = 0;
+	private SectionDistanceAzimuthCalculator distAzCalc;
 	
 	private RupDebugCriteria debugCriteria;
 	private boolean stopAfterDebugMatch;
@@ -83,7 +84,7 @@ public class ClusterRuptureBuilder {
 	 */
 	public ClusterRuptureBuilder(PlausibilityConfiguration configuration) {
 		this(configuration.getConnectionStrategy().getClusters(), configuration.getFilters(),
-				configuration.getMaxNumSplays());
+				configuration.getMaxNumSplays(), configuration.getDistAzCalc());
 	}
 	
 	/**
@@ -94,10 +95,11 @@ public class ClusterRuptureBuilder {
 	 * @param maxNumSplays the maximum number of splays per rupture (use 0 to disable splays)
 	 */
 	public ClusterRuptureBuilder(List<FaultSubsectionCluster> clusters,
-			List<PlausibilityFilter> filters, int maxNumSplays) {
+			List<PlausibilityFilter> filters, int maxNumSplays, SectionDistanceAzimuthCalculator distAzCalc) {
 		this.clusters = clusters;
 		this.filters = filters;
 		this.maxNumSplays = maxNumSplays;
+		this.distAzCalc = distAzCalc;
 	}
 	
 	/**
@@ -588,6 +590,17 @@ public class ClusterRuptureBuilder {
 		}
 		return true;
 	}
+	
+	private Jump buildJump(Jump jump, FaultSubsectionCluster toVariation) {
+		// correct the distance to be the minimum distance between the two clusters, not just the jumping point distance
+		double minDist = Double.POSITIVE_INFINITY;
+		for (FaultSection s1 : jump.fromCluster.subSects)
+			for (FaultSection s2 : toVariation.subSects)
+				minDist = Double.min(minDist, distAzCalc.getDistance(s1, s2));
+		Preconditions.checkState(toVariation.startSect.equals(jump.toSection));
+		Preconditions.checkState(toVariation.contains(jump.toSection));
+		return new Jump(jump.fromSection, jump.fromCluster, jump.toSection, toVariation, minDist);
+	}
 
 	private boolean addJumpVariations(List<ClusterRupture> rups, HashSet<UniqueRupture> uniques,
 			ClusterRupture currentRupture, ClusterRupture currentStrand,
@@ -605,10 +618,7 @@ public class ClusterRuptureBuilder {
 			}
 			if (hasLoopback)
 				continue;
-			Preconditions.checkState(variation.startSect.equals(jump.toSection));
-			Preconditions.checkState(variation.contains(jump.toSection));
-			Jump testJump = new Jump(jump.fromSection, jump.fromCluster,
-					jump.toSection, variation, jump.distance);
+			Jump testJump = buildJump(jump, variation);
 			ClusterRupture candidateRupture = currentRupture.take(testJump);
 			PlausibilityResult result = testRup(candidateRupture, false);
 			boolean debugMatch = debugCriteria != null && debugCriteria.isMatch(currentRupture, testJump)
@@ -971,39 +981,17 @@ public class ClusterRuptureBuilder {
 //		
 //		String fmPrefix;
 //		File nshmBaseDir = new File("/home/kevin/OpenSHA/UCERF4/fault_models/NSHM2023_FaultSectionsEQGeoDB_v1p2_29March2021");
+//		File setctsFile = new File(nshmBaseDir, "NSHM2023_FaultSections_v1p2.geojson");
+//		File geoDBFile = new File(nshmBaseDir, "NSHM2023_EQGeoDB_v1p2.geojson");
 //		List<FaultSection> sects;
-//		if (state == null) {
+//		if (state == null)
 //			fmPrefix = "nshm23_v1p2_all";
-//			sects = new ArrayList<>();
-//			for (List<FaultSection> stateFaults : GeoJSONFaultReader.readFaultSections(
-//					new File(nshmBaseDir, "NSHM2023_FaultSections_v1p2.geojson"), false).values())
-//				sects.addAll(stateFaults);
-//		} else {
+//		else
 //			fmPrefix = "nshm23_v1p2_"+state.toLowerCase();
-//			sects = GeoJSONFaultReader.readFaultSections(
-//					new File(nshmBaseDir, "NSHM2023_FaultSections_v1p2.geojson"), true).get(state);
-//		}
-//		Collections.sort(sects, new Comparator<FaultSection>() {
-//
-//			@Override
-//			public int compare(FaultSection o1, FaultSection o2) {
-//				return o1.getSectionName().compareTo(o2.getSectionName());
-//			}
-//		});
 //		
 //		File distAzCacheFile = new File(rupSetsDir, fmPrefix+"_dist_az_cache.csv");
 //		ScalingRelationships scale = ScalingRelationships.MEAN_UCERF3;
-//		System.out.println("Loaded "+sects.size()+" sections");
-//		// add slip rates
-//		Map<Integer, List<GeoSlipRateRecord>> slipRates = GeoJSONFaultReader.readGeoDB(
-//				new File(nshmBaseDir, "NSHM2023_EQGeoDB_v1p2.geojson"));
-//		List<FaultSection> fallbacks = new ArrayList<>();
-//		fallbacks.addAll(FaultModels.FM3_1.fetchFaultSections());
-//		fallbacks.addAll(FaultModels.FM3_2.fetchFaultSections());
-//		GeoJSONFaultReader.testMapSlipRates(sects, slipRates, 1d, fallbacks);
-//		List<FaultSection> subSects = new ArrayList<>();
-//		for (FaultSection sect : sects)
-//			subSects.addAll(sect.getSubSectionsList(0.5*sect.getOrigDownDipWidth(), subSects.size(), 2));
+//		List<FaultSection> subSects = GeoJSONFaultReader.buildSubSects(setctsFile, geoDBFile, state);
 //		System.out.println("Built "+subSects.size()+" subsections");
 		// END NSHM23
 		
@@ -1065,7 +1053,7 @@ public class ClusterRuptureBuilder {
 		
 		/*
 		 * =============================
-		 * To reproduce UCERF3 with an alternative distance/conn strategy (and calculate missing coulomb)
+		 * To reproduce UCERF3 with an alternative distance/conn strategy (and calculate missing Coulomb)
 		 * =============================
 		 */
 //		String outputName = fmPrefix+"_ucerf3";
@@ -1136,10 +1124,60 @@ public class ClusterRuptureBuilder {
 		 * For other experiments
 		 * =============================
 		 */
+		/*
+		 * Thresholds & params
+		 * 
+		 * preferred values are listed to the right of each parameter/threshold, and 'MOD' is appended whenever
+		 * one is temporarily modified from the preferred value.
+		 */
+		// PLAUSIBILITY FILTERS
+		// minimum subsections per parent
+		int minSectsPerParent = 2;				// PREF: 2
+		// filters out indirect paths
+		boolean noIndirectPaths = true;			// PREF: true
+		// relative slip rate probability
+		float slipRateProb = 0.05f;				// PREF: 0.05
+		// if false, slip rate probabilities only consider alternative jumps up to the distance (+2km) of the taken jump
+		boolean slipIncludeLonger = false;		// PREF: false
+		// fraction of interactions positive
+		float cffFractInts = 0.75f;				// PREF: 0.75
+		// number of denominator values for the CFF favorability ratio
+		int cffRatioN = 2;						// PREF: 2
+		// CFF favorability ratio threshold
+		float cffRatioThresh = 0.5f;			// PREF: 0.5
+		// relative CFF probability
+		float cffRelativeProb = 0.01f;			// PREF: 0.01
+		// if true, CFF calculations are computed with the most favorable path (up to max jump distance), which may not
+		// use the exact jumping point from the connection strategy
+		boolean favorableJumps = true;			// PREF: true
+		// cumulative jump probability threshold
+		float jumpProbThresh = 0.001f;			// PREF: 0.001 (~21 km)
+		// cumulative rake change threshold
+		float cmlRakeThresh = 360f;				// PREF: 360
+		// CONNECTION STRATEGY
+		// maximum individual jump distance
+		double maxJumpDist = 15d;				// PREF: 10
+		// if true, connections happen at places that actually work and paths are optimized. if false, closest points
+		boolean plausibleConnections = true;	// PREF: true
+		// if >0 and <maxDist, connections will only be added above this distance when no other connections exist from
+		// a given subsection. e.g., if set to 5, you can jump more than 5 km but only if no <= 5km jumps exist
+		double adaptiveMinDist = 6d;			// PREF: 0	MOD
+		// GROWING STRATEGY
+		// if nonzero, apply thinning to growing strategy
+		float adaptiveSectFract = 0.05f;		// PREF: 0.05
+		// if true, allow bilateral rupture growing (using default settings)
+		boolean bilateral = false;				// PREF: false
+		// if true, allow splays (using default settings)
+		boolean splays = false;					// PREF: false
+		/*
+		 * END Plausibility thresholds & params
+		 */
+		
 		// build stiffness calculator (used for new Coulomb)
 		double stiffGridSpacing = 2d;
+		double coeffOfFriction = 0.25;
 		SubSectStiffnessCalculator stiffnessCalc = new SubSectStiffnessCalculator(
-				subSects, stiffGridSpacing, 3e4, 3e4, 0.5, PatchAlignment.FILL_OVERLAP, 1d);
+				subSects, stiffGridSpacing, 3e4, 3e4, coeffOfFriction, PatchAlignment.FILL_OVERLAP, 1d);
 		AggregatedStiffnessCache stiffnessCache = stiffnessCalc.getAggregationCache(StiffnessType.CFF);
 		File stiffnessCacheFile = new File(rupSetsDir, stiffnessCache.getCacheFileName());
 		int stiffnessCacheSize = 0;
@@ -1154,21 +1192,13 @@ public class ClusterRuptureBuilder {
 //				AggregationMethod.NUM_POSITIVE, AggregationMethod.SUM, AggregationMethod.SUM, AggregationMethod.THREE_QUARTER_INTERACTIONS);
 		AggregatedStiffnessCalculator fractIntsAgg = new AggregatedStiffnessCalculator(StiffnessType.CFF, stiffnessCalc, true,
 				AggregationMethod.FLATTEN, AggregationMethod.NUM_POSITIVE, AggregationMethod.SUM, AggregationMethod.NORM_BY_COUNT);
-		float slipRateProb = 0.05f;		// PREF: 0.05
-		float cffFractInts = 0.75f;		// PREF: 0.75
-		int cffRatioN = 2;				// PREF: 2
-		float cffRatioThresh = 0.5f;	// PREF: 0.5
-		float cffRelativeProb = 0.01f;	// PREF: 0.01
-		boolean favorableJumps = true;	// PREF: true
-		float jumpProbThresh = 0.001f;	// PREF: 0.001
-		float cmlRakeThresh = 360f;		// PREF: 360
-		double maxJumpDist = 10d;		// PREF: 10
-//		CoulombSectRatioProb cffRatioProb = new CoulombSectRatioProb(sumAgg, cffRatioN);
 		
 		String outputName = fmPrefix;
 		
 		if (stiffGridSpacing != 2d)
 			outputName += "_stiff"+new DecimalFormat("0.#").format(stiffGridSpacing)+"km";
+		if (coeffOfFriction != 0.5d)
+			outputName += "_coeff"+(float)coeffOfFriction;
 		
 		/*
 		 * Connection strategy: which faults are allowed to connect, and where?
@@ -1180,50 +1210,47 @@ public class ClusterRuptureBuilder {
 //						distAzCalc, maxJumpDist, CoulombRates.loadUCERF3CoulombRates(fm));
 //		if (maxJumpDist != 5d)
 //			outputName += "_"+new DecimalFormat("0.#").format(maxJumpDist)+"km";
-		// use this for simpler connection rules
-		ClusterConnectionStrategy connectionStrategy =
-			new DistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, maxJumpDist);
-		if (maxJumpDist != 5d)
-			outputName += "_"+new DecimalFormat("0.#").format(maxJumpDist)+"km";
-		// use this for adaptive distance filter
-//		double r0 = 5d;
-//		double rMax = 10d;
-//		int cMax = -1;
-//		int sMax = 1;
-//		ClusterConnectionStrategy connectionStrategy =
-//				new AdaptiveDistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, r0, rMax, cMax, sMax);
-//		outputName += "_adapt"+new DecimalFormat("0.#").format(r0)+"_"+new DecimalFormat("0.#").format(rMax)+"km";
-//		if (cMax >= 0)
-//			outputName += "_cMax"+cMax;
-//		if (sMax >= 0)
-//			outputName += "_sMax"+sMax;
-		// use this to pick connections which agree with your plausibility filters
-		// some filters need a connection strategy, use one that only includes immediate neighbors at this step
-//		DistCutoffClosestSectClusterConnectionStrategy neighborsConnStrat =
-//				new DistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, 0.1d);
-//		List<PlausibilityFilter> connFilters = new ArrayList<>();
-//		if (cffRatioThresh > 0f) {
-//			connFilters.add(new CumulativeProbabilityFilter(cffRatioThresh, new CoulombSectRatioProb(
-//					sumAgg, cffRatioN, favorableJumps, (float)maxJumpDist, distAzCalc)));
-//			if (cffRelativeProb > 0f)
-//				connFilters.add(new PathPlausibilityFilter(
-//						new CumulativeProbPathEvaluator(cffRatioThresh, PlausibilityResult.FAIL_HARD_STOP,
-//								new CoulombSectRatioProb(sumAgg, cffRatioN, favorableJumps, (float)maxJumpDist, distAzCalc)),
-//						new CumulativeProbPathEvaluator(cffRelativeProb, PlausibilityResult.FAIL_HARD_STOP,
-//								new RelativeCoulombProb(sumAgg, neighborsConnStrat, false, true, favorableJumps, (float)maxJumpDist, distAzCalc))));
-//		} else if (cffRelativeProb > 0f) {
-//			connFilters.add(new CumulativeProbabilityFilter(cffRatioThresh, new RelativeCoulombProb(
-//					sumAgg, neighborsConnStrat, false, true, favorableJumps, (float)maxJumpDist, distAzCalc)));
-//		}
-//		if (cffFractInts > 0f)
-//			connFilters.add(new NetRuptureCoulombFilter(fractIntsAgg, cffFractInts));
-//		System.out.println("Building plausible connections w/ "+threads+" threads...");
-//		ClusterConnectionStrategy connectionStrategy =
-//			new PlausibleClusterConnectionStrategy(subSects, distAzCalc, maxJumpDist,
-//					PlausibleClusterConnectionStrategy.JUMP_SELECTOR_DEFAULT, connFilters);
-//		outputName += "_plausibleMulti"+new DecimalFormat("0.#").format(maxJumpDist)+"km";
-//		connectionStrategy.checkBuildThreaded(threads);
-//		System.out.println("DONE building plausible connections");
+		ClusterConnectionStrategy connectionStrategy;
+		if (plausibleConnections) {
+			// use this to pick connections which agree with your plausibility filters
+			
+			// some filters need a connection strategy, use one that only includes immediate neighbors at this step
+			DistCutoffClosestSectClusterConnectionStrategy neighborsConnStrat =
+					new DistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, 0.1d);
+			List<PlausibilityFilter> connFilters = new ArrayList<>();
+			if (cffRatioThresh > 0f) {
+				connFilters.add(new CumulativeProbabilityFilter(cffRatioThresh, new CoulombSectRatioProb(
+						sumAgg, cffRatioN, favorableJumps, (float)maxJumpDist, distAzCalc)));
+				if (cffRelativeProb > 0f)
+					connFilters.add(new PathPlausibilityFilter(
+							new CumulativeProbPathEvaluator(cffRatioThresh, PlausibilityResult.FAIL_HARD_STOP,
+									new CoulombSectRatioProb(sumAgg, cffRatioN, favorableJumps, (float)maxJumpDist, distAzCalc)),
+							new CumulativeProbPathEvaluator(cffRelativeProb, PlausibilityResult.FAIL_HARD_STOP,
+									new RelativeCoulombProb(sumAgg, neighborsConnStrat, false, true, favorableJumps, (float)maxJumpDist, distAzCalc))));
+			} else if (cffRelativeProb > 0f) {
+				connFilters.add(new CumulativeProbabilityFilter(cffRatioThresh, new RelativeCoulombProb(
+						sumAgg, neighborsConnStrat, false, true, favorableJumps, (float)maxJumpDist, distAzCalc)));
+			}
+			if (cffFractInts > 0f)
+				connFilters.add(new NetRuptureCoulombFilter(fractIntsAgg, cffFractInts));
+			connectionStrategy = new PlausibleClusterConnectionStrategy(subSects, distAzCalc, maxJumpDist,
+						PlausibleClusterConnectionStrategy.JUMP_SELECTOR_DEFAULT, connFilters);
+			outputName += "_plausibleMulti"+new DecimalFormat("0.#").format(maxJumpDist)+"km";
+//						PlausibleClusterConnectionStrategy.JUMP_SELECTOR_DEFAULT_SINGLE, connFilters);
+//			outputName += "_plausible"+new DecimalFormat("0.#").format(maxJumpDist)+"km";
+			System.out.println("Building plausible connections w/ "+threads+" threads...");
+			connectionStrategy.checkBuildThreaded(threads);
+			System.out.println("DONE building plausible connections");
+		} else {
+			// just use closest distance
+			connectionStrategy = new DistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, maxJumpDist);
+			if (maxJumpDist != 5d)
+				outputName += "_"+new DecimalFormat("0.#").format(maxJumpDist)+"km";
+		}
+		if (adaptiveMinDist > 0d && adaptiveMinDist < maxJumpDist) {
+			connectionStrategy = new AdaptiveClusterConnectionStrategy(connectionStrategy, adaptiveMinDist, 1);
+			outputName += "_adaptive"+new DecimalFormat("0.#").format(adaptiveMinDist)+"km";
+		}
 		
 		Builder configBuilder = PlausibilityConfiguration.builder(connectionStrategy, subSects);
 		
@@ -1235,8 +1262,13 @@ public class ClusterRuptureBuilder {
 		 *  UCERF3 filters
 		 */
 //		configBuilder.u3All(CoulombRates.loadUCERF3CoulombRates(fm)); outputName += "_ucerf3";
-		configBuilder.minSectsPerParent(2, true, true); // always do this one
-		configBuilder.noIndirectPaths(); outputName += "_direct";
+		if (minSectsPerParent > 1) {
+			configBuilder.minSectsPerParent(2, true, true); // always do this one
+		}
+		if (noIndirectPaths) {
+			configBuilder.noIndirectPaths(true);
+			outputName += "_direct";
+		}
 //		configBuilder.u3Cumulatives(); outputName += "_u3Cml"; // cml rake and azimuth
 //		configBuilder.cumulativeAzChange(560f); outputName += "_cmlAz"; // cml azimuth only
 		if (cmlRakeThresh > 0) {
@@ -1263,8 +1295,11 @@ public class ClusterRuptureBuilder {
 		 */
 		// SLIP RATE PROB: only increasing
 		if (slipRateProb > 0f) {
-			configBuilder.cumulativeProbability(slipRateProb, new RelativeSlipRateProb(connectionStrategy, true));
+			configBuilder.cumulativeProbability(slipRateProb,
+					new RelativeSlipRateProb(connectionStrategy, true, slipIncludeLonger));
 			outputName += "_slipP"+slipRateProb+"incr";
+			if (!slipIncludeLonger)
+				outputName += "CapDist";
 		}
 		// END SLIP RATE PROB
 		
@@ -1367,33 +1402,35 @@ public class ClusterRuptureBuilder {
 		/*
 		 * Splay constraints
 		 */
-		configBuilder.maxSplays(0); // default, no splays
-//		configBuilder.maxSplays(1); outputName += "_max1Splays";
-////		configBuilder.splayLength(0.1, true, true); outputName += "_splayLenFract0.1";
-////		configBuilder.splayLength(100, false, true, true); outputName += "_splayLen100km";
-//		configBuilder.splayLength(50, false, true, true); outputName += "_splayLen50km";
-//		configBuilder.splayLength(.5, true, true, true); outputName += "OrHalf";
-//		configBuilder.addFirst(new SplayConnectionsOnlyFilter(connectionStrategy, true)); outputName += "_splayConn";
+		if (splays) {
+			configBuilder.maxSplays(1); outputName += "_max1Splays";
+			//configBuilder.splayLength(0.1, true, true); outputName += "_splayLenFract0.1";
+			//configBuilder.splayLength(100, false, true, true); outputName += "_splayLen100km";
+			configBuilder.splayLength(50, false, true, true); outputName += "_splayLen50km";
+			configBuilder.splayLength(.5, true, true, true); outputName += "OrHalf";
+			configBuilder.addFirst(new SplayConnectionsOnlyFilter(connectionStrategy, true)); outputName += "_splayConn";
+		} else {
+			configBuilder.maxSplays(0); // default, no splays
+		}
 		
 		/*
-		 * Permutation strategies: how should faults be broken up into permutations, combinations of which
-		 * will be used to construct ruptures
+		 * Growing strategies: how should ruptures be broken up and spread onto new faults
 		 */
-		// regular (UCERF3) permutation strategy
-//		RuptureGrowingStrategy growingStrat = new ExhaustiveUnilateralRuptureGrowingStrategy();
-		// only permutate at connection points or subsection end points
-		// (for strict segmentation or testing connection points)
-//		RuptureGrowingStrategy permStrat = new ConnectionPointsRuptureGrowingStrategy();
-//		outputName += "_connPointsGrow";
-		// build permutations adaptively (skip over some end points for larger ruptures)
-		RuptureGrowingStrategy exhaustiveStrategy = new ExhaustiveUnilateralRuptureGrowingStrategy();
-//		RuptureGrowingStrategy exhaustiveStrategy = new ExhaustiveBilateralRuptureGrowingStrategy(
-//				SecondaryPermutations.EQUAL_LEN, false); outputName += "_bilateral";
-		float sectFract = 0.05f;
-		SectCountAdaptiveRuptureGrowingStrategy growingStrat = new SectCountAdaptiveRuptureGrowingStrategy(
-				exhaustiveStrategy, sectFract, true);
-		configBuilder.add(growingStrat.buildConnPointCleanupFilter(connectionStrategy));
-		outputName += "_sectFractGrow"+sectFract;
+		RuptureGrowingStrategy growingStrat;
+		if (bilateral) {
+			growingStrat = new ExhaustiveBilateralRuptureGrowingStrategy(
+					SecondaryVariations.EQUAL_LEN, false);
+			outputName += "_bilateral";
+		} else {
+			growingStrat = new ExhaustiveUnilateralRuptureGrowingStrategy();
+		}
+		if (adaptiveSectFract > 0f) {
+			SectCountAdaptiveRuptureGrowingStrategy adaptiveStrat = new SectCountAdaptiveRuptureGrowingStrategy(
+					growingStrat, adaptiveSectFract, true);
+			configBuilder.add(adaptiveStrat.buildConnPointCleanupFilter(connectionStrategy));
+			outputName += "_sectFractGrow"+adaptiveSectFract;
+			growingStrat = adaptiveStrat;
+		}
 		
 		// build our configuration
 		PlausibilityConfiguration config = configBuilder.build();

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRuptureBuilder.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRuptureBuilder.java
@@ -1161,7 +1161,7 @@ public class ClusterRuptureBuilder {
 		boolean plausibleConnections = true;	// PREF: true
 		// if >0 and <maxDist, connections will only be added above this distance when no other connections exist from
 		// a given subsection. e.g., if set to 5, you can jump more than 5 km but only if no <= 5km jumps exist
-		double adaptiveMinDist = 6d;			// PREF: 0	MOD
+		double adaptiveMinDist = 6d;			// PREF: 6
 		// GROWING STRATEGY
 		// if nonzero, apply thinning to growing strategy
 		float adaptiveSectFract = 0.05f;		// PREF: 0.05

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/PlausibilityConfiguration.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/PlausibilityConfiguration.java
@@ -199,8 +199,8 @@ public class PlausibilityConfiguration {
 			return this;
 		}
 		
-		public Builder noIndirectPaths() {
-			filters.add(new DirectPathPlausibilityFilter(connectionStrategy));
+		public Builder noIndirectPaths(boolean onlyLargerDist) {
+			filters.add(new DirectPathPlausibilityFilter(connectionStrategy, onlyLargerDist));
 			return this;
 		}
 		
@@ -459,11 +459,11 @@ public class PlausibilityConfiguration {
 		GsonBuilder builder = new GsonBuilder();
 		builder.setPrettyPrinting();
 
-		ConnStratTypeAdapter connStratAdapter = new ConnStratTypeAdapter(subSects);
-		builder.registerTypeHierarchyAdapter(ClusterConnectionStrategy.class, connStratAdapter);
-		builder.registerTypeHierarchyAdapter(FaultSection.class, new FaultSectTypeAdapter(subSects));
 		if (distAzCalc == null)
 			distAzCalc = new SectionDistanceAzimuthCalculator(subSects);
+		ConnStratTypeAdapter connStratAdapter = new ConnStratTypeAdapter(subSects, distAzCalc);
+		builder.registerTypeHierarchyAdapter(ClusterConnectionStrategy.class, connStratAdapter);
+		builder.registerTypeHierarchyAdapter(FaultSection.class, new FaultSectTypeAdapter(subSects));
 		DistAzCalcTypeAdapter distAzAdapter = new DistAzCalcTypeAdapter(distAzCalc);
 		builder.registerTypeAdapter(SectionDistanceAzimuthCalculator.class, distAzAdapter);
 		PlausibilityConfigTypeAdapter configAdapter = new PlausibilityConfigTypeAdapter(
@@ -1130,7 +1130,7 @@ public class PlausibilityConfiguration {
 //		String destFileName = "alt_filters.json";
 		
 		// current best
-		builder.cumulativeProbability(0.05f, new RelativeSlipRateProb(connStrat, true));
+		builder.cumulativeProbability(0.05f, new RelativeSlipRateProb(connStrat, true, false));
 		builder.netRupCoulomb(new AggregatedStiffnessCalculator(StiffnessType.CFF, stiffnessCalc, true,
 				AggregationMethod.NUM_POSITIVE, AggregationMethod.SUM, AggregationMethod.SUM, AggregationMethod.THREE_QUARTER_INTERACTIONS), 0f);
 //		RelativeCoulombProb prefCFFProb = new RelativeCoulombProb(sumAgg, connStrat, false, true);

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/DirectPathPlausibilityFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/DirectPathPlausibilityFilter.java
@@ -2,6 +2,8 @@ package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 
@@ -10,25 +12,30 @@ import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterConnectionStrategy;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.RuptureTreeNavigator;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
 import org.opensha.sha.faultSurface.FaultSection;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 
 import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
 
 public class DirectPathPlausibilityFilter implements PlausibilityFilter {
 	
-	private transient HashSet<IDPairing> sectJumps;
+	private transient HashMap<IDPairing, Double> sectJumps;
+	private boolean onlyLargerDist;
 
-	public DirectPathPlausibilityFilter(ClusterConnectionStrategy connStrat) {
-		sectJumps = new HashSet<>();
+	public DirectPathPlausibilityFilter(ClusterConnectionStrategy connStrat, boolean onlyLargerDist) {
+		this.onlyLargerDist = onlyLargerDist;
+		sectJumps = new HashMap<>();
 		for (Jump jump : connStrat.getAllPossibleJumps())
-			sectJumps.add(pairing(jump.fromSection, jump.toSection));
+			sectJumps.put(pairing(jump.fromSection, jump.toSection), jump.distance);
 	}
 	
 	private IDPairing pairing(FaultSection from, FaultSection to) {
@@ -59,19 +66,52 @@ public class DirectPathPlausibilityFilter implements PlausibilityFilter {
 		return result;
 	}
 	
+	private double calcJumpDistBetween(RuptureTreeNavigator nav, FaultSection from, FaultSection to) {
+		double dist = 0d;
+		FaultSection sect = to;
+		while (true) {
+			FaultSection predecessor = nav.getPredecessor(sect);
+			Preconditions.checkNotNull(predecessor, "Didn't find path between %s and %s, stalled out at %s",
+					from.getSectionId(), to.getSectionId(), sect.getSectionId());
+			if (predecessor.getParentSectionId() != sect.getParentSectionId())
+				dist += nav.getJump(predecessor, sect).distance;
+			if (predecessor.equals(from))
+				break;
+			sect = predecessor;
+		}
+		return dist;
+	}
+	
 	private PlausibilityResult evaluate(ClusterRupture rupture, List<FaultSection> prevFroms, boolean verbose) {
 		PlausibilityResult result = PlausibilityResult.PASS;
 		for (Jump jump : rupture.internalJumps) {
 			for (FaultSection prevFrom : prevFroms) {
-				IDPairing[] testPairs;
+				FaultSection[] dests;
 				if (jump.toCluster.subSects.get(0).equals(jump.toSection))
 					// simple jump
-					testPairs = new IDPairing[] { pairing(prevFrom, jump.toSection) };
+					dests = new FaultSection[] { jump.toSection };
 				else
 					// T jump, include both toSection and the start of toCluster
-					testPairs = new IDPairing[] { pairing(prevFrom, jump.toSection), pairing(prevFrom, jump.toCluster.subSects.get(0)) };
-				for (IDPairing pair : testPairs) {
-					if (sectJumps.contains(pair)) {
+					dests = new FaultSection[] { jump.toSection, jump.toCluster.subSects.get(0) };
+				for (FaultSection dest : dests) {
+					IDPairing pair = pairing(prevFrom, dest);
+					if (sectJumps.containsKey(pair)) {
+						// we have taken an indirect path
+						if (onlyLargerDist) {
+							// check and make sure that the indirect path jumped more
+							double directDist = sectJumps.get(pair);
+							if ((float)directDist > 0f) {
+								double myDist = calcJumpDistBetween(rupture.getTreeNavigator(), prevFrom, dest);
+								if ((float)myDist < (float)directDist) {
+									if (verbose)
+										System.out.println(getShortName()+": loopback detected but it used shorter jumps ("
+												+(float)myDist+ " km) than the direct path ("+(float)directDist+" km) between"
+												+prevFrom.getSectionId()+" and "+jump.toSection.getSectionId()+", so it's"
+												+ " allowed");
+									continue;
+								}
+							}
+						}
 						result = PlausibilityResult.FAIL_HARD_STOP;
 						if (verbose)
 							System.out.println(getShortName()+": loopback detected. Could have jumped directly from "
@@ -118,14 +158,20 @@ public class DirectPathPlausibilityFilter implements PlausibilityFilter {
 		@Override
 		public void write(JsonWriter out, PlausibilityFilter value) throws IOException {
 			out.beginObject();
+			out.name("onlyLargerDist").value(((DirectPathPlausibilityFilter)value).onlyLargerDist);
 			out.endObject();
 		}
 
 		@Override
 		public PlausibilityFilter read(JsonReader in) throws IOException {
 			in.beginObject();
+			boolean onlyLargerDist = false;
+			if (in.peek() == JsonToken.NAME) {
+				Preconditions.checkState(in.nextName().equals("onlyLargerDist"));
+				onlyLargerDist = in.nextBoolean();
+			}
 			in.endObject();
-			return new DirectPathPlausibilityFilter(connStrategy);
+			return new DirectPathPlausibilityFilter(connStrategy, onlyLargerDist);
 		}
 		
 	}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/SplayConnectionsOnlyFilter.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/SplayConnectionsOnlyFilter.java
@@ -1,35 +1,30 @@
 package org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
-import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterConnectionStrategy;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.RuptureTreeNavigator;
-import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
 import org.opensha.sha.faultSurface.FaultSection;
 
 import com.google.common.base.Preconditions;
-import com.google.gson.Gson;
-import com.google.gson.TypeAdapter;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 
 import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
 
 public class SplayConnectionsOnlyFilter implements PlausibilityFilter {
 	
-	private boolean allowSectionEnd;
+	private ClusterConnectionStrategy connStrat;
+	private boolean applyToMainStrand;
 	
 	private transient Map<Integer, FaultSubsectionCluster> fullClusters;
 
-	public SplayConnectionsOnlyFilter(boolean applyToMainStrand) {
-//		this.applyToMainStrand = applyToMainStrand;
+	public SplayConnectionsOnlyFilter(ClusterConnectionStrategy connStrat, boolean applyToMainStrand) {
+		this.connStrat = connStrat;
+		this.applyToMainStrand = applyToMainStrand;
 	}
 
 	@Override
@@ -45,13 +40,13 @@ public class SplayConnectionsOnlyFilter implements PlausibilityFilter {
 	private FaultSubsectionCluster getFullCluster(Integer parentID) {
 		if (fullClusters == null) {
 			synchronized (this) {
-//				if (fullClusters == null) {
-//					List<FaultSubsectionCluster> clusters = connStrat.getClusters();
-//					Map<Integer, FaultSubsectionCluster> fullClusters = new HashMap<>();
-//					for (FaultSubsectionCluster cluster : clusters)
-//						fullClusters.put(cluster.parentSectionID, cluster);
-//					this.fullClusters = fullClusters;
-//				}
+				if (fullClusters == null) {
+					List<FaultSubsectionCluster> clusters = connStrat.getClusters();
+					Map<Integer, FaultSubsectionCluster> fullClusters = new HashMap<>();
+					for (FaultSubsectionCluster cluster : clusters)
+						fullClusters.put(cluster.parentSectionID, cluster);
+					this.fullClusters = fullClusters;
+				}
 			}
 		}
 		return fullClusters.get(parentID);
@@ -62,8 +57,8 @@ public class SplayConnectionsOnlyFilter implements PlausibilityFilter {
 		if (rupture.splays.isEmpty())
 			return PlausibilityResult.PASS;
 		RuptureTreeNavigator nav = rupture.getTreeNavigator();
-//		if (applyToMainStrand)
-//			return doApply(rupture, nav);
+		if (applyToMainStrand)
+			return doApply(rupture, nav);
 		PlausibilityResult result = PlausibilityResult.PASS;
 		for (ClusterRupture splay : rupture.splays.values())
 			result = result.logicalAnd(doApply(splay, nav));

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/path/SectCoulombPathEvaluator.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/path/SectCoulombPathEvaluator.java
@@ -47,7 +47,7 @@ public class SectCoulombPathEvaluator extends ScalarCoulombPathEvaluator {
 				maxSearchDist, jump.fromCluster, jump.toCluster);
 		if (allowedJumps.size() == 1) {
 			if (verbose)
-				System.out.println("Only 1 possible jump: "+allowedJumps.get(0));
+				System.out.println("Only 1 possible jump: "+allowedJumps.get(0).getSectionId());
 			return allowedJumps.get(0);
 		}
 		// find the most favorable one
@@ -133,6 +133,10 @@ public class SectCoulombPathEvaluator extends ScalarCoulombPathEvaluator {
 	
 	public void init(ClusterConnectionStrategy connStrat, SectionDistanceAzimuthCalculator distAzCalc) {
 		this.distAzCalc = distAzCalc;
+	}
+	
+	public void setMaxJumpDist(float maxJumpDist) {
+		this.maxJumpDist = maxJumpDist;
 	}
 	
 	@Override

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/prob/CoulombSectRatioProb.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/prob/CoulombSectRatioProb.java
@@ -47,6 +47,10 @@ public class CoulombSectRatioProb implements RuptureProbabilityCalc {
 		this.distAzCalc = distAzCalc;
 	}
 	
+	public void setMaxJumpDist(float maxJumpDist) {
+		this.maxJumpDist = maxJumpDist;
+	}
+	
 	public AggregatedStiffnessCalculator getAggregator() {
 		return aggCalc;
 	}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/prob/RelativeSlipRateProb.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/prob/RelativeSlipRateProb.java
@@ -24,8 +24,8 @@ public class RelativeSlipRateProb extends AbstractRelativeProb {
 	
 	private boolean onlyAtIncreases;
 
-	public RelativeSlipRateProb(ClusterConnectionStrategy connStrat, boolean onlyAtIncreases) {
-		super(connStrat, false, true); // never negative, always relative to best
+	public RelativeSlipRateProb(ClusterConnectionStrategy connStrat, boolean onlyAtIncreases, boolean includeLongerJumps) {
+		super(connStrat, false, true, includeLongerJumps); // never negative, always relative to best
 		this.onlyAtIncreases = onlyAtIncreases;
 	}
 	

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/DistCutoffClosestSectClusterConnectionStrategy.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/DistCutoffClosestSectClusterConnectionStrategy.java
@@ -18,7 +18,7 @@ public class DistCutoffClosestSectClusterConnectionStrategy extends ClusterConne
 
 	public DistCutoffClosestSectClusterConnectionStrategy(List<? extends FaultSection> subSects,
 			SectionDistanceAzimuthCalculator distCalc, double maxJumpDist) {
-		super(subSects);
+		super(subSects, distCalc);
 		this.maxJumpDist = maxJumpDist;
 		this.distCalc = distCalc;
 	}
@@ -26,7 +26,7 @@ public class DistCutoffClosestSectClusterConnectionStrategy extends ClusterConne
 	public DistCutoffClosestSectClusterConnectionStrategy(List<? extends FaultSection> subSects,
 			List<FaultSubsectionCluster> clusters, SectionDistanceAzimuthCalculator distCalc,
 			double maxJumpDist) {
-		super(subSects, clusters);
+		super(subSects, clusters, distCalc);
 		this.maxJumpDist = maxJumpDist;
 		this.distCalc = distCalc;
 	}

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/InputJumpsOrDistClusterConnectionStrategy.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/InputJumpsOrDistClusterConnectionStrategy.java
@@ -26,7 +26,7 @@ public class InputJumpsOrDistClusterConnectionStrategy extends ClusterConnection
 
 	public InputJumpsOrDistClusterConnectionStrategy(List<? extends FaultSection> subSects,
 			SectionDistanceAzimuthCalculator distCalc, double maxJumpDist, Collection<Jump> inputJumps) {
-		super(subSects);
+		super(subSects, distCalc);
 		this.maxJumpDist = maxJumpDist;
 		this.distCalc = distCalc;
 		initAllowedSectConnections(inputJumps);
@@ -35,7 +35,7 @@ public class InputJumpsOrDistClusterConnectionStrategy extends ClusterConnection
 	public InputJumpsOrDistClusterConnectionStrategy(List<? extends FaultSection> subSects,
 			List<FaultSubsectionCluster> clusters, SectionDistanceAzimuthCalculator distCalc,
 			double maxJumpDist, Collection<Jump> inputJumps) {
-		super(subSects, clusters);
+		super(subSects, clusters, distCalc);
 		this.maxJumpDist = maxJumpDist;
 		this.distCalc = distCalc;
 		initAllowedSectConnections(inputJumps);

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/NoConnectivityStrategy.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/NoConnectivityStrategy.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
 import org.opensha.sha.faultSurface.FaultSection;
 
 /**
@@ -14,12 +15,13 @@ import org.opensha.sha.faultSurface.FaultSection;
  */
 public class NoConnectivityStrategy extends ClusterConnectionStrategy {
 
-	public NoConnectivityStrategy(List<? extends FaultSection> subSections, List<FaultSubsectionCluster> clusters) {
-		super(subSections, clusters);
+	public NoConnectivityStrategy(List<? extends FaultSection> subSections, List<FaultSubsectionCluster> clusters,
+			SectionDistanceAzimuthCalculator distCalc) {
+		super(subSections, clusters, distCalc);
 	}
 
-	public NoConnectivityStrategy(List<? extends FaultSection> subSections) {
-		super(subSections);
+	public NoConnectivityStrategy(List<? extends FaultSection> subSections, SectionDistanceAzimuthCalculator distCalc) {
+		super(subSections, distCalc);
 	}
 
 	@Override

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/PrecomputedClusterConnectionStrategy.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/PrecomputedClusterConnectionStrategy.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.opensha.commons.util.IDPairing;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
 import org.opensha.sha.faultSurface.FaultSection;
 
 import com.google.common.collect.HashMultimap;
@@ -16,8 +17,8 @@ class PrecomputedClusterConnectionStrategy extends ClusterConnectionStrategy {
 	private double maxJumpDist;
 
 	PrecomputedClusterConnectionStrategy(String name, List<? extends FaultSection> subSections,
-			List<FaultSubsectionCluster> clusters, double maxJumpDist) {
-		super(subSections, clusters);
+			List<FaultSubsectionCluster> clusters, double maxJumpDist, SectionDistanceAzimuthCalculator distCalc) {
+		super(subSections, clusters, distCalc);
 		this.name = name;
 		this.maxJumpDist = maxJumpDist;
 		this.connectionsAdded = true;

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/UCERF3ClusterConnectionStrategy.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/UCERF3ClusterConnectionStrategy.java
@@ -20,7 +20,7 @@ public class UCERF3ClusterConnectionStrategy extends ClusterConnectionStrategy {
 
 	public UCERF3ClusterConnectionStrategy(List<? extends FaultSection> subSects,
 			SectionDistanceAzimuthCalculator distCalc, double maxJumpDist, CoulombRates coulombRates) {
-		super(subSects);
+		super(subSects, distCalc);
 		this.distCalc = distCalc;
 		this.maxJumpDist = maxJumpDist;
 		this.coulombRates = coulombRates;

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/ClusterRupturePerturbationBuilder.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/ClusterRupturePerturbationBuilder.java
@@ -12,15 +12,18 @@ import java.util.zip.ZipException;
 import org.dom4j.DocumentException;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRuptureBuilder;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRuptureBuilder.*;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityConfiguration;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityConfiguration.Builder;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.path.CumulativeProbPathEvaluator;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.path.NucleationClusterEvaluator;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.path.PathPlausibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.path.SectCoulombPathEvaluator;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.prob.CoulombSectRatioProb;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.prob.CumulativeProbabilityFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.prob.RelativeCoulombProb;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.prob.RuptureProbabilityCalc;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.prob.Shaw07JumpDistProb;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.CumulativeAzimuthChangeFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.CumulativeRakeChangeFilter;
@@ -29,6 +32,7 @@ import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.Sp
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.SplayLengthFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.U3CompatibleCumulativeRakeChangeFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.coulomb.NetRuptureCoulombFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.AdaptiveClusterConnectionStrategy;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterConnectionStrategy;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.RuptureGrowingStrategy;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.DistCutoffClosestSectClusterConnectionStrategy;
@@ -65,9 +69,15 @@ public class ClusterRupturePerturbationBuilder {
 //		File primaryFile = new File(rupSetsDir, "fm3_1_plausible10km_direct_slipP0.05incr_cff0.75IntsPos_comb2Paths_cffFavP0.02_cffFavRatioN2P0.5_sectFractPerm0.05.zip");
 //		String primaryName = "Plausible 10km (MultiEnds), Slip P>0.05 (@Incr), CFF 3/4 Ints >0, CFF Comb Paths: [Sect R>0.5, P>0.02], 5% Fract Increase";
 //		File primaryFile = new File(rupSetsDir, "fm3_1_plausibleMulti10km_direct_slipP0.05incr_cff0.75IntsPos_comb2Paths_cffFavP0.02_cffFavRatioN2P0.5_sectFractPerm0.05.zip");
-		String primaryName = "Plausible 10km (MultiEnds), Rake≤360, Jump P>0.001, Slip P>0.05 (@Incr), CFF 3/4 Ints >0, CFF Comb Paths: [Sect R>0.5, P>0.01], 5% Fract Increase";
-		File primaryFile = new File(rupSetsDir, "fm3_1_plausibleMulti10km_direct_cmlRake360_jumpP0.001_slipP0.05incr_cff0.75IntsPos_comb2Paths_cffFavP0.01_cffFavRatioN2P0.5_sectFractGrow0.05.zip");
-		RuptureGrowingStrategy growingStrat = new SectCountAdaptiveRuptureGrowingStrategy(0.05f, true);
+//		String primaryName = "Plausible 10km (MultiEnds), Rake≤360, Jump P>0.001, Slip P>0.05 (@Incr), CFF 3/4 Ints >0, CFF Comb Paths: [Sect R>0.5, P>0.01], 5% Fract Increase";
+//		File primaryFile = new File(rupSetsDir, "fm3_1_plausibleMulti10km_direct_cmlRake360_jumpP0.001_slipP0.05incr_cff0.75IntsPos_comb2Paths_cffFavP0.01_cffFavRatioN2P0.5_sectFractGrow0.05.zip");
+//		String primaryName = "Plausible 10km (MultiEnds), Rake≤360, Jump P>0.001, Slip P>0.05 (@Incr), CFF 3/4 Ints >0, CFF Comb Paths: [Sect R>0.5, P>0.01], 5% Fract Increase";
+//		File primaryFile = new File(rupSetsDir, "fm3_1_plausibleMulti10km_direct_cmlRake360_jumpP0.001_slipP0.05incrCapDist_cff0.75IntsPos_comb2Paths_cffFavP0.01_cffFavRatioN2P0.5_sectFractGrow0.05.zip");
+//		String primaryName = "Plausible Adaptive 5-10km (MultiEnds), Rake≤360, Jump P>0.001, Slip P>0.05 (@Incr), CFF 3/4 Ints >0, CFF Comb Paths: [Sect R>0.5, P>0.01], 5% Fract Increase";
+//		File primaryFile = new File(rupSetsDir, "fm3_1_plausibleMulti10km_adaptive5km_direct_cmlRake360_jumpP0.001_slipP0.05incrCapDist_cff0.75IntsPos_comb2Paths_cffFavP0.01_cffFavRatioN2P0.5_sectFractGrow0.05.zip");
+		String primaryName = "Plausible Adaptive 6-15km (MultiEnds), Rake≤360, Jump P>0.001, Slip P>0.05 (@Incr), CFF 3/4 Ints >0, CFF Comb Paths: [Sect R>0.5, P>0.01], 5% Fract Increase";
+		File primaryFile = new File(rupSetsDir, "fm3_1_plausibleMulti15km_adaptive6km_direct_cmlRake360_jumpP0.001_slipP0.05incrCapDist_cff0.75IntsPos_comb2Paths_cffFavP0.01_cffFavRatioN2P0.5_sectFractGrow0.05.zip");
+		RuptureGrowingStrategy primaryGrowingStrat = new SectCountAdaptiveRuptureGrowingStrategy(0.05f, true);
 		ScalingRelationships scale = ScalingRelationships.MEAN_UCERF3;
 		boolean rebuild = false;
 		boolean replot = false;
@@ -80,7 +90,6 @@ public class ClusterRupturePerturbationBuilder {
 		
 		// alternate connection strategies
 		SectionDistanceAzimuthCalculator distAzCalc = primaryConfig.getDistAzCalc();
-		DistCutoffClosestSectClusterConnectionStrategy neighborsConnStrat = new DistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, 0.1d);
 		SubSectStiffnessCalculator stiffnessCalc = new SubSectStiffnessCalculator(
 				subSects, 2d, 3e4, 3e4, 0.5, PatchAlignment.FILL_OVERLAP, 1d);
 		AggregatedStiffnessCalculator sumAgg = new AggregatedStiffnessCalculator(StiffnessType.CFF, stiffnessCalc, true,
@@ -93,25 +102,56 @@ public class ClusterRupturePerturbationBuilder {
 		float cffRatioThresh = 0.5f;
 		float cffRelativeProb = 0.01f;
 		boolean favorableJumps = true;
-		double[] altJumpDists = { 5d, 15d };
+		double[] altJumpDists = { 5d, 6d, 8d, 10d, 15d, 20d };
+		double adaptiveR0 = 6d;
 		
+		System.out.println("Initializing alt connection strategies");
 		double origMaxJumpDist = primaryConfig.getConnectionStrategy().getMaxJumpDist();
 		List<ClusterConnectionStrategy> altConnStrats = new ArrayList<>();
 		altConnStrats.add(new DistCutoffClosestSectClusterConnectionStrategy(rupSet.getFaultSectionDataList(),
 				primaryConfig.getDistAzCalc(), origMaxJumpDist));
-		altConnStrats.add(new PlausibleClusterConnectionStrategy(subSects, distAzCalc, origMaxJumpDist,
-				new FallbackJumpSelector(true, new PassesMinimizeFailedSelector(), new BestScalarSelector(2d)),
-				buildPlausibleConnFilters(distAzCalc, neighborsConnStrat, sumAgg,
-						fractIntsAgg, cffFractInts, cffRatioN, cffRatioThresh, cffRelativeProb, favorableJumps,
-						origMaxJumpDist)));
-		for (double maxJumpDist : altJumpDists) {
-			List<PlausibilityFilter> connFilters = buildPlausibleConnFilters(distAzCalc, neighborsConnStrat, sumAgg,
-					fractIntsAgg, cffFractInts, cffRatioN, cffRatioThresh, cffRelativeProb, favorableJumps,
-					maxJumpDist);
-			altConnStrats.add(new PlausibleClusterConnectionStrategy(subSects, distAzCalc, maxJumpDist,
-					PlausibleClusterConnectionStrategy.JUMP_SELECTOR_DEFAULT, connFilters));
+		List<PlausibilityFilter> origConnFilters = buildPlausibleConnFilters(
+				distAzCalc, new DistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, 0.1d), sumAgg,
+				fractIntsAgg, cffFractInts, cffRatioN, cffRatioThresh, cffRelativeProb, favorableJumps,
+				origMaxJumpDist);
+		ClusterConnectionStrategy singleConnStrat = new PlausibleClusterConnectionStrategy(subSects, distAzCalc, origMaxJumpDist,
+				PlausibleClusterConnectionStrategy.JUMP_SELECTOR_DEFAULT_SINGLE, origConnFilters);
+		if (adaptiveR0 > 0d) {
+			// add regular distance cutoff, but adaptive
+			altConnStrats.add(new AdaptiveClusterConnectionStrategy(altConnStrats.get(0), adaptiveR0, 1));
+			// add single conn
+			altConnStrats.add(new AdaptiveClusterConnectionStrategy(singleConnStrat, adaptiveR0, 1));
+			// add regular but non-adaptive
+			altConnStrats.add(new PlausibleClusterConnectionStrategy(subSects, distAzCalc, origMaxJumpDist,
+					PlausibleClusterConnectionStrategy.JUMP_SELECTOR_DEFAULT, origConnFilters));
+			// add different adaptive distances
+			for (double altR0 : altJumpDists) {
+				if ((float)altR0 != (float)adaptiveR0 && (float)altR0 < (float)origMaxJumpDist) {
+					PlausibleClusterConnectionStrategy plausible = new PlausibleClusterConnectionStrategy(subSects, distAzCalc, origMaxJumpDist,
+							PlausibleClusterConnectionStrategy.JUMP_SELECTOR_DEFAULT, origConnFilters);
+					altConnStrats.add(new AdaptiveClusterConnectionStrategy(plausible, altR0, 1));
+				}
+			}
+		} else {
+			altConnStrats.add(singleConnStrat);
 		}
 		
+		for (double maxJumpDist : altJumpDists) {
+			if ((float)maxJumpDist == (float)origMaxJumpDist)
+				continue;
+			List<PlausibilityFilter> connFilters = buildPlausibleConnFilters(
+					distAzCalc, new DistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, 0.1d), sumAgg,
+					fractIntsAgg, cffFractInts, cffRatioN, cffRatioThresh, cffRelativeProb, favorableJumps,
+					maxJumpDist);
+			PlausibleClusterConnectionStrategy plausible = new PlausibleClusterConnectionStrategy(subSects, distAzCalc, maxJumpDist,
+					PlausibleClusterConnectionStrategy.JUMP_SELECTOR_DEFAULT, connFilters);
+			if (adaptiveR0 > 0d && (float)adaptiveR0 < (float)maxJumpDist)
+				altConnStrats.add(new AdaptiveClusterConnectionStrategy(plausible, adaptiveR0, 1));
+			else
+				altConnStrats.add(plausible);
+		}
+		
+		System.out.println("Initializing alt growing strategies");
 		// alternate growing strategies
 		List<RuptureGrowingStrategy> altGrowStrats = new ArrayList<>();
 		altGrowStrats.add(new ExhaustiveUnilateralRuptureGrowingStrategy());
@@ -133,8 +173,9 @@ public class ClusterRupturePerturbationBuilder {
 		File outputDir = new File(rupSetsDir, primaryPrefix+"_comp");
 		Preconditions.checkState(outputDir.exists() || outputDir.mkdir());
 
+		System.out.println("Adding filter-removal configs");
 		List<PlausibilityConfiguration> configs = new ArrayList<>();
-		List<RuptureGrowingStrategy> permStrats = new ArrayList<>();
+		List<RuptureGrowingStrategy> growingStrats = new ArrayList<>();
 		List<String> names = new ArrayList<>();
 		List<String> prefixes = new ArrayList<>();
 		// add filter removal configurations
@@ -161,7 +202,7 @@ public class ClusterRupturePerturbationBuilder {
 					configs.add(new PlausibilityConfiguration(myFilters, primaryConfig.getMaxNumSplays(), primaryConnStrat, distAzCalc));
 					names.add("Sans Filter: "+evals[e].getName());
 					prefixes.add("sans_"+fileSafe(evals[e].getShortName()));
-					permStrats.add(growingStrat);
+					growingStrats.add(primaryGrowingStrat);
 				}
 				// now add one version where they're separate paths
 				List<PlausibilityFilter> myFilters = new ArrayList<>(otherFilters);
@@ -170,24 +211,25 @@ public class ClusterRupturePerturbationBuilder {
 				configs.add(new PlausibilityConfiguration(myFilters, primaryConfig.getMaxNumSplays(), primaryConnStrat, distAzCalc));
 				names.add(evals.length+" Path Filters Separated");
 				prefixes.add("separate_paths");
-				permStrats.add(growingStrat);
+				growingStrats.add(primaryGrowingStrat);
 			} else {
 				configs.add(new PlausibilityConfiguration(otherFilters, primaryConfig.getMaxNumSplays(), primaryConnStrat, distAzCalc));
 				names.add("Sans Filter: "+filter.getName());
 				prefixes.add("sans_"+fileSafe(filter.getShortName()));
-				permStrats.add(growingStrat);
+				growingStrats.add(primaryGrowingStrat);
 			}
 		}
 		
+		System.out.println("Adding UCERF3-related alternatives");
 		// add UCERF3 filters
 		Builder builder = PlausibilityConfiguration.builder(primaryConnStrat, distAzCalc).minSectsPerParent(2, true, true).u3Azimuth()
 				.cumulativeRakeChange(180f).cumulativeAzChange(560f);
-		if (growingStrat instanceof SectCountAdaptiveRuptureGrowingStrategy)
-			builder.add(((SectCountAdaptiveRuptureGrowingStrategy)growingStrat).buildConnPointCleanupFilter(primaryConnStrat));
+		if (primaryGrowingStrat instanceof SectCountAdaptiveRuptureGrowingStrategy)
+			builder.add(((SectCountAdaptiveRuptureGrowingStrategy)primaryGrowingStrat).buildConnPointCleanupFilter(primaryConnStrat));
 		configs.add(builder.build());
 		names.add("UCERF3 Azimuth & Cumulative Filters");
 		prefixes.add("ucerf_filters_sans_coulomb");
-		permStrats.add(growingStrat);
+		growingStrats.add(primaryGrowingStrat);
 
 		boolean hasCmlAz = false;
 		for (PlausibilityFilter filter : filters)
@@ -200,7 +242,7 @@ public class ClusterRupturePerturbationBuilder {
 			configs.add(PlausibilityConfiguration.builder(primaryConnStrat, distAzCalc).addAll(plusAz).build());
 			names.add("Add Cumulative Azimuth");
 			prefixes.add("add_CumulativeAzimuth");
-			permStrats.add(growingStrat);
+			growingStrats.add(primaryGrowingStrat);
 		}
 		
 		boolean hasCmlRake = false;
@@ -214,7 +256,7 @@ public class ClusterRupturePerturbationBuilder {
 			configs.add(PlausibilityConfiguration.builder(primaryConnStrat, distAzCalc).addAll(plusRake).build());
 			names.add("Add Cumulative Rake<=180");
 			prefixes.add("add_CumulativeRake");
-			permStrats.add(growingStrat);
+			growingStrats.add(primaryGrowingStrat);
 		}
 		
 		boolean hasCmlJump = false;
@@ -236,7 +278,7 @@ public class ClusterRupturePerturbationBuilder {
 			configs.add(PlausibilityConfiguration.builder(primaryConnStrat, distAzCalc).addAll(withoutRakeJump).build());
 			names.add("Sans Filters: Cumulative Rake & Jump Distance");
 			prefixes.add("sans_CumulativeRakeAndJump");
-			permStrats.add(growingStrat);
+			growingStrats.add(primaryGrowingStrat);
 		}
 		
 		// add UCERF3 filters
@@ -245,14 +287,15 @@ public class ClusterRupturePerturbationBuilder {
 		builder.add(new CumulativeProbabilityFilter(cffRatioThresh, new CoulombSectRatioProb(
 				sumAgg, cffRatioN, favorableJumps, (float)primaryConnStrat.getMaxJumpDist(), distAzCalc)));
 		builder.add(new NetRuptureCoulombFilter(fractIntsAgg, cffFractInts));
-		if (growingStrat instanceof SectCountAdaptiveRuptureGrowingStrategy)
-			builder.add(((SectCountAdaptiveRuptureGrowingStrategy)growingStrat).buildConnPointCleanupFilter(primaryConnStrat));
+		if (primaryGrowingStrat instanceof SectCountAdaptiveRuptureGrowingStrategy)
+			builder.add(((SectCountAdaptiveRuptureGrowingStrategy)primaryGrowingStrat).buildConnPointCleanupFilter(primaryConnStrat));
 		configs.add(builder.build());
 		names.add("UCERF3 Cumulative Filters, New CFF Ratio & 3/4 Interactions");
 		prefixes.add("ucerf3_cumulatives_cffRatio_cffInteractions");
-		permStrats.add(growingStrat);
+		growingStrats.add(primaryGrowingStrat);
 		
 		if (altGrowStrats != null) {
+			System.out.println("Adding alt gorwing strategies");
 			for (RuptureGrowingStrategy altPermStrat : altGrowStrats) {
 				List<PlausibilityFilter> otherFilters = new ArrayList<>();
 				for (PlausibilityFilter filter : filters)
@@ -263,20 +306,52 @@ public class ClusterRupturePerturbationBuilder {
 				configs.add(new PlausibilityConfiguration(otherFilters, primaryConfig.getMaxNumSplays(), primaryConnStrat, distAzCalc));
 				names.add("Alt Growing: "+altPermStrat.getName());
 				prefixes.add("alt_grow_"+fileSafe(altPermStrat.getName()));
-				permStrats.add(altPermStrat);
+				growingStrats.add(altPermStrat);
 			}
 		}
 		
+		int threads = Integer.max(1, Integer.min(31, Runtime.getRuntime().availableProcessors()-2));
+		
 		if (altConnStrats != null && altConnStrats.size() > 0) {
+			System.out.println("Adding alt connection strategies");
+			String filtersJSON = primaryConfig.filtersToJSON(filters);
+//			System.out.println("Original filters JSON:");
+//			System.out.println(filtersJSON);
 			for (ClusterConnectionStrategy altConnStrat : altConnStrats) {
 				// filters can use the connection strategy, so need to build new ones (through serialization)
-				String filtersJSON = primaryConfig.filtersToJSON(filters);
+				altConnStrat.checkBuildThreaded(threads);
+				// update distances
 				List<PlausibilityFilter> altFilters = PlausibilityConfiguration.readFiltersJSON(filtersJSON, altConnStrat, distAzCalc);
+				if ((float)altConnStrat.getMaxJumpDist() != (float)primaryConnStrat.getMaxJumpDist()) {
+					System.out.println("Chekcing for Max Jump Dist updates...");
+					for (PlausibilityFilter filter : altFilters) {
+						if (filter instanceof CumulativeProbabilityFilter) {
+							for (RuptureProbabilityCalc calc : ((CumulativeProbabilityFilter) filter).getProbCalcs())
+								checkUpdateProbCalcJumpDist((float)altConnStrat.getMaxJumpDist(), calc);
+						} else if (filter instanceof PathPlausibilityFilter) {
+							for (NucleationClusterEvaluator nuclEval : ((PathPlausibilityFilter) filter).getEvaluators()) {
+								if (nuclEval instanceof CumulativeProbPathEvaluator) {
+									for (RuptureProbabilityCalc calc : ((CumulativeProbPathEvaluator) nuclEval).getCalcs())
+										checkUpdateProbCalcJumpDist((float)altConnStrat.getMaxJumpDist(), calc);
+								} else if (nuclEval instanceof SectCoulombPathEvaluator) {
+									((SectCoulombPathEvaluator)nuclEval).setMaxJumpDist((float)altConnStrat.getMaxJumpDist());
+									System.out.println("Updated "+nuclEval.getName()+" to "+(float)altConnStrat.getMaxJumpDist()+"km");
+								}
+							}
+						}
+					}
+				}
 				configs.add(new PlausibilityConfiguration(altFilters, primaryConfig.getMaxNumSplays(), altConnStrat, distAzCalc));
+
+//				if (altConnStrat.getName().contains("15")) {
+//					System.out.println("Mod filters JSON");
+//					System.out.println(configs.get(configs.size()-1).filtersToJSON(altFilters));
+//				}
 				names.add("Alt Connections: "+altConnStrat.getName());
 				prefixes.add("alt_conn_"+fileSafe(altConnStrat.getName()));
-				permStrats.add(growingStrat);
+				growingStrats.add(primaryGrowingStrat);
 			}
+//			System.exit(0);
 		}
 		
 		if (primaryConfig.getMaxNumSplays() > 0) {
@@ -287,10 +362,11 @@ public class ClusterRupturePerturbationBuilder {
 			configs.add(new PlausibilityConfiguration(otherFilters, 0, primaryConnStrat, distAzCalc));
 			names.add("Sans: Splays");
 			prefixes.add("sans_sect_increase_thinning");
-			permStrats.add(growingStrat);
+			growingStrats.add(primaryGrowingStrat);
 		}
 
 		// see if we should load any coulomb cache
+		System.out.println("Loading Coulomb caches");
 		Map<String, List<AggregatedStiffnessCache>> loadedCoulombCaches = new HashMap<>();
 		RupSetDiagnosticsPageGen.checkLoadCoulombCache(filters, rupSetsDir, loadedCoulombCaches);
 		
@@ -305,8 +381,6 @@ public class ClusterRupturePerturbationBuilder {
 			Preconditions.checkState(!prevPrefixes.contains(prefix), "Duplicate prefix: %s", prefix);
 			prevPrefixes.add(prefix);
 		}
-		
-		int threads = Integer.max(1, Integer.min(31, Runtime.getRuntime().availableProcessors()-2));
 		
 		// add pure UCERF3
 		if (subSects.size() == 2606) {
@@ -330,7 +404,7 @@ public class ClusterRupturePerturbationBuilder {
 			String name = names.get(i);
 			String prefix = prefixes.get(i);
 			System.out.println("Processing alternative: "+name);
-			RuptureGrowingStrategy permStrat = permStrats.get(i);
+			RuptureGrowingStrategy permStrat = growingStrats.get(i);
 			
 			File outputFile = new File(outputDir, prefix+".zip");
 			System.out.println("RupSet file: "+outputFile.getAbsolutePath());
@@ -339,6 +413,9 @@ public class ClusterRupturePerturbationBuilder {
 			if (rebuild || !outputFile.exists()) {
 				System.out.println("Building...");
 				ClusterRuptureBuilder build = new ClusterRuptureBuilder(altConfig);
+				
+//				build.setDebugCriteria(new SectsRupDebugCriteria(false, false,
+//						ClusterRuptureBuilder.loadRupString("[667:12,11,10,9,8,7,6][696:2534,2535]", false)), true);
 				
 				List<ClusterRupture> rups = build.build(permStrat, threads);
 				
@@ -401,6 +478,16 @@ public class ClusterRupturePerturbationBuilder {
 		while (str.contains("__"))
 			str = str.replace("__", "_");
 		return str.replaceAll("\\W+", "");
+	}
+	
+	private static void checkUpdateProbCalcJumpDist(float newJumpDist, RuptureProbabilityCalc calc) {
+		if (calc instanceof RelativeCoulombProb) {
+			((RelativeCoulombProb) calc).setMaxJumpDist(newJumpDist);
+			System.out.println("Updated "+calc.getName()+" to "+newJumpDist+"km");
+		} else if (calc instanceof CoulombSectRatioProb) {
+			((CoulombSectRatioProb) calc).setMaxJumpDist(newJumpDist);
+			System.out.println("Updated "+calc.getName()+" to "+newJumpDist+"km");
+		}
 	}
 
 }

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/ClusterRupturePlausibilityDebug.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/ClusterRupturePlausibilityDebug.java
@@ -49,7 +49,11 @@ public class ClusterRupturePlausibilityDebug {
 //						+ "nz_demo5_crustal_slipP0.01incr_cff3_4_IntsPos_comb3Paths_cffP0.01_cffSPathFav15_cffCPathRPatchHalfPos_sectFractPerm0.05.zip"));
 //						+ "fm3_1_plausible10km_direct_slipP0.05incr_cff0.75IntsPos_comb2Paths_cffFavP0.02_cffFavRatioN2P0.5_sectFractPerm0.05.zip"));
 //						+ "fm3_1_plausibleMulti10km_direct_cmlRake180_jumpP0.001_slipP0.05incr_cff0.75IntsPos_comb2Paths_cffFavP0.01_cffFavRatioN2P0.25_sectFractPerm0.05.zip"));
-						+ "rsqsim_4983_stitched_m6.5_skip65000_sectArea0.5.zip"));
+//						+ "rsqsim_4983_stitched_m6.5_skip65000_sectArea0.5.zip"));
+//						+ "fm3_1_plausibleMulti15km_direct_cmlRake360_jumpP0.001_slipP0.05incrCapDist_cff0.75IntsPos_comb2Paths_cffFavP0.01_cffFavRatioN2P0.5_sectFractGrow0.05.zip"));
+						+ "fm3_1_plausibleMulti10km_adaptive5km_direct_cmlRake360_jumpP0.001_slipP0.05incrCapDist_cff0.75IntsPos_comb2Paths_"
+						+ "cffFavP0.01_cffFavRatioN2P0.5_sectFractGrow0.05_comp/alt_conn_Adaptive_r05p0km_sectMax1_Plausible_3filters_"
+						+ "maxDist15km_MultiEnds.zip"));
 		System.out.println("Loaded "+rupSet.getNumRuptures()+" ruptures");
 		
 		PlausibilityConfiguration config = rupSet.getPlausibilityConfiguration();
@@ -65,7 +69,7 @@ public class ClusterRupturePlausibilityDebug {
 		}
 		
 //		int[] testIndexes = { 372703 };
-		int[] testIndexes = { 173179 };
+		int[] testIndexes = { 141968 };
 		
 		List<ClusterRupture> testRuptures = new ArrayList<>();
 		for (int testIndex : testIndexes)

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RupSetFilterComparePageGen.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RupSetFilterComparePageGen.java
@@ -81,11 +81,15 @@ public class RupSetFilterComparePageGen {
 
 	public static void main(String[] args) throws IOException, DocumentException {
 		File rupSetsDir = new File("/home/kevin/OpenSHA/UCERF4/rup_sets");
+
+//		String inputName = "RSQSim 4983, SectArea=0.5";
+//		File inputFile = new File(rupSetsDir, "rsqsim_4983_stitched_m6.5_skip65000_sectArea0.5.zip");
+////		File inputFile = new File(rupSetsDir, "rsqsim_4983_stitched_m6.5_skip65000_sectArea0.5_unique.zip");
+//		File distAzCache = new File(rupSetsDir, "fm3_1_dist_az_cache.csv");
+		String inputName = "RSQSim 5133, SectArea=0.5";
+		File inputFile = new File(rupSetsDir, "rsqsim_5133_m6_skip50000_sectArea0.5.zip");
+		File distAzCache = null;
 		
-		String inputName = "RSQSim 4983, SectArea=0.5";
-		File inputFile = new File(rupSetsDir, "rsqsim_4983_stitched_m6.5_skip65000_sectArea0.5.zip");
-//		File inputFile = new File(rupSetsDir, "rsqsim_4983_stitched_m6.5_skip65000_sectArea0.5_unique.zip");
-		File distAzCache = new File(rupSetsDir, "fm3_1_dist_az_cache.csv");
 		File altFiltersFile = new File(rupSetsDir, "u3_az_cff_cmls.json");
 		String altName = "UCERF3";
 		
@@ -118,7 +122,7 @@ public class RupSetFilterComparePageGen {
 		FaultSystemRupSet rupSet = FaultSystemIO.loadRupSet(inputFile);
 		
 		SectionDistanceAzimuthCalculator distAzCalc = new SectionDistanceAzimuthCalculator(rupSet.getFaultSectionDataList());
-		if (distAzCache.exists()) {
+		if (distAzCache != null && distAzCache.exists()) {
 			System.out.println("Loading dist/az cache from "+distAzCache.getAbsolutePath());
 			distAzCalc.loadCacheFile(distAzCache);
 		}
@@ -168,8 +172,10 @@ public class RupSetFilterComparePageGen {
 			minMags = new double[] { 7d, 7.5d, 8d };
 		if ((float)minRupMag >= 6.5d)
 			minMags = new double[] { 6.5d, 7d, 7.5d, 8d };
+		else if ((float)minRupMag >= 6d)
+			minMags = new double[] { 6d, 6.5d, 7d, 7.5d, 8d };
 		else
-			minMags = new double[] { 0d, 6.5d, 7d, 7.5d, 8d };
+			minMags = new double[] { 0d, 6d, 6.5d, 7d, 7.5d, 8d };
 		
 		CPT magIndexCPT = new CPT(0, minMags.length-1, Color.BLUE, Color.RED, Color.BLACK);
 		
@@ -186,7 +192,7 @@ public class RupSetFilterComparePageGen {
 			
 			@Override
 			public PlausibilityFilter get(Float value) {
-				return new CumulativeProbabilityFilter(value, new RelativeSlipRateProb(connStrat, true));
+				return new CumulativeProbabilityFilter(value, new RelativeSlipRateProb(connStrat, true, false));
 			}
 		});
 		minVals.add(0.01f);

--- a/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RuptureConnectionSearch.java
+++ b/src/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RuptureConnectionSearch.java
@@ -674,7 +674,7 @@ public class RuptureConnectionSearch {
 				}
 				availableClusters.remove(jump.toCluster);
 				if (debug) System.out.println("\tTaking jump: "+jump);
-				rupture = rupture.take(jump);
+				rupture = rupture.take(correctJumpDist(jump));
 				// current strand has now been replaced, find the new one
 				currentStrand = splaySearchRecursive(rupture, currentStrand.clusters[0]);
 				if (debug) System.out.println("Current strand after jump: "+currentStrand);
@@ -689,6 +689,14 @@ public class RuptureConnectionSearch {
 			rupture = buildRupture(rupture, splay, availableClusters, jumpsFromMap, debug);
 		}
 		return rupture;
+	}
+	
+	private Jump correctJumpDist(Jump jump) {
+		double minDist = Double.POSITIVE_INFINITY;
+		for (FaultSection s1 : jump.fromCluster.subSects)
+			for (FaultSection s2 : jump.toCluster.subSects)
+				minDist = Double.min(minDist, distCalc.getDistance(s1, s2));
+		return new Jump(jump.fromSection, jump.fromCluster, jump.toSection, jump.toCluster, minDist);
 	}
 	
 	private ClusterRupture splaySearchRecursive(ClusterRupture rup, FaultSubsectionCluster firstCluster) {


### PR DESCRIPTION
We noticed some strange behavior where rupture sets could be smaller when the distance threshold increased. We have addressed this in a few ways:

* Relative Slip Rate Probability filter now only considers alternative faults up to the taken jump distance + 2km
* The direct path plausibility filter only applies if the direct path has a shorter cumulative distance than the indirect path
* Jump distances were previously taken as the distance between the sections where the connection strategy dictates that the jump occurs. This unfairly penalizes connection strategies that don't use the closest point. We have now updated jump distances to be the closest point between clusters on either side of the jump, irregardless of the dictated connection point. This mostly affects the cumulative jump distance filter.

These changes increased the UCERF3 fault system rupture count over 500k, so we also are revisiting the adaptive connection strategy to further reduce the count. The new adaptive implementation now wraps any arbitrary connection strategy.

Also updates to the main method of ClusterRuptureBuilder to make it easier to keep track of which parameters have been changed from default.